### PR TITLE
Add Linux process column for total context switches

### DIFF
--- a/htop.1.in
+++ b/htop.1.in
@@ -386,6 +386,9 @@ Which cgroup the process is in.
 .B OOM
 OOM killer score.
 .TP
+.B CTXT
+Incremental sum of voluntary and nonvoluntary context switches.
+.TP
 .B IO_PRIORITY (IO)
 The I/O scheduling class followed by the priority if the class supports it:
    \fBR\fR for Realtime

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -14,6 +14,7 @@ in the source distribution for its full text.
 #define PROCESS_FLAG_LINUX_CGROUP   0x0800
 #define PROCESS_FLAG_LINUX_OOM      0x1000
 #define PROCESS_FLAG_LINUX_SMAPS    0x2000
+#define PROCESS_FLAG_LINUX_CTXT     0x4000
 
 typedef enum UnsupportedProcessFields {
    FLAGS = 9,
@@ -80,7 +81,8 @@ typedef enum LinuxProcessFields {
    M_PSS = 119,
    M_SWAP = 120,
    M_PSSWP = 121,
-   LAST_PROCESSFIELD = 122,
+   CTXT = 122,
+   LAST_PROCESSFIELD = 123,
 } LinuxProcessField;
 
 #include "IOPriority.h"
@@ -138,6 +140,8 @@ typedef struct LinuxProcess_ {
    float blkio_delay_percent;
    float swapin_delay_percent;
    #endif
+   unsigned long ctxt_total;
+   unsigned long ctxt_diff;
 } LinuxProcess;
 
 #define Process_isKernelThread(_process) (((LinuxProcess*)(_process))->isKernelThread)


### PR DESCRIPTION
Displays the incremental sum of voluntary_ctxt_switches and nonvoluntary_ctxt_switches.

Closes: #113