### PR TITLE
Avoid unsigned integer overflow

### DIFF
--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -61,7 +61,7 @@ static ssize_t xread(int fd, void *buf, size_t count) {
 static int sortTtyDrivers(const void* va, const void* vb) {
    TtyDriver* a = (TtyDriver*) va;
    TtyDriver* b = (TtyDriver*) vb;
-   return (a->major == b->major) ? (a->minorFrom - b->minorFrom) : (a->major - b->major);
+   return (a->major == b->major) ? ((int)a->minorFrom - (int)b->minorFrom) : ((int)a->major - (int)b->major);
 }
 
 static void LinuxProcessList_initTtyDrivers(LinuxProcessList* this) {


### PR DESCRIPTION
unsigned overflow is well defined, but creates noise when using
sanitizers. unsigned overflow can be a symptom of logic issues of
counter, so its reasonable to use.

```
linux/LinuxProcessList.c:64:50: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'unsigned int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior linux/LinuxProcessList.c:64:50 in
linux/LinuxProcessList.c:64:11: runtime error: implicit conversion from type 'unsigned int' of value 4294967295 (32-bit, unsigned) to type 'int' changed the value to -1 (32-bit, signed)
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior linux/LinuxProcessList.c:64:11 in
linux/LinuxProcessList.c:64:78: runtime error: unsigned integer overflow: 4 - 136 cannot be represented in type 'unsigned int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior linux/LinuxProcessList.c:64:78 in
```