### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,22 +1,22 @@
 name: CI
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [ push, pull_request ]
 
 jobs:
   build-ubuntu-latest:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Install Dependencies
+      run: sudo apt-get install libncursesw5-dev
+    - name: Bootstrap
+      run: ./autogen.sh
+    - name: Configure
+      run: ./configure --enable-werror
     - name: Build
-      run: |
-        sudo apt-get install libncursesw5-dev
-        ./autogen.sh
-        ./configure
-        make
+      run: make
+    - name: Distcheck
+      run: make distcheck
 
 #  build-macos-latest:
 #    runs-on: macos-latest
@@ -27,3 +27,12 @@ jobs:
 #        ./autogen.sh
 #        ./configure
 #        make
+
+  whitespace_check:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: check-whitespaces
+        run: git diff-tree --check $(git hash-object -t tree /dev/null) HEAD

--- a/Action.c
+++ b/Action.c
@@ -615,4 +615,3 @@ void Action_setBindings(Htop_Action* keys) {
    keys['c'] = actionTagAllChildren;
    keys['e'] = actionShowEnvScreen;
 }
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,5 +52,4 @@ Donations
 ---------
 
 If you like htop, feel free to [buy the author a
-beer](http://hisham.hm/htop/index.php?page=donate). :-) 
-
+beer](http://hisham.hm/htop/index.php?page=donate). :-)

--- a/COPYING
+++ b/COPYING
@@ -353,4 +353,3 @@ Public License instead of this License.
  applicable licenses of the version of PLPA used in your combined work,
  provided that you include the source code of such version of PLPA when
  and as the GNU GPL requires distribution of source code.
-

--- a/ChangeLog
+++ b/ChangeLog
@@ -219,7 +219,7 @@ What's new in version 1.0.2
 What's new in version 1.0.1
 
 * Move .htoprc to XDG-compliant path ~/.config/htop/htoprc,
-  respecting $XDG_CONFIG_HOME 
+  respecting $XDG_CONFIG_HOME
   (thanks to Hadzhimurad Ustarkhan for the suggestion.)
 * Safer behavior on the kill screen, to make it harder to kill the wrong process.
 * Fix for building in FreeBSD 8.2
@@ -607,7 +607,7 @@ What's new in version 0.3.1
 
 What's new in version 0.3
 
-* BUGFIX: no dirt left on screen on horizontal scrolling 
+* BUGFIX: no dirt left on screen on horizontal scrolling
 * Signal selection on "kill" command
 * Color-coding for users, nice and process status
 * "Follow" function

--- a/ColumnsPanel.c
+++ b/ColumnsPanel.c
@@ -164,4 +164,3 @@ void ColumnsPanel_update(Panel* super) {
    }
    this->settings->fields[size] = 0;
 }
-

--- a/ListItem.c
+++ b/ListItem.c
@@ -85,4 +85,3 @@ long ListItem_compare(const void* cast1, const void* cast2) {
    ListItem* obj2 = (ListItem*) cast2;
    return strcmp(obj1->value, obj2->value);
 }
-

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,7 @@ applications_DATA = htop.desktop
 pixmapdir = $(datadir)/pixmaps
 pixmap_DATA = htop.png
 
-AM_CFLAGS = -pedantic -Wall $(wextra_flag) -std=c99 -D_XOPEN_SOURCE_EXTENDED -DSYSCONFDIR=\"$(sysconfdir)\" -I"$(top_srcdir)/$(my_htop_platform)"
+AM_CFLAGS += -pedantic -Wall $(wextra_flag) -std=c99 -D_XOPEN_SOURCE_EXTENDED -DSYSCONFDIR=\"$(sysconfdir)\" -I"$(top_srcdir)/$(my_htop_platform)"
 AM_LDFLAGS =
 AM_CPPFLAGS = -DNDEBUG
 

--- a/NEWS
+++ b/NEWS
@@ -2,4 +2,3 @@
 See the commit history for news of the past.
 See the bug tracker for news of the future.
 Run the program for news of the present.
-

--- a/TESTPLAN
+++ b/TESTPLAN
@@ -4,47 +4,47 @@ Main screen:
    For all views, all modes:
 
       Mouse click header - nothing happens.
-      
+
       Mouse click on ProcessList title bar - exit Tree view, update FunctionBar, title bar updates, sort by clicked field.
 *** FAILING: wrong FB update depending on mode; does not change sort in wip branch
          click on same entry - invert sort.
             click on another entry - sort another field.
-      
+
       Mouse click on a process - select that process.
-      
+
       for each entry in FunctionBar:
          Mouse click entry - perform action of associated key.
-      
+
    In Normal mode, Sorted view:
-   
+
       <+> or <-> - do nothing.
-      
+
       <F6> - enter SortBy screen.
-   
+
    In Normal mode, Tree view:
 
       select process - update F6 in FunctionBar if subtree is collapsed or expanded.
-      
+
       <F6>, <+> or <-> - expand/collapse subtree.
-   
+
    In Normal mode, either Sorted or Tree view:
 
       <F3>, </> - activate Search mode.
-   
+
       <F4>, <\> - activate Filter mode.
 
       <F7>, <]> - as root only, decrease process NICE value.
-      
+
       <F8>, <[> - increase process NICE value.
 
       <a> - enter Affinity screen.
 
       <b> - do nothing.
-      
+
       <c> - select process and all its children.
-      
+
       <d>, <e>, <f>, <g> - do nothing.
-      
+
       <F1>, <h>, <?> - enter Help screen.
 
       <i> - on Linux, enter IOPriority screen.
@@ -64,67 +64,67 @@ Main screen:
       <s> - enter STrace screen.
 
       <F5>, <t> - toggle between Tree and Sorted view, update F5 in FunctionBar, follow process
-      
+
       <u> - enter User screen.
 
       <v>, <w>, <x>, <y>, <z> - do nothing.
-      
+
       <A>, <B> - do nothing.
-      
+
       <F2>, <C>, <S> - enter Setup screen.
 
       <D>, <E> - do nothing.
-      
+
       <F> - follow process.
 
       <G> - do nothing.
-      
+
       <H> - toggle show/hide userland threads.
-      
+
       <I> - invert sort order.
-      
+
       <J> - do nothing.
-      
+
       <K> - toggle show/hide kernel threads.
 
       <L> - do nothing.
 
       <M> - enter Sorted view, update function bar, sort by MEM%.
-      
+
       <N>, <O> - do nothing.
 
       <P> - enter Sorted view, update function bar, sort by CPU%.
 
       <Q>, <R> - do nothing.
-      
+
       <T> - enter Sorted view, update function bar, sort by TIME.
-      
+
       <U> - untag all processes.
-      
+
       <V>, <W>, <X>, <Y>, <Z> - do nothing.
-      
+
       <<>, <>>, <,>, <.> - enter SortBy screen.
-      
+
       space - tag current process, move down cursor.
 
       numbers - incremental PID search.
-   
+
    In Search mode:
 
       TODO
-  
+
    In Filter mode:
-   
+
       TODO
 
 Setup screen:
 
    TODO
-   
+
 SortBy screen:
 
    TODO
-   
+
 User screen:
 
    TODO
@@ -136,7 +136,7 @@ Kill screen:
 Affinity screen:
 
    TODO
-   
+
 Help screen:
 
    any key - back to Main screen.
@@ -152,4 +152,3 @@ STrace screen:
 LSOF screen:
 
    TODO
-   

--- a/XAlloc.c
+++ b/XAlloc.c
@@ -14,7 +14,7 @@
 #include <stdlib.h>
 }*/
 
-static inline void fail() {
+void fail() {
    curs_set(1);
    endwin();
    err(1, NULL);
@@ -43,6 +43,10 @@ void* xRealloc(void* ptr, size_t size) {
    }
    return data;
 }
+
+#undef xAsprintf
+
+#define xAsprintf(strp, fmt, ...) do { int _r=asprintf(strp, fmt, __VA_ARGS__); if (_r < 0) { fail(); } } while(0)
 
 #define xSnprintf(fmt, len, ...) do { int _l=len; int _n=snprintf(fmt, _l, __VA_ARGS__); if (!(_n > -1 && _n < _l)) { curs_set(1); endwin(); err(1, NULL); } } while(0)
 

--- a/XAlloc.h
+++ b/XAlloc.h
@@ -11,11 +11,17 @@
 #include <assert.h>
 #include <stdlib.h>
 
+extern void fail(void);
+
 extern void* xMalloc(size_t size);
 
 extern void* xCalloc(size_t nmemb, size_t size);
 
 extern void* xRealloc(void* ptr, size_t size);
+
+#undef xAsprintf
+
+#define xAsprintf(strp, fmt, ...) do { int _r=asprintf(strp, fmt, __VA_ARGS__); if (_r < 0) { fail(); } } while(0)
 
 #define xSnprintf(fmt, len, ...) do { int _l=len; int _n=snprintf(fmt, _l, __VA_ARGS__); if (!(_n > -1 && _n < _l)) { curs_set(1); endwin(); err(1, NULL); } } while(0)
 

--- a/configure.ac
+++ b/configure.ac
@@ -223,7 +223,7 @@ else
       HTOP_CHECK_LIB([ncurses],  [refresh], [HAVE_LIBNCURSES],
       missing_libraries="$missing_libraries libncurses"
    ))))
-   
+
    AC_CHECK_HEADERS([curses.h],[:],
       [AC_CHECK_HEADERS([ncurses/curses.h],[:],
          [AC_CHECK_HEADERS([ncurses/ncurses.h],[:],

--- a/configure.ac
+++ b/configure.ac
@@ -295,6 +295,9 @@ then
    ])
 fi
 
+AC_ARG_ENABLE([werror], [AS_HELP_STRING([--enable-werror], [Treat warnings as errors (default: warnings are not errors)])], [enable_werror="$enableval"], [enable_werror=no])
+AS_IF([test "x$enable_werror" = "xyes"], [AM_CFLAGS="$AM_CFLAGS -Werror"])
+AC_SUBST([AM_CFLAGS])
 
 # Bail out on errors.
 # ----------------------------------------------------------------------

--- a/darwin/Battery.c
+++ b/darwin/Battery.c
@@ -72,4 +72,3 @@ void Battery_getData(double* level, ACPresence* isOnAC) {
       CFRelease(power_sources);
    }
 }
-

--- a/darwin/DarwinCRT.c
+++ b/darwin/DarwinCRT.c
@@ -32,4 +32,3 @@ void CRT_handleSIGSEGV(int sgn) {
    #endif
    abort();
 }
-

--- a/dragonflybsd/DragonFlyBSDCRT.c
+++ b/dragonflybsd/DragonFlyBSDCRT.c
@@ -32,4 +32,3 @@ void CRT_handleSIGSEGV(int sgn) {
    #endif
    abort();
 }
-

--- a/freebsd/FreeBSDCRT.c
+++ b/freebsd/FreeBSDCRT.c
@@ -18,4 +18,3 @@ void CRT_handleSIGSEGV(int sgn) {
    fprintf(stderr, "\nPlease contact your platform package maintainer!\n\n");
    abort();
 }
-

--- a/htop.1.in
+++ b/htop.1.in
@@ -2,11 +2,11 @@
 .SH "NAME"
 htop \- interactive process viewer
 .SH "SYNOPSIS"
-.LP 
+.LP
 .B htop
 .RB [ \-dChpustv ]
 .SH "DESCRIPTION"
-.LP 
+.LP
 .B htop
 is a cross-platform ncurses-based process viewer.
 .LP
@@ -20,11 +20,11 @@ multiple processes and acting on them all at once.
 .LP
 Tasks related to processes (killing, renicing) can be done without
 entering their PIDs.
-.br 
+.br
 .SH "COMMAND-LINE OPTIONS"
 .LP
 Mandatory arguments to long options are mandatory for short options too.
-.LP 
+.LP
 .TP
 \fB\-d \-\-delay=DELAY\fR
 Delay between updates, in tenths of seconds. If the delay value is
@@ -54,10 +54,10 @@ Output version information and exit
 \fB\-t \-\-tree
 Show processes in tree view
 .SH "INTERACTIVE COMMANDS"
-.LP 
+.LP
 The following commands are supported while in
 .BR htop :
-.LP 
+.LP
 .TP 5
 .B Up, Alt-k
 Select (highlight) the previous process in the process list. Scroll the list
@@ -159,7 +159,7 @@ Quit
 Invert the sort order: if sort order is increasing, switch to decreasing, and
 vice-versa.
 .TP
-.B +, \- 
+.B +, \-
 When in tree view mode, expand or collapse subtree. When a subtree is collapsed
 a "+" sign shows to the left of the process name.
 .TP
@@ -203,7 +203,7 @@ Refresh: redraw screen and recalculate values.
 PID search: type in process ID and the selection highlight will be moved to it.
 .PD
 .SH "COLUMNS"
-.LP 
+.LP
 The following columns can display data about each process. A value of '\-' in
 all the rows indicates that a column is unsupported on your system, or
 currently unimplemented in
@@ -213,11 +213,11 @@ The names below are the ones used in the
 shown in
 .BR htop 's
 main screen, it is shown below in parenthesis.
-.LP 
+.LP
 .TP 5
 .B Command
 The full command line of the process (i.e. program name and arguments).
-.TP 
+.TP
 .B PID
 The process ID.
 .TP
@@ -238,7 +238,7 @@ The process's group ID.
 .TP
 .B SESSION (SID)
 The process's session ID.
-.TP 
+.TP
 .B TTY_NR (TTY)
 The controlling terminal of the process.
 .TP
@@ -401,7 +401,7 @@ The percentage of time spent swapping in pages. Requires CAP_NET_ADMIN.
 .B All other flags
 Currently unsupported (always displays '-').
 .SH "CONFIG FILE"
-.LP 
+.LP
 By default
 .B htop
 reads its configuration from the XDG-compliant path
@@ -437,7 +437,7 @@ space and make memory size representations consistent throughout
 and
 .BR limits.conf (5).
 .SH "AUTHORS"
-.LP 
+.LP
 .B htop
 was originally developed by Hisham Muhammad.
 Nowadays it is maintained by the community at <htop@groups.io>.

--- a/linux/IOPriority.c
+++ b/linux/IOPriority.c
@@ -38,4 +38,3 @@ typedef int IOPriority;
 #define IOPriority_Idle IOPriority_tuple(IOPRIO_CLASS_IDLE, 7)
 
 }*/
-

--- a/linux/IOPriorityPanel.c
+++ b/linux/IOPriorityPanel.c
@@ -41,4 +41,3 @@ Panel* IOPriorityPanel_new(IOPriority currPrio) {
 IOPriority IOPriorityPanel_getIOPriority(Panel* this) {
    return (IOPriority) ( ((ListItem*) Panel_getSelected(this))->key );
 }
-

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -514,4 +514,3 @@ long LinuxProcess_compare(const void* v1, const void* v2) {
 bool Process_isThread(Process* this) {
    return (Process_isUserlandThread(this) || Process_isKernelThread(this));
 }
-

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -822,11 +822,11 @@ static char* LinuxProcessList_updateTtyDevice(TtyDriver* ttyDrivers, unsigned in
       struct stat sstat;
       char* fullPath;
       for(;;) {
-         asprintf(&fullPath, "%s/%d", ttyDrivers[i].path, idx);
+         xAsprintf(&fullPath, "%s/%d", ttyDrivers[i].path, idx);
          int err = stat(fullPath, &sstat);
          if (err == 0 && major(sstat.st_rdev) == maj && minor(sstat.st_rdev) == min) return fullPath;
          free(fullPath);
-         asprintf(&fullPath, "%s%d", ttyDrivers[i].path, idx);
+         xAsprintf(&fullPath, "%s%d", ttyDrivers[i].path, idx);
          err = stat(fullPath, &sstat);
          if (err == 0 && major(sstat.st_rdev) == maj && minor(sstat.st_rdev) == min) return fullPath;
          free(fullPath);
@@ -837,7 +837,7 @@ static char* LinuxProcessList_updateTtyDevice(TtyDriver* ttyDrivers, unsigned in
       if (err == 0 && tty_nr == sstat.st_rdev) return strdup(ttyDrivers[i].path);
    }
    char* out;
-   asprintf(&out, "/dev/%u:%u", maj, min);
+   xAsprintf(&out, "/dev/%u:%u", maj, min);
    return out;
 }
 

--- a/openbsd/OpenBSDCRT.c
+++ b/openbsd/OpenBSDCRT.c
@@ -19,4 +19,3 @@ void CRT_handleSIGSEGV(int sgn) {
    fprintf(stderr, "\nPlease contact your platform package maintainer!\n\n");
    abort();
 }
-

--- a/openbsd/OpenBSDProcessList.c
+++ b/openbsd/OpenBSDProcessList.c
@@ -400,4 +400,3 @@ void ProcessList_goThroughEntries(ProcessList* this) {
    OpenBSDProcessList_scanProcs(opl);
    OpenBSDProcessList_scanCPUTime(opl);
 }
-

--- a/scripts/MakeHeader.py
+++ b/scripts/MakeHeader.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-import os, sys, string, io
+#!/usr/bin/env python3
+import os, sys, io
 try:
    from StringIO import StringIO
 except ImportError:

--- a/solaris/Battery.c
+++ b/solaris/Battery.c
@@ -5,4 +5,3 @@ void Battery_getData(double* level, ACPresence* isOnAC) {
    *level = -1;
    *isOnAC = AC_ERROR;
 }
-

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -419,4 +419,3 @@ void ProcessList_goThroughEntries(ProcessList* this) {
    this->kernelThreads = 1;
    proc_walk(&SolarisProcessList_walkproc, this, PR_WALK_LWP);
 }
-

--- a/test_spec.lua
+++ b/test_spec.lua
@@ -1,7 +1,7 @@
 #!/usr/bin/env lua
 
 local VISUALDELAY = os.getenv("VISUALDELAY")
- 
+
 local visual = VISUALDELAY or false
 local visual_delay = VISUALDELAY and (tonumber(VISUALDELAY)) or 0.1
 local short_delay = 0.3
@@ -70,7 +70,7 @@ local function show(key)
          term_win:mvaddstr(0, 0, tostring(key))
       end
       term_win:refresh()
-      
+
       delay(visual_delay)
    end
 end
@@ -191,7 +191,7 @@ local function set_display_option(n)
 end
 
 describe("htop test suite", function()
-   
+
    running_it("performs incremental filter", function()
       send("\\")
       send("x\127bux\127sted") -- test backspace
@@ -397,13 +397,13 @@ describe("htop test suite", function()
          assert.not_equal(pair[1], pair[2])
       end
    end)
-   
+
    running_it("visits each setup screen", function()
       send("S")
       send(curses.KEY_DOWN, 3)
       send(curses.KEY_F10)
    end)
-   
+
    running_it("adds and removes PPID column", function()
       send("S")
       send(curses.KEY_DOWN, 3)
@@ -423,7 +423,7 @@ describe("htop test suite", function()
       assert.equal(check(ppid))
       assert.not_equal(check(not_ppid))
    end)
-   
+
    running_it("changes CPU affinity for a process", function()
       send("a")
       send(" \n")
@@ -468,7 +468,7 @@ describe("htop test suite", function()
       assert.equal(check(zerocpu))
       assert.not_equal(check(nonzerocpu))
    end)
-   
+
    running_it("changes IO priority for a process", function()
       send("/")
       send("htop")
@@ -502,7 +502,7 @@ describe("htop test suite", function()
       send("\n")
       send(curses.KEY_F10)
    end)
-   
+
    local meters = {
       { name = "clock", down = 0, string = "Time" },
       { name = "load", down = 2, string = "Load" },
@@ -558,7 +558,7 @@ describe("htop test suite", function()
       send("\n")
       send(curses.KEY_F10)
    end)
-   
+
    local display_options = {
       { name = "tree view", down = 0 },
       { name = "shadow other user's process", down = 1 },
@@ -574,7 +574,7 @@ describe("htop test suite", function()
       { name = "update process names", down = 11 },
       { name = "guest time in CPU%", down = 12 },
    }
-   
+
    for _, item in ipairs(display_options) do
       running_it("checks display option to "..item.name, function()
          for _ = 1, 2 do
@@ -641,7 +641,7 @@ describe("htop test suite", function()
          assert.equal(attrs.white_on_black, untaggedattr)
       end
    end)
-   
+
    for i = 1, 62 do
       running_it("show column "..i, function()
          send("S")
@@ -670,7 +670,7 @@ describe("htop test suite", function()
          end
       end)
    end
-   
+
    it("finally quits", function()
       assert(not terminated())
       send("q")
@@ -685,4 +685,3 @@ describe("htop test suite", function()
       os.execute("make lcov && xdg-open lcov/index.html")
    end)
 end)
-

--- a/unsupported/Battery.c
+++ b/unsupported/Battery.c
@@ -5,4 +5,3 @@ void Battery_getData(double* level, ACPresence* isOnAC) {
    *level = -1;
    *isOnAC = AC_ERROR;
 }
-

--- a/unsupported/UnsupportedCRT.c
+++ b/unsupported/UnsupportedCRT.c
@@ -18,4 +18,3 @@ void CRT_handleSIGSEGV(int sgn) {
    fprintf(stderr, "\nPlease contact your platform package maintainer!\n\n");
    abort();
 }
-

--- a/unsupported/UnsupportedProcess.c
+++ b/unsupported/UnsupportedProcess.c
@@ -30,4 +30,3 @@ void UnsupportedProcess_delete(Object* cast) {
    // free platform-specific fields here
    free(this);
 }
-

--- a/zfs/ZfsArcMeter.c
+++ b/zfs/ZfsArcMeter.c
@@ -93,7 +93,7 @@ MeterClass ZfsArcMeter_class = {
       .delete = Meter_delete,
       .display = ZfsArcMeter_display,
    },
-   .updateValues = ZfsArcMeter_updateValues, 
+   .updateValues = ZfsArcMeter_updateValues,
    .defaultMode = TEXT_METERMODE,
    .maxItems = 6,
    .total = 100.0,

--- a/zfs/ZfsArcStats.c
+++ b/zfs/ZfsArcStats.c
@@ -20,3 +20,5 @@ typedef struct ZfsArcStats_ {
    unsigned long long int uncompressed;
 } ZfsArcStats;
 }*/
+
+static int make_iso_compilers_happy __attribute__((unused));

--- a/zfs/ZfsArcStats.h
+++ b/zfs/ZfsArcStats.h
@@ -23,4 +23,5 @@ typedef struct ZfsArcStats_ {
    unsigned long long int uncompressed;
 } ZfsArcStats;
 
+
 #endif


### PR DESCRIPTION
* configure: add option --enable-werror
  Adds the compiler flag -Werror to fail on warnings.
  Useful for CI runs.
* github/ci: improve ci
  - split steps for readability
  - fail on compiler warnings
  - add whitespace check
  - run on all branches
  - run `make distcheck`
* MakeHeader.py: use python3 shebang and drop unused import
* Remove trailing whitespaces
* Resolve default compiler warnings

