### PR TITLE
fixed display of blank bars

### DIFF
--- a/Meter.c
+++ b/Meter.c
@@ -523,6 +523,9 @@ MeterMode* Meter_modes[] = {
 
 static void BlankMeter_updateValues(Meter* this, char* buffer, int size) {
    (void) this; (void) buffer; (void) size;
+   if (size > 0) {
+      *buffer = 0;
+   }
 }
 
 static void BlankMeter_display(Object* cast, RichString* out) {


### PR DESCRIPTION
The buffer for blank bars was left uninitialized resulting in random
looking characters sometimes even overwriting the end of the bar.