### PR TITLE
build improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install Dependencies
-      run: sudo apt-get install libncursesw5-dev
+      run: sudo apt-get install pkg-config libncursesw5-dev
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
@@ -30,7 +30,7 @@ jobs:
         sudo add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main' -y
         sudo apt-get update -q
     - name: Install Dependencies
-      run: sudo apt-get install clang-10 libncursesw5-dev
+      run: sudo apt-get install clang-10 pkg-config libncursesw5-dev
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
@@ -45,7 +45,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install Dependencies
-      run: sudo apt-get install libncursesw5-dev libhwloc-dev libnl-3-dev libnl-genl-3-dev
+      run: sudo apt-get install pkg-config libncursesw5-dev libhwloc-dev libnl-3-dev libnl-genl-3-dev
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure

--- a/Makefile.am
+++ b/Makefile.am
@@ -231,13 +231,6 @@ coverage:
 cppcheck:
 	cppcheck -q -v . --enable=all -DHAVE_CGROUP -DHAVE_OPENVZ -DHAVE_TASKSTATS
 
-dist-hook: $(top_distdir)/configure
-	@if grep 'pkg_m4_absent' '$(top_distdir)/configure'; then \
-	   echo 'configure is generated without pkg.m4. Please supply pkg.m4 and run ./autogen.sh to rebuild the configure script.'>&2; \
-	   (exit 1); \
-	else :; \
-	fi
-
 .PHONY: lcov
 
 lcov:

--- a/Makefile.am
+++ b/Makefile.am
@@ -226,7 +226,7 @@ coverage:
 	$(MAKE) all CFLAGS="" AM_CPPFLAGS="-fprofile-arcs -ftest-coverage -DDEBUG" LDFLAGS="-lgcov"
 
 .c.h:
-	./scripts/MakeHeader.py $<
+	$(AM_V_GEN)./scripts/MakeHeader.py $<
 
 cppcheck:
 	cppcheck -q -v . --enable=all -DHAVE_CGROUP -DHAVE_OPENVZ -DHAVE_TASKSTATS

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,3 +1,10 @@
 #!/bin/sh
+
+set -e
+
+bindir=${0%/*}
+: ${bindir:=.}
+cd "$bindir"
+
 mkdir -p m4
 autoreconf --install --force

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_PREREQ(2.65)
+AC_PREREQ([2.69])
 AC_INIT([htop],[3.0.0],[htop@groups.io])
 
 AC_CONFIG_SRCDIR([htop.c])
@@ -12,7 +12,7 @@ AC_CONFIG_MACRO_DIR([m4])
 # Required by hwloc scripts
 AC_CANONICAL_TARGET
 
-AM_INIT_AUTOMAKE([1.11])
+AM_INIT_AUTOMAKE([1.15 -Wall])
 
 # Checks for programs.
 # ----------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,12 @@ AM_PROG_CC_C_O
 # Required by hwloc scripts
 AC_USE_SYSTEM_EXTENSIONS
 
+# Setup Libtool.
+# ----------------------------------------------------------------------
+LT_PREREQ([2.4.6])
+LT_INIT
+AC_SUBST([LIBTOOL_DEPS])
+
 # Setup pkg-config.
 # ----------------------------------------------------------------------
 m4_ifndef([PKG_PREREQ],

--- a/configure.ac
+++ b/configure.ac
@@ -13,6 +13,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_CANONICAL_TARGET
 
 AM_INIT_AUTOMAKE([1.15 -Wall])
+AM_SILENT_RULES([yes])
 
 # Checks for programs.
 # ----------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -275,6 +275,9 @@ fi
 AC_ARG_ENABLE(hwloc, [AS_HELP_STRING([--enable-hwloc], [enable hwloc support for CPU affinity])],, enable_hwloc="no")
 if test "x$enable_hwloc" = xyes
 then
+   PKG_CHECK_MODULES([LIBHWLOC], [hwloc], [], [missing_libraries="$missing_libraries libhwloc"])
+   CFLAGS="$CFLAGS $LIBHWLOC_CFLAGS"
+   LIBS="$LIBS $LIBHWLOC_LIBS"
    AC_CHECK_LIB([hwloc], [hwloc_get_proc_cpubind], [], [missing_libraries="$missing_libraries libhwloc"])
    AC_CHECK_HEADERS([hwloc.h],[:], [missing_headers="$missing_headers $ac_header"])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,14 @@ AM_PROG_CC_C_O
 # Required by hwloc scripts
 AC_USE_SYSTEM_EXTENSIONS
 
+# Setup pkg-config.
+# ----------------------------------------------------------------------
+m4_ifndef([PKG_PREREQ],
+    [m4_fatal([must install pkg-config 0.29 or later before running ./autogen.sh])])
+PKG_PREREQ([0.29])
+
+PKG_PROG_PKG_CONFIG
+
 # Checks for platform.
 # ----------------------------------------------------------------------
 case "$target_os" in
@@ -273,18 +281,11 @@ fi
 AC_ARG_ENABLE(delayacct, [AS_HELP_STRING([--enable-delayacct], [enable Linux delay accounting])],, enable_delayacct="no")
 if test "x$enable_delayacct" = xyes
 then
-   m4_ifdef([PKG_PROG_PKG_CONFIG], [
-      PKG_PROG_PKG_CONFIG()
-      PKG_CHECK_MODULES(LIBNL3, libnl-3.0, [], [missing_libraries="$missing_libraries libnl-3"])
-      PKG_CHECK_MODULES(LIBNL3GENL, libnl-genl-3.0, [], [missing_libraries="$missing_libraries libnl-genl-3"])
-      CFLAGS="$CFLAGS $LIBNL3_CFLAGS $LIBNL3GENL_CFLAGS"
-      LIBS="$LIBS $LIBNL3_LIBS $LIBNL3GENL_LIBS"
-      AC_DEFINE(HAVE_DELAYACCT, 1, [Define if delay accounting support should be enabled.])
-   ], [
-      pkg_m4_absent=1
-      m4_warning([configure is generated without pkg.m4. 'make dist' target will be disabled.])
-      AC_MSG_ERROR([htop on Linux requires pkg-config for checking delayacct requirements. Please install pkg-config and run ./autogen.sh to rebuild the configure script.])
-   ])
+   PKG_CHECK_MODULES(LIBNL3, libnl-3.0, [], [missing_libraries="$missing_libraries libnl-3"])
+   PKG_CHECK_MODULES(LIBNL3GENL, libnl-genl-3.0, [], [missing_libraries="$missing_libraries libnl-genl-3"])
+   CFLAGS="$CFLAGS $LIBNL3_CFLAGS $LIBNL3GENL_CFLAGS"
+   LIBS="$LIBS $LIBNL3_LIBS $LIBNL3GENL_LIBS"
+   AC_DEFINE(HAVE_DELAYACCT, 1, [Define if delay accounting support should be enabled.])
 fi
 
 AC_ARG_ENABLE([werror], [AS_HELP_STRING([--enable-werror], [Treat warnings as errors (default: warnings are not errors)])], [enable_werror="$enableval"], [enable_werror=no])


### PR DESCRIPTION
Using a non-system HWLOC was only possible when setting `CFLAGS` and `LIBS` on the `configure` line. Using `pkg-config` to get the flags from the `.pc` file makes this more convenient. Utilizing `libtool` for the linking step also eases this, as `libtool` uses `rpath` for libraries not in system paths.