### PR TITLE
Change option '-m' to '-M' for consistency of cli

### DIFF
--- a/htop.1.in
+++ b/htop.1.in
@@ -51,6 +51,9 @@ Show only the processes of a given user
 \fB\-U \-\-no-unicode\fR
 Do not use unicode but ASCII characters for graph meters
 .TP
+\fB\-M \-\-no-mouse\fR
+Disable support of mouse control
+.TP
 \fB\-v \-\-version
 Output version information and exit
 .TP

--- a/htop.c
+++ b/htop.c
@@ -38,7 +38,7 @@ static void printHelpFlag() {
    fputs("htop " VERSION "\n"
          "Released under the GNU GPL.\n\n"
          "-C --no-color               Use a monochrome color scheme\n"
-         "-m --no-mouse               Disable the mouse\n"
+         "-M --no-mouse               Disable the mouse\n"
          "-d --delay=DELAY            Set the delay between updates, in tenths of seconds\n"
          "-h --help                   Print this help screen\n"
          "-s --sort-key=COLUMN        Sort by COLUMN (try --sort-key=help for a list)\n"
@@ -90,7 +90,7 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
       {"user",       optional_argument,   0, 'u'},
       {"no-color",   no_argument,         0, 'C'},
       {"no-colour",  no_argument,         0, 'C'},
-      {"no-mouse",   no_argument,         0, 'm'},
+      {"no-mouse",   no_argument,         0, 'M'},
       {"no-unicode", no_argument,         0, 'U'},
       {"tree",       no_argument,         0, 't'},
       {"pid",        required_argument,   0, 'p'},
@@ -99,7 +99,7 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
 
    int opt, opti=0;
    /* Parse arguments */
-   while ((opt = getopt_long(argc, argv, "hvmCs:td:u::Up:", long_opts, &opti))) {
+   while ((opt = getopt_long(argc, argv, "hvMCs:td:u::Up:", long_opts, &opti))) {
       if (opt == EOF) break;
       switch (opt) {
          case 'h':
@@ -150,7 +150,7 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
          case 'C':
             flags.useColors = false;
             break;
-         case 'm':
+         case 'M':
             flags.enableMouse = false;
             break;
          case 'U':


### PR DESCRIPTION
`-m` was added as short option for `--no-mouse`, this is inconsistence
to the rest of the cli since otherwise the short options to disable a
feature are capital letters. Therefore this commit renames the option to
`-M`.

This commit also documents the option in the man page.

Supersedes PR #138 and solves #139.