### PR TITLE
Reduce oom cast from long to int

### DIFF
--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -492,7 +492,7 @@ long LinuxProcess_compare(const void* v1, const void* v2) {
       return strcmp(p1->cgroup ? p1->cgroup : "", p2->cgroup ? p2->cgroup : "");
    #endif
    case OOM:
-      return ((long)p2->oom - (long)p1->oom);
+      return ((int)p2->oom - (int)p1->oom);
    #ifdef HAVE_DELAYACCT
    case PERCENT_CPU_DELAY:
       return (p2->cpu_delay_percent > p1->cpu_delay_percent ? 1 : -1);


### PR DESCRIPTION
Oom values should never be greater then INT_MAX, they should be in the
range 0 - 1000.

Improves: d9a5dd4b916636b5e7ba8631885427372f0cfcad