### PR TITLE
always display frequency in MHz

### DIFF
--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -70,7 +70,7 @@ static void CPUMeter_updateValues(Meter* this, char* buffer, int size) {
       if (cpuFrequency < 0) {
          xSnprintf(cpuFrequencyBuffer, sizeof(cpuFrequencyBuffer), "N/A");
       } else {
-         xSnprintf(cpuFrequencyBuffer, sizeof(cpuFrequencyBuffer), "%.0fGHz", cpuFrequency);
+         xSnprintf(cpuFrequencyBuffer, sizeof(cpuFrequencyBuffer), "%.0fMHz", cpuFrequency);
       }
       if (this->pl->settings->showCPUUsage) {
          xSnprintf(buffer, size, "%5.1f%% %s", percent, cpuFrequencyBuffer);

--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -65,18 +65,13 @@ static void CPUMeter_updateValues(Meter* this, char* buffer, int size) {
    memset(this->values, 0, sizeof(double) * CPU_METER_ITEMCOUNT);
    double percent = Platform_setCPUValues(this, cpu);
    if (this->pl->settings->showCPUFrequency) {
-      /* Initial frequency is in MHz. Emit it as GHz if it's larger than 1000MHz */
       double cpuFrequency = this->values[CPU_METER_FREQUENCY];
       char unit = 'M';
       char cpuFrequencyBuffer[16];
       if (cpuFrequency < 0) {
          xSnprintf(cpuFrequencyBuffer, sizeof(cpuFrequencyBuffer), "N/A");
       } else {
-         if (cpuFrequency > 1000) {
-            cpuFrequency /= 1000;
-            unit = 'G';
-         }
-         xSnprintf(cpuFrequencyBuffer, sizeof(cpuFrequencyBuffer), "%.3f%cHz", cpuFrequency, unit);
+         xSnprintf(cpuFrequencyBuffer, sizeof(cpuFrequencyBuffer), "%.0f%cHz", cpuFrequency, unit);
       }
       if (this->pl->settings->showCPUUsage) {
          xSnprintf(buffer, size, "%5.1f%% %s", percent, cpuFrequencyBuffer);

--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -70,7 +70,7 @@ static void CPUMeter_updateValues(Meter* this, char* buffer, int size) {
       if (cpuFrequency < 0) {
          xSnprintf(cpuFrequencyBuffer, sizeof(cpuFrequencyBuffer), "N/A");
       } else {
-         xSnprintf(cpuFrequencyBuffer, sizeof(cpuFrequencyBuffer), "%.0f%cHz", cpuFrequency, unit);
+         xSnprintf(cpuFrequencyBuffer, sizeof(cpuFrequencyBuffer), "%.0fGHz", cpuFrequency);
       }
       if (this->pl->settings->showCPUUsage) {
          xSnprintf(buffer, size, "%5.1f%% %s", percent, cpuFrequencyBuffer);

--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -66,7 +66,6 @@ static void CPUMeter_updateValues(Meter* this, char* buffer, int size) {
    double percent = Platform_setCPUValues(this, cpu);
    if (this->pl->settings->showCPUFrequency) {
       double cpuFrequency = this->values[CPU_METER_FREQUENCY];
-      char unit = 'M';
       char cpuFrequencyBuffer[16];
       if (cpuFrequency < 0) {
          xSnprintf(cpuFrequencyBuffer, sizeof(cpuFrequencyBuffer), "N/A");


### PR DESCRIPTION
Change the displaying of the frequency to be consistent and always use the same unit, ie. MHz.

I think it is disturbing to have the unit change from MHz to GHz, and it makes it hard to read. Additionally, I don't think it is useful to have a precision higher than 1 MHz.

With this commit, the number of characters used is the same as before while keeping a single display unit (MHz).