### PR TITLE
minor fixes for Solaris 11

### DIFF
--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -202,8 +202,8 @@ static inline void SolarisProcessList_scanZfsArcstats(ProcessList* pl) {
    int                 ksrphyserr = -1;
    kstat_named_t       *cur_kstat = NULL;
 
-   if (spl->kd != NULL)  { arcstats   = kstat_lookup(spl->kd,"zfs",0,"arcstats"); }
-   if (arcstats != NULL) { ksrphyserr = kstat_read(spl->kd,arcstats,NULL); }
+   if (spl->kd != NULL)  { arcstats   = kstat_lookup(spl->kd, "zfs", 0, "arcstats"); }
+   if (arcstats != NULL) { ksrphyserr = kstat_read(spl->kd, arcstats, NULL); }
    if (ksrphyserr != -1) {
       cur_kstat = kstat_data_lookup( arcstats, "size" );
       spl->zfs.size = cur_kstat->value.ui64 / 1024;
@@ -213,19 +213,19 @@ static inline void SolarisProcessList_scanZfsArcstats(ProcessList* pl) {
       spl->zfs.max = cur_kstat->value.ui64 / 1024;
 
       cur_kstat = kstat_data_lookup( arcstats, "mfu_size" );
-      spl->zfs.MFU = cur_kstat->value.ui64 / 1024;
+      spl->zfs.MFU = cur_kstat != NULL ? cur_kstat->value.ui64 / 1024 : 0;
 
       cur_kstat = kstat_data_lookup( arcstats, "mru_size" );
-      spl->zfs.MRU = cur_kstat->value.ui64 / 1024;
+      spl->zfs.MRU = cur_kstat != NULL ? cur_kstat->value.ui64 / 1024 : 0;
 
       cur_kstat = kstat_data_lookup( arcstats, "anon_size" );
-      spl->zfs.anon = cur_kstat->value.ui64 / 1024;
+      spl->zfs.anon = cur_kstat != NULL ? cur_kstat->value.ui64 / 1024 : 0;
 
       cur_kstat = kstat_data_lookup( arcstats, "hdr_size" );
-      spl->zfs.header = cur_kstat->value.ui64 / 1024;
+      spl->zfs.header = cur_kstat != NULL ? cur_kstat->value.ui64 / 1024 : 0;
 
       cur_kstat = kstat_data_lookup( arcstats, "other_size" );
-      spl->zfs.other = cur_kstat->value.ui64 / 1024;
+      spl->zfs.other = cur_kstat != NULL ? cur_kstat->value.ui64 / 1024 : 0;
 
       if ((cur_kstat = kstat_data_lookup( arcstats, "compressed_size" )) != NULL) {
          spl->zfs.compressed = cur_kstat->value.ui64 / 1024;


### PR DESCRIPTION
I hit two issues when running the current htop on Solaris 11.4:
1. it crashes (due the NULL pointer dereference) in SolarisProcessList_scanZfsArcstats() because the following kstats are not present in Solaris 11.4:

    - mfu_size
    - mru_size
    - anon_size
    - hdr_size
    - other_size

    They are missing at least also from recent Solaris 11.3 and Solaris 10 1/13 (aka Update 11). I suppose they may exist in some OpenSolaris forks so I think we can keep them in the code. Unfortunately it looks like there are no equivalents in Solaris we can use instead of these or to calculate them.  

2. When running in a Non-Global Zone, htop does not display any memory used. It looks to me that we should use "freemem" kstat rather than "pageslocked" as the latter is always 0 in the zone.