### PR TITLE
Add option -m/--no-mouse to man page

### DIFF
--- a/htop.1.in
+++ b/htop.1.in
@@ -51,6 +51,9 @@ Show only the processes of a given user
 \fB\-U \-\-no-unicode\fR
 Do not use unicode but ASCII characters for graph meters
 .TP
+\fB\-m \-\-no-mouse\fR
+Disable support of mouse control
+.TP
 \fB\-v \-\-version
 Output version information and exit
 .TP


### PR DESCRIPTION
The option -m / --nomouse_in_man was missing in the man page, compared to the
output of `htop -h`.