### PR TITLE
ignore vim keys in prompts

### DIFF
--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -190,7 +190,7 @@ void ScreenManager_run(ScreenManager* this, Panel** lastFocus, int* lastKey) {
       set_escdelay(25);
       ch = getch();
 
-      if (this->settings->vimMode) {
+      if (this->settings->vimMode && panelFocus->currentBar->size != 3) {
          switch (ch) {
             case 'h': ch = KEY_LEFT; break;
             case 'j': ch = KEY_DOWN; break;

--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -190,6 +190,7 @@ void ScreenManager_run(ScreenManager* this, Panel** lastFocus, int* lastKey) {
       set_escdelay(25);
       ch = getch();
 
+      // currentBar->size == 3 is a workaround to identify prompts
       if (this->settings->vimMode && panelFocus->currentBar->size != 3) {
          switch (ch) {
             case 'h': ch = KEY_LEFT; break;


### PR DESCRIPTION
this makes it so vimmode(rewriting hjkl to arrow keys) will be ignored when inside a prompt, such as search or filter. to detect this im simply looking at when the functionbar only has 3 items (esc, cancel, prompt) as I couldnt find a more straight forward way to find out.

this would resolve #34 