### PR TITLE
Clean up some code duplication in the header files

### DIFF
--- a/Action.h
+++ b/Action.h
@@ -37,13 +37,9 @@ typedef struct State_ {
 
 Object* Action_pickFromVector(State* st, Panel* list, int x, bool followProcess);
 
-// ----------------------------------------
-
 bool Action_setUserOnly(const char* userName, uid_t* userId);
 
 Htop_Reaction Action_setSortKey(Settings* settings, ProcessField sortKey);
-
-// ----------------------------------------
 
 Htop_Reaction Action_follow(State* st);
 

--- a/Action.h
+++ b/Action.h
@@ -7,12 +7,11 @@ Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
 
-#include "IncSet.h"
-#include "Settings.h"
 #include "Header.h"
-#include "UsersTable.h"
-#include "ProcessList.h"
 #include "Panel.h"
+#include "ProcessList.h"
+#include "Settings.h"
+#include "UsersTable.h"
 
 typedef enum {
    HTOP_OK = 0x00,

--- a/Affinity.h
+++ b/Affinity.h
@@ -8,14 +8,6 @@ Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
 
-#ifdef HAVE_LIBHWLOC
-#if __linux__
-#define HTOP_HWLOC_CPUBIND_FLAG HWLOC_CPUBIND_THREAD
-#else
-#define HTOP_HWLOC_CPUBIND_FLAG HWLOC_CPUBIND_PROCESS
-#endif
-#endif
-
 #include "Process.h"
 #include "ProcessList.h"
 

--- a/Affinity.h
+++ b/Affinity.h
@@ -24,13 +24,7 @@ void Affinity_delete(Affinity* this);
 
 void Affinity_add(Affinity* this, int id);
 
-#ifdef HAVE_LIBHWLOC
-
-Affinity* Affinity_get(Process* proc, ProcessList* pl);
-
-bool Affinity_set(Process* proc, Arg arg);
-
-#elif HAVE_LINUX_AFFINITY
+#if defined(HAVE_LIBHWLOC) || defined(HAVE_LINUX_AFFINITY)
 
 Affinity* Affinity_get(Process* proc, ProcessList* pl);
 

--- a/CRT.c
+++ b/CRT.c
@@ -39,10 +39,6 @@ in the source distribution for its full text.
 #define ColorPairGrayBlack ColorPair(Magenta,Magenta)
 #define ColorIndexGrayBlack ColorIndex(Magenta,Magenta)
 
-#define KEY_WHEELUP KEY_F(20)
-#define KEY_WHEELDOWN KEY_F(21)
-#define KEY_RECLICK KEY_F(22)
-
 const char *CRT_treeStrAscii[TREE_STR_COUNT] = {
    "-", // TREE_STR_HORZ
    "|", // TREE_STR_VERT
@@ -550,12 +546,7 @@ void CRT_restorePrivileges() {
 
 #else
 
-/* Turn setuid operations into NOPs */
-
-#ifndef CRT_dropPrivileges
-#define CRT_dropPrivileges()
-#define CRT_restorePrivileges()
-#endif
+// In this case, the setuid operations are defined as macros in CRT.h
 
 #endif
 

--- a/CRT.h
+++ b/CRT.h
@@ -7,30 +7,11 @@ Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
 
-#if HAVE_SETUID_ENABLED
-#endif
-
-#define ColorIndex(i,j) ((7-i)*8+j)
-
-#define ColorPair(i,j) COLOR_PAIR(ColorIndex(i,j))
-
-#define Black COLOR_BLACK
-#define Red COLOR_RED
-#define Green COLOR_GREEN
-#define Yellow COLOR_YELLOW
-#define Blue COLOR_BLUE
-#define Magenta COLOR_MAGENTA
-#define Cyan COLOR_CYAN
-#define White COLOR_WHITE
-
-#define ColorPairGrayBlack ColorPair(Magenta,Magenta)
-#define ColorIndexGrayBlack ColorIndex(Magenta,Magenta)
+#include <stdbool.h>
 
 #define KEY_WHEELUP KEY_F(20)
 #define KEY_WHEELDOWN KEY_F(21)
 #define KEY_RECLICK KEY_F(22)
-
-#include <stdbool.h>
 
 typedef enum TreeStr_ {
    TREE_STR_HORZ,
@@ -158,15 +139,11 @@ extern int CRT_scrollWheelVAmount;
 
 extern char* CRT_termType;
 
-// TODO move color scheme to Settings, perhaps?
-
 extern int CRT_colorScheme;
 
 extern void *backtraceArray[128];
 
 #if HAVE_SETUID_ENABLED
-
-#define DIE(msg) do { CRT_done(); fprintf(stderr, msg); exit(1); } while(0)
 
 void CRT_dropPrivileges();
 
@@ -182,8 +159,6 @@ void CRT_restorePrivileges();
 #endif
 
 #endif
-
-// TODO: pass an instance of Settings instead.
 
 void CRT_init(int delay, int colorScheme, bool allowUnicode);
 

--- a/CRT.h
+++ b/CRT.h
@@ -9,9 +9,9 @@ in the source distribution for its full text.
 
 #include <stdbool.h>
 
-#define KEY_WHEELUP KEY_F(20)
+#define KEY_WHEELUP   KEY_F(20)
 #define KEY_WHEELDOWN KEY_F(21)
-#define KEY_RECLICK KEY_F(22)
+#define KEY_RECLICK   KEY_F(22)
 
 typedef enum TreeStr_ {
    TREE_STR_HORZ,

--- a/ColorsPanel.h
+++ b/ColorsPanel.h
@@ -7,12 +7,6 @@ Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
 
-// TO ADD A NEW SCHEME:
-// * Increment the size of bool check in ColorsPanel.h
-// * Add the entry in the ColorSchemeNames array below in the file
-// * Add a define in CRT.h that matches the order of the array
-// * Add the colors in CRT_setColors
-
 #include "Panel.h"
 #include "Settings.h"
 #include "ScreenManager.h"

--- a/Header.c
+++ b/Header.c
@@ -16,8 +16,6 @@ in the source distribution for its full text.
 #include <string.h>
 #include <stdlib.h>
 
-#define Header_forEachColumn(this_, i_) for (int (i_)=0; (i_) < (this_)->nrColumns; ++(i_))
-
 Header* Header_new(struct ProcessList_* pl, Settings* settings, int nrColumns) {
    Header* this = xCalloc(1, sizeof(Header));
    this->columns = xCalloc(nrColumns, sizeof(Vector*));

--- a/IncSet.c
+++ b/IncSet.c
@@ -7,7 +7,6 @@ in the source distribution for its full text.
 
 #include "IncSet.h"
 #include "StringUtils.h"
-#include "Panel.h"
 #include "ListItem.h"
 #include "CRT.h"
 #include <string.h>

--- a/MainPanel.h
+++ b/MainPanel.h
@@ -8,9 +8,9 @@ Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
 
-#include "Panel.h"
 #include "Action.h"
-#include "Settings.h"
+#include "IncSet.h"
+#include "Panel.h"
 
 typedef struct MainPanel_ {
    Panel super;

--- a/Meter.c
+++ b/Meter.c
@@ -11,7 +11,6 @@ in the source distribution for its full text.
 #include "Object.h"
 #include "CRT.h"
 #include "StringUtils.h"
-#include "ListItem.h"
 #include "Settings.h"
 
 #include <math.h>
@@ -19,9 +18,6 @@ in the source distribution for its full text.
 #include <stdlib.h>
 #include <stdarg.h>
 #include <assert.h>
-#include <sys/time.h>
-
-#define METER_BUFFER_LEN 256
 
 #define GRAPH_DELAY (DEFAULT_DELAY/2)
 

--- a/Meter.h
+++ b/Meter.h
@@ -7,15 +7,10 @@ Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
 
-#define METER_BUFFER_LEN 256
-
-#define GRAPH_DELAY (DEFAULT_DELAY/2)
-
-#define GRAPH_HEIGHT 4 /* Unit: rows (lines) */
-
 #include "ListItem.h"
-
 #include <sys/time.h>
+
+#define METER_BUFFER_LEN 256
 
 typedef struct Meter_ Meter;
 
@@ -108,23 +103,7 @@ void Meter_setMode(Meter* this, int modeIndex);
 
 ListItem* Meter_toListItem(Meter* this, bool moving);
 
-/* ---------- TextMeterMode ---------- */
-
-/* ---------- BarMeterMode ---------- */
-
-/* ---------- GraphMeterMode ---------- */
-
-#ifdef HAVE_LIBNCURSESW
-#define PIXPERROW_UTF8 4
-#endif
-
-#define PIXPERROW_ASCII 2
-
-/* ---------- LEDMeterMode ---------- */
-
 extern MeterMode* Meter_modes[];
-
-/* Blank meter */
 
 extern int BlankMeter_attributes[];
 

--- a/MetersPanel.h
+++ b/MetersPanel.h
@@ -24,14 +24,6 @@ struct MetersPanel_ {
    bool moving;
 };
 
-
-// Note: In code the meters are known to have bar/text/graph "Modes", but in UI
-// we call them "Styles".
-// We avoid UTF-8 arrows ← → here as they might display full-width on Chinese
-// terminals, breaking our aligning.
-// In <http://unicode.org/reports/tr11/>, arrows (U+2019..U+2199) are
-// considered "Ambiguous characters".
-
 void MetersPanel_setMoving(MetersPanel* this, bool moving);
 
 extern PanelClass MetersPanel_class;

--- a/Panel.c
+++ b/Panel.c
@@ -19,8 +19,6 @@ in the source distribution for its full text.
 #include <string.h>
 #include <assert.h>
 
-#define KEY_CTRL(l) ((l)-'A'+1)
-
 PanelClass Panel_class = {
    .super = {
       .extends = Class(Object),

--- a/Process.c
+++ b/Process.c
@@ -21,7 +21,6 @@ in the source distribution for its full text.
 #include <sys/resource.h>
 #include <sys/param.h>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <signal.h>
@@ -37,29 +36,7 @@ in the source distribution for its full text.
 #include <sys/sysmacros.h>
 #endif
 
-#ifdef __ANDROID__
-#define SYS_ioprio_get __NR_ioprio_get
-#define SYS_ioprio_set __NR_ioprio_set
-#endif
-
-// On Linux, this works only with glibc 2.1+. On earlier versions
-// the behavior is similar to have a hardcoded page size.
-#ifndef PAGE_SIZE
-#define PAGE_SIZE ( sysconf(_SC_PAGESIZE) )
-#endif
-#define PAGE_SIZE_KB ( PAGE_SIZE / ONE_K )
-
 static int Process_getuid = -1;
-
-#define ONE_K 1024L
-#define ONE_M (ONE_K * ONE_K)
-#define ONE_G (ONE_M * ONE_K)
-#define ONE_T ((long long)ONE_G * ONE_K)
-
-#define ONE_DECIMAL_K 1000L
-#define ONE_DECIMAL_M (ONE_DECIMAL_K * ONE_DECIMAL_K)
-#define ONE_DECIMAL_G (ONE_DECIMAL_M * ONE_DECIMAL_K)
-#define ONE_DECIMAL_T ((long long)ONE_DECIMAL_G * ONE_DECIMAL_K)
 
 char Process_pidFormat[20] = "%7d ";
 

--- a/Process.h
+++ b/Process.h
@@ -8,10 +8,6 @@ Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
 
-#ifdef MAJOR_IN_MKDEV
-#elif defined(MAJOR_IN_SYSMACROS)
-#endif
-
 #ifdef __ANDROID__
 #define SYS_ioprio_get __NR_ioprio_get
 #define SYS_ioprio_set __NR_ioprio_set

--- a/RichString.c
+++ b/RichString.c
@@ -12,8 +12,6 @@ in the source distribution for its full text.
 #include <stdlib.h>
 #include <string.h>
 
-#define RICHSTRING_MAXLEN 350
-
 #define charBytes(n) (sizeof(CharType) * (n))
 
 static void RichString_extendLen(RichString* this, int len) {

--- a/RichString.h
+++ b/RichString.h
@@ -7,7 +7,6 @@ Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
 
-#define RICHSTRING_MAXLEN 350
 
 #include "config.h"
 #include <ctype.h>
@@ -50,15 +49,13 @@ in the source distribution for its full text.
 #define CharType chtype
 #endif
 
+#define RICHSTRING_MAXLEN 350
+
 typedef struct RichString_ {
    int chlen;
    CharType* chptr;
    CharType chstr[RICHSTRING_MAXLEN+1];
 } RichString;
-
-#define charBytes(n) (sizeof(CharType) * (n))
-
-#define RichString_setLen(this, len) do{ if(len < RICHSTRING_MAXLEN && this->chlen < RICHSTRING_MAXLEN) { RichString_setChar(this,len,0); this->chlen=len; } else RichString_extendLen(this,len); }while(0)
 
 #ifdef HAVE_LIBNCURSESW
 

--- a/ScreenManager.h
+++ b/ScreenManager.h
@@ -7,7 +7,6 @@ Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
 
-#include "FunctionBar.h"
 #include "Vector.h"
 #include "Header.h"
 #include "Settings.h"

--- a/Settings.c
+++ b/Settings.c
@@ -17,8 +17,6 @@ in the source distribution for its full text.
 #include <string.h>
 #include <unistd.h>
 
-#define DEFAULT_DELAY 15
-
 void Settings_delete(Settings* this) {
    free(this->filename);
    free(this->fields);

--- a/StringUtils.c
+++ b/StringUtils.c
@@ -14,12 +14,6 @@ in the source distribution for its full text.
 #include <strings.h>
 #include <stdlib.h>
 
-
-/*
- * String_startsWith gives better performance if strlen(match) can be computed
- * at compile time (e.g. when they are immutable string literals). :)
- */
-
 char* String_cat(const char* s1, const char* s2) {
    int l1 = strlen(s1);
    int l2 = strlen(s2);

--- a/TraceScreen.c
+++ b/TraceScreen.c
@@ -8,7 +8,6 @@ in the source distribution for its full text.
 #include "TraceScreen.h"
 
 #include "CRT.h"
-#include "InfoScreen.h"
 #include "ProcessList.h"
 #include "ListItem.h"
 #include "IncSet.h"

--- a/Vector.c
+++ b/Vector.c
@@ -261,7 +261,7 @@ inline Object* Vector_get(Vector* this, int idx) {
 
 #else
 
-#define Vector_get(v_, idx_) ((v_)->array[idx_])
+// In this case, Vector_get is defined as a macro in vector.h
 
 #endif
 
@@ -274,7 +274,7 @@ inline int Vector_size(Vector* this) {
 
 #else
 
-#define Vector_size(v_) ((v_)->items)
+// In this case, Vector_size is defined as a macro in vector.h
 
 #endif
 

--- a/Vector.h
+++ b/Vector.h
@@ -72,10 +72,6 @@ int Vector_size(Vector* this);
 
 #endif
 
-/*
-
-*/
-
 void Vector_add(Vector* this, void* data_);
 
 int Vector_indexOf(Vector* this, void* search_, Object_Compare compare);


### PR DESCRIPTION
PR #70 got rid of the infrastructure for generating header files, but it left behind some code duplication.

Some of cases are things that belong in the header file and don't need to be repeated in the C file. Other cases are things that belong in the C file and don't need to be in the header file.

In this commit I tried to fix all of these that I could find. When given a choice I preferred keeping things out of the header file, unless they were being used by someone else.