### PR TITLE
Document missing fields in man page

### DIFF
--- a/htop.1.in
+++ b/htop.1.in
@@ -318,14 +318,14 @@ The library size of the process.
 The size of the dirty pages of the process.
 .TP
 .B M_SWAP (SWAP)
-Size of the process's swapped pages.
+The size of the process's swapped pages.
 .TP
 .B M_PSS (PSS)
-proportional set size, same as M_RESIDENT but each page is divided by the
+The proportional set size, same as M_RESIDENT but each page is divided by the
 number of processes sharing it.
 .TP
 .B M_M_PSSWP (PSSWP)
-Shows proportional swap share of this mapping, unlike \fBM_SWAP\fR this does not take
+The proportional swap share of this mapping, unlike M_SWAP this does not take
 into account swapped out page of underlying shmem objects.
 .TP
 .B ST_UID (UID)

--- a/htop.1.in
+++ b/htop.1.in
@@ -317,6 +317,9 @@ The library size of the process.
 .B M_DT (DIRTY)
 The size of the dirty pages of the process.
 .TP
+.B M_SWAP (SWAP)
+Size of the process's swapped pages.
+.TP
 .B ST_UID (UID)
 The user ID of the process owner.
 .TP

--- a/htop.1.in
+++ b/htop.1.in
@@ -320,6 +320,14 @@ The size of the dirty pages of the process.
 .B M_SWAP (SWAP)
 Size of the process's swapped pages.
 .TP
+.B M_PSS (PSS)
+proportional set size, same as M_RESIDENT but each page is divided by the
+number of processes sharing it.
+.TP
+.B M_M_PSSWP (PSSWP)
+Shows proportional swap share of this mapping, unlike \fBM_SWAP\fR this does not take
+into account swapped out page of underlying shmem objects.
+.TP
 .B ST_UID (UID)
 The user ID of the process owner.
 .TP


### PR DESCRIPTION
I noticed that some fields are not documented in the man page. We should fix
that.

Undocumented fields (list generated from source):
- [ ] CNSWAP
- ~COMM~ (not a field in the options but fixed)
- [ ] EXIT_SIGNAL
- ~LAST_PROCESSFIELD~ – not a real field
- [x] M_PSS
- [x] M_PSSWP
- [X] M_SWAP
- ~NULL_PROCESSFIELD~ – not a real field