### PR TITLE
Unbreak with -fno-common on FreeBSD

### DIFF
--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -33,7 +33,7 @@ in the source distribution for its full text.
 #include <sys/resource.h>
 
 #define JAIL_ERRMSGLEN	1024
-char jail_errmsg[JAIL_ERRMSGLEN];
+extern char jail_errmsg[JAIL_ERRMSGLEN];
 
 typedef struct CPUData_ {
 
@@ -69,6 +69,7 @@ typedef struct FreeBSDProcessList_ {
 
 }*/
 
+char jail_errmsg[JAIL_ERRMSGLEN];
 
 static int MIB_hw_physmem[2];
 static int MIB_vm_stats_vm_v_page_count[4];

--- a/freebsd/FreeBSDProcessList.h
+++ b/freebsd/FreeBSDProcessList.h
@@ -19,7 +19,7 @@ in the source distribution for its full text.
 #include <sys/resource.h>
 
 #define JAIL_ERRMSGLEN	1024
-char jail_errmsg[JAIL_ERRMSGLEN];
+extern char jail_errmsg[JAIL_ERRMSGLEN];
 
 typedef struct CPUData_ {
 
@@ -54,15 +54,17 @@ typedef struct FreeBSDProcessList_ {
 } FreeBSDProcessList;
 
 
+extern char jail_errmsg[JAIL_ERRMSGLEN];
 
-ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, uid_t userId);
 
-void ProcessList_delete(ProcessList* this);
+extern ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, uid_t userId);
 
-char* FreeBSDProcessList_readProcessName(kvm_t* kd, struct kinfo_proc* kproc, int* basenameEnd);
+extern void ProcessList_delete(ProcessList* this);
 
-char* FreeBSDProcessList_readJailName(struct kinfo_proc* kproc);
+extern char* FreeBSDProcessList_readProcessName(kvm_t* kd, struct kinfo_proc* kproc, int* basenameEnd);
 
-void ProcessList_goThroughEntries(ProcessList* this);
+extern char* FreeBSDProcessList_readJailName(struct kinfo_proc* kproc);
+
+extern void ProcessList_goThroughEntries(ProcessList* this);
 
 #endif


### PR DESCRIPTION
GCC10 and Clang11 now default to -fno-common.
```
ld: error: duplicate symbol: jail_errmsg
>>> defined at Platform.c
>>>            freebsd/Platform.o:(jail_errmsg)
>>> defined at FreeBSDProcessList.c
>>>            freebsd/FreeBSDProcessList.o:(.bss+0x90)
```