### PR TITLE
Xalloc dedup&cleanup

### DIFF
--- a/XAlloc.c
+++ b/XAlloc.c
@@ -5,6 +5,8 @@
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
+
+#include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -37,6 +39,32 @@ void* xRealloc(void* ptr, size_t size) {
       fail();
    }
    return data;
+}
+
+int xAsprintf(char** strp, const char* fmt, ...) {
+   va_list vl;
+   va_start(vl, fmt);
+   int _r = vasprintf(strp, fmt, vl);
+   va_end(vl);
+
+   if (_r < 0) {
+      fail();
+   }
+
+   return _r;
+}
+
+int xSnprintf(char* buf, int len, const char* fmt, ...) {
+   va_list vl;
+   va_start(vl, fmt);
+   int _n=vsnprintf(buf, len, fmt, vl);
+   va_end(vl);
+
+   if (!(_n > -1 && _n < len)) {
+      fail();
+   }
+
+   return _n;
 }
 
 char* xStrdup_(const char* str) {

--- a/XAlloc.c
+++ b/XAlloc.c
@@ -67,7 +67,7 @@ int xSnprintf(char* buf, int len, const char* fmt, ...) {
    return _n;
 }
 
-char* xStrdup_(const char* str) {
+char* xStrdup(const char* str) {
    char* data = strdup(str);
    if (!data) {
       fail();

--- a/XAlloc.h
+++ b/XAlloc.h
@@ -25,14 +25,6 @@ int xAsprintf(char **strp, const char* fmt, ...);
 ATTR_FORMAT(printf, 3, 4)
 int xSnprintf(char *buf, int len, const char* fmt, ...);
 
-#undef xStrdup
-#undef xStrdup_
-#ifdef NDEBUG
-# define xStrdup_ xStrdup
-#else
-# define xStrdup(str_) (assert(str_), xStrdup_(str_))
-#endif
-
-char* xStrdup_(const char* str) ATTR_NONNULL;
+char* xStrdup(const char* str) ATTR_NONNULL;
 
 #endif

--- a/XAlloc.h
+++ b/XAlloc.h
@@ -19,11 +19,11 @@ void* xCalloc(size_t nmemb, size_t size);
 
 void* xRealloc(void* ptr, size_t size);
 
-#undef xAsprintf
+ATTR_FORMAT(printf, 2, 3)
+int xAsprintf(char **strp, const char* fmt, ...);
 
-#define xAsprintf(strp, fmt, ...) do { int _r=asprintf(strp, fmt, __VA_ARGS__); if (_r < 0) { fail(); } } while(0)
-
-#define xSnprintf(fmt, len, ...) do { int _l=len; int _n=snprintf(fmt, _l, __VA_ARGS__); if (!(_n > -1 && _n < _l)) { curs_set(1); endwin(); err(1, NULL); } } while(0)
+ATTR_FORMAT(printf, 3, 4)
+int xSnprintf(char *buf, int len, const char* fmt, ...);
 
 #undef xStrdup
 #undef xStrdup_

--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -355,7 +355,7 @@ char* FreeBSDProcessList_readJailName(struct kinfo_proc* kproc) {
       if (jid < 0) {
          if (!jail_errmsg[0])
             xSnprintf(jail_errmsg, JAIL_ERRMSGLEN, "jail_get: %s", strerror(errno));
-            return NULL;
+         return NULL;
       } else if (jid == kproc->ki_jid) {
          jname = xStrdup(jnamebuf);
          if (jname == NULL)


### PR DESCRIPTION
This cleans up some of the mess in `XAlloc.h` …

This also fixes an argument list issue the original macro had (`buf` was missing and wrongly labelled `fmt`).