### PR TITLE
Avoid new checkbox glyphs

### DIFF
--- a/AffinityPanel.c
+++ b/AffinityPanel.c
@@ -55,20 +55,20 @@ static void MaskItem_delete(Object* cast) {
 static void MaskItem_display(Object* cast, RichString* out) {
    MaskItem* this = (MaskItem*)cast;
    assert (this != NULL);
+   RichString_append(out, CRT_colors[CHECK_BOX], "[");
    if (this->value == 2)
-      RichString_append(out, CRT_colors[CHECK_MARK], CRT_checkStr[CHECK_STR_FULL]);
+      RichString_append(out, CRT_colors[CHECK_MARK], "x");
    else if (this->value == 1)
-      RichString_append(out, CRT_colors[CHECK_MARK], CRT_checkStr[CHECK_STR_PARTIAL]);
+      RichString_append(out, CRT_colors[CHECK_MARK], "o");
    else
-      RichString_append(out, CRT_colors[CHECK_MARK], CRT_checkStr[CHECK_STR_NONE]);
+      RichString_append(out, CRT_colors[CHECK_MARK], " ");
+   RichString_append(out, CRT_colors[CHECK_BOX], "]");
    RichString_append(out, CRT_colors[CHECK_TEXT], " ");
    if (this->indent)
       RichString_append(out, CRT_colors[PROCESS_TREE], this->indent);
    if (this->sub_tree) {
-      RichString_append(out, CRT_colors[PROCESS_TREE],
-                        this->sub_tree == 1
-                        ? CRT_collapStr[COLLAP_STR_OPEN]
-                        : CRT_collapStr[COLLAP_STR_CLOSED]);
+      RichString_append(out, CRT_colors[  PROCESS_TREE],
+                        this->sub_tree == 1 ? "[-]" : "[+]");
       RichString_append(out, CRT_colors[CHECK_TEXT], " ");
    }
    RichString_append(out, CRT_colors[CHECK_TEXT], this->text);
@@ -303,7 +303,7 @@ static MaskItem *AffinityPanel_addObject(AffinityPanel* this, hwloc_obj_t obj, u
    }
 
    /* "[x] " + "|- " * depth + ("[+] ")? + name */
-   unsigned width = (CRT_utf8 ? 2 : 4) + 3 * depth + (item->sub_tree ? (CRT_utf8 ? 2 : 4) : 0) + strlen(buf);
+   unsigned width = 4 + 3 * depth + (item->sub_tree ? 4 : 0) + strlen(buf);
    if (width > this->width)
       this->width = width;
 

--- a/AffinityPanel.c
+++ b/AffinityPanel.c
@@ -260,7 +260,7 @@ static HandlerResult AffinityPanel_eventHandler(Panel* super, int ch) {
 
 static MaskItem *AffinityPanel_addObject(AffinityPanel* this, hwloc_obj_t obj, unsigned indent, MaskItem *parent) {
    const char* type_name = hwloc_obj_type_string(obj->type);
-   const char* index_prefix = " #";
+   const char* index_prefix = "#";
    unsigned depth = obj->depth;
    unsigned index = obj->logical_index;
    size_t off = 0, left = 10 * depth;
@@ -286,7 +286,7 @@ static MaskItem *AffinityPanel_addObject(AffinityPanel* this, hwloc_obj_t obj, u
       off += len, left -= len;
    }
 
-   xSnprintf(buf, 64, "%s%s%u", type_name, index_prefix, index);
+   xSnprintf(buf, 64, "%s %s%u", type_name, index_prefix, index);
 
    MaskItem *item = MaskItem_newMask(buf, indent_buf, obj->complete_cpuset, false);
    if (parent)

--- a/CRT.c
+++ b/CRT.c
@@ -167,7 +167,9 @@ const char *CRT_treeStrUtf8[TREE_STR_COUNT] = {
    "\xe2\x94\x9c", // TREE_STR_RTEE ├
    "\xe2\x94\x94", // TREE_STR_BEND └
    "\xe2\x94\x8c", // TREE_STR_TEND ┌
-   "+",            // TREE_STR_OPEN +
+   "+",            // TREE_STR_OPEN +, TODO use 🮯 'BOX DRAWINGS LIGHT HORIZONTAL
+                   // WITH VERTICAL STROKE' (U+1FBAF, "\xf0\x9f\xae\xaf") when
+                   // Unicode 13 is common
    "\xe2\x94\x80", // TREE_STR_SHUT ─
 };
 

--- a/CRT.h
+++ b/CRT.h
@@ -47,19 +47,6 @@ typedef enum TreeStr_ {
    TREE_STR_COUNT
 } TreeStr;
 
-typedef enum CheckStr_ {
-   CHECK_STR_NONE,
-   CHECK_STR_PARTIAL,
-   CHECK_STR_FULL,
-   CHECK_STR_COUNT
-} CheckStr;
-
-typedef enum CollapStr_ {
-   COLLAP_STR_OPEN,
-   COLLAP_STR_CLOSED,
-   COLLAP_STR_COUNT
-} CollapStr;
-
 typedef enum ColorSchemes_ {
    COLORSCHEME_DEFAULT = 0,
    COLORSCHEME_MONOCHROME = 1,
@@ -114,6 +101,7 @@ typedef enum ColorElements_ {
    LOAD_AVERAGE_FIFTEEN,
    LOAD_AVERAGE_FIVE,
    LOAD_AVERAGE_ONE,
+   CHECK_BOX,
    CHECK_MARK,
    CHECK_TEXT,
    CLOCK,
@@ -150,27 +138,15 @@ extern void CRT_handleSIGSEGV(int sgn);
 
 extern const char *CRT_treeStrAscii[TREE_STR_COUNT];
 
-extern const char *CRT_checkStrAscii[CHECK_STR_COUNT];
-
-extern const char *CRT_collapStrAscii[COLLAP_STR_COUNT];
-
 #ifdef HAVE_LIBNCURSESW
 
 extern const char *CRT_treeStrUtf8[TREE_STR_COUNT];
 
-extern const char *CRT_checkStrUtf8[CHECK_STR_COUNT];
-
-extern const char *CRT_collapStrUtf8[COLLAP_STR_COUNT];
+extern bool CRT_utf8;
 
 #endif
 
-extern bool CRT_utf8;
-
 extern const char **CRT_treeStr;
-
-extern const char **CRT_checkStr;
-
-extern const char **CRT_collapStr;
 
 extern int CRT_delay;
 

--- a/CheckItem.c
+++ b/CheckItem.c
@@ -35,11 +35,12 @@ static void CheckItem_delete(Object* cast) {
 static void CheckItem_display(Object* cast, RichString* out) {
    CheckItem* this = (CheckItem*)cast;
    assert (this != NULL);
+   RichString_write(out, CRT_colors[CHECK_BOX], "[");
    if (CheckItem_get(this))
-      RichString_append(out, CRT_colors[CHECK_MARK], CRT_checkStr[CHECK_STR_FULL]);
+      RichString_append(out, CRT_colors[CHECK_MARK], "x");
    else
-      RichString_append(out, CRT_colors[CHECK_MARK], CRT_checkStr[CHECK_STR_NONE]);
-   RichString_append(out, CRT_colors[CHECK_TEXT], " ");
+      RichString_append(out, CRT_colors[CHECK_MARK], " ");
+   RichString_append(out, CRT_colors[CHECK_BOX], "] ");
    RichString_append(out, CRT_colors[CHECK_TEXT], this->text);
 }
 


### PR DESCRIPTION
The Unicode glyphs did not had many friends, as they were unreadable for most users. Thus revert back to pure ASCII, additionally avoid also glyphs (`[+]`/`[-]`) for the tree collapsing. It now uses the the tree glyphs, the same as the process list.

Fixes #29.