### PR TITLE
Number CPUs from zero by default.

### DIFF
--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -81,7 +81,7 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Highlight large numbers in memory counters"), &(settings->highlightMegabytes)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Leave a margin around header"), &(settings->headerMargin)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Detailed CPU time (System/IO-Wait/Hard-IRQ/Soft-IRQ/Steal/Guest)"), &(settings->detailedCPUTime)));
-   Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Count CPUs from 0 instead of 1"), &(settings->countCPUsFromZero)));
+   Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Count CPUs from 1 instead of 0"), &(settings->countCPUsFromOne)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Update process names on every refresh"), &(settings->updateProcessNames)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Add guest time in CPU meter percentage"), &(settings->accountGuestInCPUMeter)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Also show CPU percentage numerically"), &(settings->showCPUUsage)));

--- a/Settings.c
+++ b/Settings.c
@@ -166,8 +166,11 @@ static bool Settings_read(Settings* this, const char* fileName) {
          this->detailedCPUTime = atoi(option[1]);
       } else if (String_eq(option[0], "detailed_cpu_time")) {
          this->detailedCPUTime = atoi(option[1]);
+      } else if (String_eq(option[0], "cpu_count_from_one")) {
+         this->countCPUsFromOne = atoi(option[1]);
       } else if (String_eq(option[0], "cpu_count_from_zero")) {
-         this->countCPUsFromZero = atoi(option[1]);
+         // old (inverted) naming also supported for backwards compatibility
+         this->countCPUsFromOne = !atoi(option[1]);
       } else if (String_eq(option[0], "show_cpu_usage")) {
          this->showCPUUsage = atoi(option[1]);
       } else if (String_eq(option[0], "show_cpu_frequency")) {
@@ -266,7 +269,7 @@ bool Settings_write(Settings* this) {
    fprintf(fd, "tree_view=%d\n", (int) this->treeView);
    fprintf(fd, "header_margin=%d\n", (int) this->headerMargin);
    fprintf(fd, "detailed_cpu_time=%d\n", (int) this->detailedCPUTime);
-   fprintf(fd, "cpu_count_from_zero=%d\n", (int) this->countCPUsFromZero);
+   fprintf(fd, "cpu_count_from_one=%d\n", (int) this->countCPUsFromOne);
    fprintf(fd, "show_cpu_usage=%d\n", (int) this->showCPUUsage);
    fprintf(fd, "show_cpu_frequency=%d\n", (int) this->showCPUFrequency);
    fprintf(fd, "update_process_names=%d\n", (int) this->updateProcessNames);
@@ -299,7 +302,7 @@ Settings* Settings_new(int cpuCount) {
    this->highlightBaseName = false;
    this->highlightMegabytes = false;
    this->detailedCPUTime = false;
-   this->countCPUsFromZero = false;
+   this->countCPUsFromOne = false;
    this->showCPUUsage = true;
    this->showCPUFrequency = false;
    this->updateProcessNames = false;

--- a/Settings.h
+++ b/Settings.h
@@ -31,7 +31,7 @@ typedef struct Settings_ {
    int direction;
    ProcessField sortKey;
 
-   bool countCPUsFromZero;
+   bool countCPUsFromOne;
    bool detailedCPUTime;
    bool showCPUUsage;
    bool showCPUFrequency;
@@ -56,7 +56,7 @@ typedef struct Settings_ {
    bool changed;
 } Settings;
 
-#define Settings_cpuId(settings, cpu) ((settings)->countCPUsFromZero ? (cpu) : (cpu)+1)
+#define Settings_cpuId(settings, cpu) ((settings)->countCPUsFromOne ? (cpu)+1 : (cpu))
 
 void Settings_delete(Settings* this);
 


### PR DESCRIPTION
Numbering from one is idiosyncratic and inconsistent with basically
everything else in the world; it doesn't make much sense as default
behavior.

All naming is updated to reflect that numbering from one is a
non-default, opt-in option, with the exception of the label of the
flag saved in htoprc, which remains "cpu_count_from_zero" (with a
correspondingly inverted boolean sense) for backwards compatibility
with existing configs.