### PR TITLE
Use ATTR_NONNULL to annotate declarations

### DIFF
--- a/Affinity.c
+++ b/Affinity.c
@@ -6,6 +6,8 @@ Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "config.h"
+
 #include "Affinity.h"
 
 #include <stdlib.h>

--- a/AvailableMetersPanel.h
+++ b/AvailableMetersPanel.h
@@ -7,10 +7,10 @@ Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
 
-#include "Settings.h"
 #include "Panel.h"
-#include "ScreenManager.h"
 #include "ProcessList.h"
+#include "ScreenManager.h"
+#include "Settings.h"
 
 typedef struct AvailableMetersPanel_ {
    Panel super;

--- a/CategoriesPanel.h
+++ b/CategoriesPanel.h
@@ -8,9 +8,9 @@ in the source distribution for its full text.
 */
 
 #include "Panel.h"
-#include "Settings.h"
-#include "ScreenManager.h"
 #include "ProcessList.h"
+#include "ScreenManager.h"
+#include "Settings.h"
 
 typedef struct CategoriesPanel_ {
    Panel super;

--- a/ColorsPanel.h
+++ b/ColorsPanel.h
@@ -8,8 +8,8 @@ in the source distribution for its full text.
 */
 
 #include "Panel.h"
-#include "Settings.h"
 #include "ScreenManager.h"
+#include "Settings.h"
 
 typedef struct ColorsPanel_ {
    Panel super;

--- a/DisplayOptionsPanel.h
+++ b/DisplayOptionsPanel.h
@@ -8,8 +8,8 @@ in the source distribution for its full text.
 */
 
 #include "Panel.h"
-#include "Settings.h"
 #include "ScreenManager.h"
+#include "Settings.h"
 
 typedef struct DisplayOptionsPanel_ {
    Panel super;

--- a/IncSet.h
+++ b/IncSet.h
@@ -7,9 +7,10 @@ Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include <stdbool.h>
+
 #include "FunctionBar.h"
 #include "Panel.h"
-#include <stdbool.h>
 
 #define INCMODE_MAX 40
 

--- a/InfoScreen.h
+++ b/InfoScreen.h
@@ -1,10 +1,10 @@
 #ifndef HEADER_InfoScreen
 #define HEADER_InfoScreen
 
-#include "Process.h"
-#include "Panel.h"
 #include "FunctionBar.h"
 #include "IncSet.h"
+#include "Panel.h"
+#include "Process.h"
 
 typedef struct InfoScreen_ InfoScreen;
 

--- a/Meter.h
+++ b/Meter.h
@@ -7,8 +7,9 @@ Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
 
-#include "ListItem.h"
 #include <sys/time.h>
+
+#include "ListItem.h"
 
 #define METER_BUFFER_LEN 256
 

--- a/MetersPanel.h
+++ b/MetersPanel.h
@@ -8,8 +8,8 @@ in the source distribution for its full text.
 */
 
 #include "Panel.h"
-#include "Settings.h"
 #include "ScreenManager.h"
+#include "Settings.h"
 
 typedef struct MetersPanel_ MetersPanel;
 

--- a/Panel.h
+++ b/Panel.h
@@ -7,9 +7,9 @@ Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "FunctionBar.h"
 #include "Object.h"
 #include "Vector.h"
-#include "FunctionBar.h"
 
 typedef struct Panel_ Panel;
 

--- a/Process.h
+++ b/Process.h
@@ -20,9 +20,9 @@ in the source distribution for its full text.
 #endif
 #define PAGE_SIZE_KB ( PAGE_SIZE / ONE_K )
 
-#include "Object.h"
-
 #include <sys/types.h>
+
+#include "Object.h"
 
 #define PROCESS_FLAG_IO 0x0001
 

--- a/ProcessList.h
+++ b/ProcessList.h
@@ -7,12 +7,12 @@ Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
 
-#include "Vector.h"
 #include "Hashtable.h"
-#include "UsersTable.h"
 #include "Panel.h"
 #include "Process.h"
 #include "Settings.h"
+#include "UsersTable.h"
+#include "Vector.h"
 
 #ifdef HAVE_LIBHWLOC
 #include <hwloc.h>

--- a/ScreenManager.h
+++ b/ScreenManager.h
@@ -7,10 +7,10 @@ Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
 
-#include "Vector.h"
 #include "Header.h"
 #include "Settings.h"
 #include "Panel.h"
+#include "Vector.h"
 
 typedef enum Orientation_ {
    VERTICAL,

--- a/Settings.h
+++ b/Settings.h
@@ -9,8 +9,9 @@ in the source distribution for its full text.
 
 #define DEFAULT_DELAY 15
 
-#include "Process.h"
 #include <stdbool.h>
+
+#include "Process.h"
 
 typedef struct {
    int len;

--- a/XAlloc.c
+++ b/XAlloc.c
@@ -5,6 +5,8 @@
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
+
+#include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -37,6 +39,32 @@ void* xRealloc(void* ptr, size_t size) {
       fail();
    }
    return data;
+}
+
+int xAsprintf(char** strp, const char* fmt, ...) {
+   va_list vl;
+   va_start(vl, fmt);
+   int _r = vasprintf(strp, fmt, vl);
+   va_end(vl);
+
+   if (_r < 0) {
+      fail();
+   }
+
+   return _r;
+}
+
+int xSnprintf(char* buf, int len, const char* fmt, ...) {
+   va_list vl;
+   va_start(vl, fmt);
+   int _n=vsnprintf(buf, len, fmt, vl);
+   va_end(vl);
+
+   if (!(_n > -1 && _n < len)) {
+      fail();
+   }
+
+   return _n;
 }
 
 char* xStrdup_(const char* str) {

--- a/XAlloc.c
+++ b/XAlloc.c
@@ -67,7 +67,7 @@ int xSnprintf(char* buf, int len, const char* fmt, ...) {
    return _n;
 }
 
-char* xStrdup_(const char* str) {
+char* xStrdup(const char* str) {
    char* data = strdup(str);
    if (!data) {
       fail();

--- a/XAlloc.h
+++ b/XAlloc.h
@@ -25,14 +25,6 @@ int xAsprintf(char **strp, const char* fmt, ...);
 ATTR_FORMAT(printf, 3, 4)
 int xSnprintf(char *buf, int len, const char* fmt, ...);
 
-#undef xStrdup
-#undef xStrdup_
-#ifdef NDEBUG
-# define xStrdup_ xStrdup
-#else
-# define xStrdup(str_) (assert(str_), xStrdup_(str_))
-#endif
-
-char* xStrdup_(const char* str) ATTR_NONNULL;
+char* xStrdup(const char* str) ATTR_NONNULL;
 
 #endif

--- a/XAlloc.h
+++ b/XAlloc.h
@@ -19,11 +19,11 @@ void* xCalloc(size_t nmemb, size_t size);
 
 void* xRealloc(void* ptr, size_t size);
 
-#undef xAsprintf
+ATTR_FORMAT(printf, 2, 3)
+int xAsprintf(char **strp, const char* fmt, ...);
 
-#define xAsprintf(strp, fmt, ...) do { int _r=asprintf(strp, fmt, __VA_ARGS__); if (_r < 0) { fail(); } } while(0)
-
-#define xSnprintf(fmt, len, ...) do { int _l=len; int _n=snprintf(fmt, _l, __VA_ARGS__); if (!(_n > -1 && _n < _l)) { curs_set(1); endwin(); err(1, NULL); } } while(0)
+ATTR_FORMAT(printf, 3, 4)
+int xSnprintf(char *buf, int len, const char* fmt, ...);
 
 #undef xStrdup
 #undef xStrdup_

--- a/XAlloc.h
+++ b/XAlloc.h
@@ -7,8 +7,8 @@
 
 #include "Macros.h"
 
-#include <err.h>
 #include <assert.h>
+#include <err.h>
 #include <stdlib.h>
 
 void fail(void) ATTR_NORETURN;

--- a/configure.ac
+++ b/configure.ac
@@ -169,6 +169,23 @@ m4_define([HTOP_CHECK_LIB],
    ], [$4])
 ])
 
+dnl https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
+  ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS
+
 AC_ARG_ENABLE(unicode, [AS_HELP_STRING([--enable-unicode], [enable Unicode support])], ,enable_unicode="yes")
 if test "x$enable_unicode" = xyes; then
    HTOP_CHECK_SCRIPT([ncursesw6], [addnwstr], [HAVE_LIBNCURSESW], "ncursesw6-config",
@@ -290,6 +307,8 @@ AM_CFLAGS="\
  -Wundef\
  -Wunused\
  -Wwrite-strings"
+
+AX_CHECK_COMPILE_FLAG([-Wnull-dereference], [AM_CFLAGS="$AM_CFLAGS -Wnull-dereference"], , [-Werror])
 
 AC_ARG_ENABLE([werror], [AS_HELP_STRING([--enable-werror], [Treat warnings as errors (default: warnings are not errors)])], [enable_werror="$enableval"], [enable_werror=no])
 AS_IF([test "x$enable_werror" = "xyes"], [AM_CFLAGS="$AM_CFLAGS -Werror"])

--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -355,7 +355,7 @@ char* FreeBSDProcessList_readJailName(struct kinfo_proc* kproc) {
       if (jid < 0) {
          if (!jail_errmsg[0])
             xSnprintf(jail_errmsg, JAIL_ERRMSGLEN, "jail_get: %s", strerror(errno));
-            return NULL;
+         return NULL;
       } else if (jid == kproc->ki_jid) {
          jname = xStrdup(jnamebuf);
          if (jname == NULL)


### PR DESCRIPTION
If #155 gets merged before this, a minor change in `XAlloc.h` is recommended to include these attributes for the newly created/renamed functions `xAsnprintf`, `xSnprintf` and `xStrdup`.

I can also rebase this PR onto #155. If okay, I'd add the necessary changes to the above mentioned functions.