### PR TITLE
Drop always true condition

### DIFF
--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -237,7 +237,7 @@ char* Platform_getProcessEnv(pid_t pid) {
    if (fd) {
       size_t capacity = 4096, size = 0, bytes;
       env = xMalloc(capacity);
-      while (env && (bytes = fread(env+size, 1, capacity-size, fd)) > 0) {
+      while ((bytes = fread(env+size, 1, capacity-size, fd)) > 0) {
          size += bytes;
          capacity *= 2;
          env = xRealloc(env, capacity);


### PR DESCRIPTION
`env` is allocated by checked allocation functions and can not be NULL.

This checks confuses clang analyzer and causes a null-dereference
warning on `env[size-1]`.