### PR TITLE
fix width of `AffinitPanel`

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -320,6 +320,7 @@ static Htop_Reaction actionSetAffinity(State* st) {
    if (!affinity1) return HTOP_OK;
    int width;
    Panel* affinityPanel = AffinityPanel_new(st->pl, affinity1, &width);
+   width += 1; /* we add a gap between the panels */
    Affinity_delete(affinity1);
 
    void* set = Action_pickFromVector(st, affinityPanel, width, true);

--- a/AffinityPanel.c
+++ b/AffinityPanel.c
@@ -352,7 +352,9 @@ Panel* AffinityPanel_new(ProcessList* pl, Affinity* affinity, int* width) {
    Panel_init(super, 1, 1, 1, 1, Class(MaskItem), false, FunctionBar_new(AffinityPanelFunctions, AffinityPanelKeys, AffinityPanelEvents));
 
    this->pl = pl;
-   this->width = 15;
+   /* defaults to 15, this also includes the gap between the panels,
+    * but this will be added by the caller */
+   this->width = 14;
 
    this->cpuids   = Vector_new(Class(MaskItem), true, DEFAULT_SIZE);
 


### PR DESCRIPTION
The panel size of 15 includes the gap to the next panel, thus use 14 as
the minimum size and let the caller of `AffinityPanel_new` handle the
gap.