### PR TITLE
Feature to normalize process CPU percent.

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -406,6 +406,7 @@ static const struct { const char* key; const char* info; } helpLeft[] = {
    { .key = "  P M T: ", .info = "sort by CPU%, MEM% or TIME" },
    { .key = "      I: ", .info = "invert sort order" },
    { .key = " F6 > .: ", .info = "select sort column" },
+   { .key = "      z: ", .info = "toggle normalize process CPU%" },
    { .key = NULL, .info = NULL }
 };
 
@@ -495,7 +496,7 @@ static Htop_Reaction actionHelp(State* st) {
    attrset(CRT_colors[DEFAULT_COLOR]);
 
    attrset(CRT_colors[HELP_BOLD]);
-   mvaddstr(23,0, "Press any key to return.");
+   mvaddstr(24,0, "Press any key to return.");
    attrset(CRT_colors[DEFAULT_COLOR]);
    refresh();
    CRT_readKey();
@@ -530,6 +531,10 @@ static Htop_Reaction actionShowEnvScreen(State* st) {
    return HTOP_REFRESH | HTOP_REDRAW_BAR;
 }
 
+static Htop_Reaction actionToggleCPUNormalize(State* st) {
+   st->settings->normalizeCPUPercent = ! st->settings->normalizeCPUPercent;
+   return HTOP_REFRESH;
+}
 
 void Action_setBindings(Htop_Action* keys) {
    keys[KEY_RESIZE] = actionResize;
@@ -584,4 +589,5 @@ void Action_setBindings(Htop_Action* keys) {
    keys['U'] = actionUntagAll;
    keys['c'] = actionTagAllChildren;
    keys['e'] = actionShowEnvScreen;
+   keys['z'] = actionToggleCPUNormalize;
 }

--- a/Process.c
+++ b/Process.c
@@ -231,12 +231,15 @@ void Process_writeField(Process* this, RichString* str, ProcessField field) {
 
    switch (field) {
    case PERCENT_CPU: {
-      if (this->percent_cpu > 999.9) {
-         xSnprintf(buffer, n, "%4u ", (unsigned int)this->percent_cpu);
-      } else if (this->percent_cpu > 99.9) {
-         xSnprintf(buffer, n, "%3u. ", (unsigned int)this->percent_cpu);
+      float percent_cpu = this->percent_cpu;
+      if (this->settings->normalizeCPUPercent)
+        percent_cpu /= this->settings->cpuCount;
+      if (percent_cpu > 999.9) {
+         xSnprintf(buffer, n, "%4u ", (unsigned int)percent_cpu);
+      } else if (percent_cpu > 99.9) {
+         xSnprintf(buffer, n, "%3u. ", (unsigned int)percent_cpu);
       } else {
-         xSnprintf(buffer, n, "%4.1f ", this->percent_cpu);
+         xSnprintf(buffer, n, "%4.1f ", percent_cpu);
       }
       break;
    }

--- a/Settings.c
+++ b/Settings.c
@@ -306,6 +306,7 @@ Settings* Settings_new(int cpuCount) {
    this->cpuCount = cpuCount;
    this->showProgramPath = true;
    this->highlightThreads = true;
+   this->normalizeCPUPercent = false;
    #ifdef HAVE_LIBHWLOC
    this->topologyAffinity = false;
    #endif

--- a/Settings.h
+++ b/Settings.h
@@ -49,6 +49,7 @@ typedef struct Settings_ {
    bool accountGuestInCPUMeter;
    bool headerMargin;
    bool enableMouse;
+   bool normalizeCPUPercent;
    #ifdef HAVE_LIBHWLOC
    bool topologyAffinity;
    #endif

--- a/htop.1.in
+++ b/htop.1.in
@@ -56,6 +56,9 @@ Output version information and exit
 .TP
 \fB\-t \-\-tree
 Show processes in tree view
+.TP
+\fB\-n \-\-normalize-cpu
+Divide process CPU percent by the number of CPU cores
 .SH "INTERACTIVE COMMANDS"
 .LP
 The following commands are supported while in

--- a/htop.c
+++ b/htop.c
@@ -45,6 +45,7 @@ static void printHelpFlag() {
          "-u --user[=USERNAME]        Show only processes for a given user (or $USER)\n"
          "-U --no-unicode             Do not use unicode but plain ASCII\n"
          "-p --pid=PID,[,PID,PID...]  Show only the given PIDs\n"
+         "-n --normalize-cpu          Divide process CPU percent by the number of CPU cores\n"
          "-v --version                Print version info\n"
          "\n"
          "Long options may be passed with a single dash.\n\n"
@@ -65,6 +66,7 @@ typedef struct CommandLineSettings_ {
    bool enableMouse;
    bool treeView;
    bool allowUnicode;
+   bool normalizeCPUPercent;
 } CommandLineSettings;
 
 static CommandLineSettings parseArguments(int argc, char** argv) {
@@ -78,27 +80,29 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
       .enableMouse = true,
       .treeView = false,
       .allowUnicode = true,
+      .normalizeCPUPercent = false
    };
 
    static struct option long_opts[] =
    {
-      {"help",       no_argument,         0, 'h'},
-      {"version",    no_argument,         0, 'v'},
-      {"delay",      required_argument,   0, 'd'},
-      {"sort-key",   required_argument,   0, 's'},
-      {"user",       optional_argument,   0, 'u'},
-      {"no-color",   no_argument,         0, 'C'},
-      {"no-colour",  no_argument,         0, 'C'},
-      {"no-mouse",   no_argument,         0, 'm'},
-      {"no-unicode", no_argument,         0, 'U'},
-      {"tree",       no_argument,         0, 't'},
-      {"pid",        required_argument,   0, 'p'},
+      {"help",          no_argument,         0, 'h'},
+      {"version",       no_argument,         0, 'v'},
+      {"delay",         required_argument,   0, 'd'},
+      {"sort-key",      required_argument,   0, 's'},
+      {"user",          optional_argument,   0, 'u'},
+      {"no-color",      no_argument,         0, 'C'},
+      {"no-colour",     no_argument,         0, 'C'},
+      {"no-mouse",      no_argument,         0, 'm'},
+      {"no-unicode",    no_argument,         0, 'U'},
+      {"tree",          no_argument,         0, 't'},
+      {"pid",           required_argument,   0, 'p'},
+      {"normalize-cpu", no_argument,         0, 'n'},
       {0,0,0,0}
    };
 
    int opt, opti=0;
    /* Parse arguments */
-   while ((opt = getopt_long(argc, argv, "hvmCs:td:u::Up:", long_opts, &opti))) {
+   while ((opt = getopt_long(argc, argv, "hvmCs:td:u::Up:n", long_opts, &opti))) {
       if (opt == EOF) break;
       switch (opt) {
          case 'h':
@@ -176,6 +180,9 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
 
             break;
          }
+        case 'n':
+            flags.normalizeCPUPercent = true;
+            break;
          default:
             exit(1);
       }
@@ -232,6 +239,8 @@ int main(int argc, char** argv) {
       settings->enableMouse = false;
    if (flags.treeView)
       settings->treeView = true;
+   if (flags.normalizeCPUPercent)
+      settings->normalizeCPUPercent = true;
 
    CRT_init(settings->delay, settings->colorScheme, flags.allowUnicode);
 


### PR DESCRIPTION
Feature divides the reported process CPU percent by the number of CPU
cores. Selected by command-line '-n' or '--normalize-cpu' and can be
toggled at main screen with the 'z' key. Disabled by default.