### PR TITLE
Make --enable-hwloc and --enable-linux-affinity mutual exclusive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: ./configure --enable-werror
+      run: ./configure --enable-werror --enable-linux-affinity
     - name: Build
       run: make
     - name: Distcheck
-      run: make distcheck DISTCHECK_CONFIGURE_FLAGS=--enable-werror
+      run: make distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-werror --enable-linux-affinity"
 
   build-ubuntu-clang-latest:
     runs-on: ubuntu-latest
@@ -34,11 +34,11 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: ./configure --enable-werror
+      run: ./configure --enable-werror --enable-linux-affinity
     - name: Build
       run: make
     - name: Distcheck
-      run: make distcheck DISTCHECK_CONFIGURE_FLAGS=--enable-werror
+      run: make distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-werror --enable-linux-affinity"
 
   build-ubuntu-latest-full-featured:
     runs-on: ubuntu-latest
@@ -49,11 +49,11 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: ./configure --enable-werror --enable-openvz --enable-cgroup --enable-vserver --enable-ancient-vserver --enable-taskstats --enable-unicode --enable-linux-affinity --enable-hwloc --enable-setuid --enable-delayacct
+      run: ./configure --enable-werror --enable-openvz --enable-cgroup --enable-vserver --enable-ancient-vserver --enable-taskstats --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct
     - name: Build
       run: make
     - name: Distcheck
-      run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror --enable-openvz --enable-cgroup --enable-vserver --enable-ancient-vserver --enable-taskstats --enable-unicode --enable-linux-affinity --enable-hwloc --enable-setuid --enable-delayacct'
+      run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror --enable-openvz --enable-cgroup --enable-vserver --enable-ancient-vserver --enable-taskstats --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct'
 
   whitespace_check:
     runs-on: ubuntu-latest

--- a/Affinity.h
+++ b/Affinity.h
@@ -11,6 +11,10 @@ in the source distribution for its full text.
 #include "Process.h"
 #include "ProcessList.h"
 
+#if defined(HAVE_LIBHWLOC) && defined(HAVE_LINUX_AFFINITY)
+#error hwlock and linux affinity are mutual exclusive.
+#endif
+
 typedef struct Affinity_ {
    ProcessList* pl;
    int size;

--- a/configure.ac
+++ b/configure.ac
@@ -214,33 +214,43 @@ if test "$my_htop_platform" = "solaris"; then
    AC_CHECK_LIB([malloc], [free], [], [missing_libraries="$missing_libraries libmalloc"])
 fi
 
-AC_ARG_ENABLE(linux_affinity, [AS_HELP_STRING([--enable-linux-affinity], [enable Linux sched_setaffinity and sched_getaffinity for affinity support, disables hwloc])], ,enable_linux_affinity="yes")
-if test "x$enable_linux_affinity" = xyes; then
-   AC_MSG_CHECKING([for usable sched_setaffinity])
-   AC_RUN_IFELSE([
-     AC_LANG_PROGRAM([[
-       #include <sched.h>
-       #include <errno.h>
-       static cpu_set_t cpuset;
-       ]], [[
-       CPU_ZERO(&cpuset);
-       sched_setaffinity(0, sizeof(cpu_set_t), &cpuset);
-       if (errno == ENOSYS) return 1;
-       ]])],
-     [AC_MSG_RESULT([yes])],
-     [enable_linux_affinity=no
-      AC_MSG_RESULT([no])],
-     [AC_MSG_RESULT([yes (assumed while cross compiling)])])
+AC_ARG_ENABLE(hwloc, [AS_HELP_STRING([--enable-hwloc], [enable hwloc support for CPU affinity, disables Linux affinity])],, enable_hwloc="no")
+if test "x$enable_hwloc" = xyes
+then
+   AC_CHECK_LIB([hwloc], [hwloc_get_proc_cpubind], [], [missing_libraries="$missing_libraries libhwloc"])
+   AC_CHECK_HEADERS([hwloc.h],[:], [missing_headers="$missing_headers $ac_header"])
+fi
+
+AC_ARG_ENABLE(linux_affinity, [AS_HELP_STRING([--enable-linux-affinity], [enable Linux sched_setaffinity and sched_getaffinity for affinity support, conflicts with hwloc])], ,enable_linux_affinity="check")
+if test "x$enable_linux_affinity" = xcheck; then
+   if test "x$enable_hwloc" = xyes; then
+      enable_linux_affinity=no
+   else
+      AC_MSG_CHECKING([for usable sched_setaffinity])
+      AC_RUN_IFELSE([
+         AC_LANG_PROGRAM([[
+            #include <sched.h>
+            #include <errno.h>
+            static cpu_set_t cpuset;
+         ]], [[
+            CPU_ZERO(&cpuset);
+            sched_setaffinity(0, sizeof(cpu_set_t), &cpuset);
+            if (errno == ENOSYS) return 1;
+         ]])],
+      [enable_linux_affinity=yes
+       AC_MSG_RESULT([yes])],
+      [enable_linux_affinity=no
+       AC_MSG_RESULT([no])],
+      [AC_MSG_RESULT([yes (assumed while cross compiling)])])
+   fi
 fi
 if test "x$enable_linux_affinity" = xyes; then
    AC_DEFINE(HAVE_LINUX_AFFINITY, 1, [Define if Linux sched_setaffinity and sched_getaffinity are to be used.])
 fi
 
-AC_ARG_ENABLE(hwloc, [AS_HELP_STRING([--enable-hwloc], [enable hwloc support for CPU affinity])],, enable_hwloc="no")
-if test "x$enable_hwloc" = xyes
+if test "x$enable_linux_affinity" = xyes -a "x$enable_hwloc" = xyes
 then
-   AC_CHECK_LIB([hwloc], [hwloc_get_proc_cpubind], [], [missing_libraries="$missing_libraries libhwloc"])
-   AC_CHECK_HEADERS([hwloc.h],[:], [missing_headers="$missing_headers $ac_header"])
+   AC_MSG_ERROR([--enable-hwloc and --enable-linux-affinity are mutual exclusive. Specify at most one of them.])
 fi
 
 AC_ARG_ENABLE(setuid, [AS_HELP_STRING([--enable-setuid], [enable setuid support for platforms that need it])],, enable_setuid="no")


### PR DESCRIPTION
They can not be supported both at the same time.
Fail configure step instead of silently only use hwloc.