### PR TITLE
minor vim bind improvements

### DIFF
--- a/Panel.c
+++ b/Panel.c
@@ -385,10 +385,12 @@ bool Panel_onKey(Panel* this, int key) {
    switch (key) {
    case KEY_DOWN:
    case KEY_CTRL('N'):
+   case 'j':
       this->selected++;
       break;
    case KEY_UP:
    case KEY_CTRL('P'):
+   case 'k':
       this->selected--;
       break;
    #ifdef KEY_C_DOWN
@@ -403,6 +405,7 @@ bool Panel_onKey(Panel* this, int key) {
    #endif
    case KEY_LEFT:
    case KEY_CTRL('B'):
+   case 'h':
       if (this->scrollH > 0) {
          this->scrollH -= MAX(CRT_scrollHAmount, 0);
          this->needsRedraw = true;
@@ -410,6 +413,7 @@ bool Panel_onKey(Panel* this, int key) {
       break;
    case KEY_RIGHT:
    case KEY_CTRL('F'):
+   case 'l':
       this->scrollH += CRT_scrollHAmount;
       this->needsRedraw = true;
       break;

--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -196,12 +196,9 @@ void ScreenManager_run(ScreenManager* this, Panel** lastFocus, int* lastKey) {
             case 'j': ch = KEY_DOWN; break;
             case 'k': ch = KEY_UP; break;
             case 'l': ch = KEY_RIGHT; break;
-            case KEY_LEFT: ch = 'h'; break;
-            case KEY_DOWN: ch = 'j'; break;
-            case KEY_UP: ch = 'k'; break;
-            case KEY_RIGHT: ch = 'l'; break;
+            case 'H': ch = 'h'; break;
+            case 'J': ch = 'j'; break;
             case 'K': ch = 'k'; break;
-            case 'J': ch = 'K'; break;
             case 'L': ch = 'l'; break;
          }
       }


### PR DESCRIPTION
this addresses two things mainly:

1. keep arrow keys working in vim mode
2. allow `hjkl` movement in panels (open files, environment vars, etc)

the arrow keys are restored in vimmode by dropping `H` and `K` keys when vimmode is on and simply remapping `HJKL` to `hjkl` directly without the need to ruin arrow keys. `hjkl` movement in panels is simply added regardless of vimmode, as this doesnt collide with anything here and in the existing codebase it isnt trivial to access the settings from within panel.c

this would fix #69 