### PR TITLE
Coverity fixes

### DIFF
--- a/InfoScreen.c
+++ b/InfoScreen.c
@@ -80,7 +80,7 @@ void InfoScreen_drawTitled(InfoScreen* this, const char* fmt, ...) {
    va_start(ap, fmt);
    attrset(CRT_colors[METER_TEXT]);
    mvhline(0, 0, ' ', COLS);
-   wmove(stdscr, 0, 0);
+   (void) wmove(stdscr, 0, 0);
    vw_printw(stdscr, fmt, ap);
    attrset(CRT_colors[DEFAULT_COLOR]);
    this->display->needsRedraw = true;

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -1142,10 +1142,10 @@ static inline double LinuxProcessList_scanCPUTime(LinuxProcessList* this) {
       char* ok = fgets(buffer, PROC_LINE_LENGTH, file);
       if (!ok) buffer[0] = '\0';
       if (i == 0)
-         sscanf(buffer,   "cpu  %16llu %16llu %16llu %16llu %16llu %16llu %16llu %16llu %16llu %16llu",         &usertime, &nicetime, &systemtime, &idletime, &ioWait, &irq, &softIrq, &steal, &guest, &guestnice);
+         (void) sscanf(buffer,   "cpu  %16llu %16llu %16llu %16llu %16llu %16llu %16llu %16llu %16llu %16llu",         &usertime, &nicetime, &systemtime, &idletime, &ioWait, &irq, &softIrq, &steal, &guest, &guestnice);
       else {
          int cpuid;
-         sscanf(buffer, "cpu%4d %16llu %16llu %16llu %16llu %16llu %16llu %16llu %16llu %16llu %16llu", &cpuid, &usertime, &nicetime, &systemtime, &idletime, &ioWait, &irq, &softIrq, &steal, &guest, &guestnice);
+         (void) sscanf(buffer, "cpu%4d %16llu %16llu %16llu %16llu %16llu %16llu %16llu %16llu %16llu %16llu", &cpuid, &usertime, &nicetime, &systemtime, &idletime, &ioWait, &irq, &softIrq, &steal, &guest, &guestnice);
          assert(cpuid == i - 1);
       }
       // Guest time is already accounted in usertime

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -1062,9 +1062,9 @@ static inline void LinuxProcessList_scanMemoryInfo(ProcessList* this) {
 }
 
 static inline void LinuxProcessList_scanZfsArcstats(LinuxProcessList* lpl) {
-   unsigned long long int dbufSize;
-   unsigned long long int dnodeSize;
-   unsigned long long int bonusSize;
+   unsigned long long int dbufSize = 0;
+   unsigned long long int dnodeSize = 0;
+   unsigned long long int bonusSize = 0;
 
    FILE* file = fopen(PROCARCSTATSFILE, "r");
    if (file == NULL) {

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -1235,7 +1235,7 @@ static inline double LinuxProcessList_scanCPUFrequency(LinuxProcessList* this) {
             (sscanf(buffer, "cpu MHz : %lf", &frequency) == 1) ||
             (sscanf(buffer, "cpu MHz: %lf", &frequency) == 1)
          ) {
-            if (cpuid < 0) {
+            if (cpuid < 0 || cpuid > (cpus - 1)) {
                CRT_fatalError(PROCCPUINFOFILE " is malformed: cpu MHz line without corresponding processor line");
             }
 

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -275,7 +275,8 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, ui
       } else if (String_startsWith(buffer, "cpu")) {
          cpus++;
       } else if (String_startsWith(buffer, "btime ")) {
-         sscanf(buffer, "btime %lld\n", &btime);
+         if (sscanf(buffer, "btime %lld\n", &btime) != 1)
+            CRT_fatalError("Failed to parse btime from " PROCSTATFILE);
          break;
       }
    } while(true);


### PR DESCRIPTION
There is one strange issue left:

```
399static Htop_Reaction actionStrace(State* st) {
400   Process* p = (Process*) Panel_getSelected(st->panel);
   1. Condition !p, taking false branch.
401   if (!p) return HTOP_OK;
   2. alloc_fn: Storage is returned from allocation function TraceScreen_new. [show details]
   3. var_assign: Assigning: ts = storage returned from TraceScreen_new(p).
402   TraceScreen* ts = TraceScreen_new(p);
   4. noescape: Resource ts is not freed or pointed-to in TraceScreen_forkTracer. [show details]
403   bool ok = TraceScreen_forkTracer(ts);
   5. Condition ok, taking false branch.
404   if (ok) {
405      InfoScreen_run((InfoScreen*)ts);
406   }
   6. noescape: There is at least one path in TraceScreen_delete on which resource ts is not freed or pointed-to.
407   TraceScreen_delete((Object*)ts);
408   clear();
409   CRT_enableDelay();
   CID 213660 (#1 of 1): Resource leak (RESOURCE_LEAK)7. leaked_storage: Variable ts going out of scope leaks the storage it points to.
410   return HTOP_REFRESH | HTOP_REDRAW_BAR;
411}
```

But I do not see any path in `TraceScreen_delete()` that does not free `ts`:

```
void TraceScreen_delete(Object* cast) {
   TraceScreen* this = (TraceScreen*) cast;
   if (this->child > 0) {
      kill(this->child, SIGTERM);
      waitpid(this->child, NULL, 0);
      fclose(this->strace);
   }
   CRT_enableDelay();
   free(InfoScreen_done((InfoScreen*)cast));
}
```