### PR TITLE
Cleanup includes

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -8,28 +8,32 @@ in the source distribution for its full text.
 #include "config.h"
 
 #include "Action.h"
+
+#include <pwd.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
 #include "Affinity.h"
 #include "AffinityPanel.h"
 #include "CategoriesPanel.h"
+#include "CommandScreen.h"
 #include "CRT.h"
 #include "EnvScreen.h"
-#include "CommandScreen.h"
+#include "FunctionBar.h"
+#include "IncSet.h"
+#include "InfoScreen.h"
+#include "ListItem.h"
+#include "Macros.h"
 #include "MainPanel.h"
 #include "OpenFilesScreen.h"
 #include "Process.h"
+#include "ProvideCurses.h"
 #include "ScreenManager.h"
 #include "SignalsPanel.h"
 #include "TraceScreen.h"
-#include "Platform.h"
+#include "Vector.h"
 #include "XUtils.h"
 
-#include <ctype.h>
-#include <math.h>
-#include <pwd.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <sys/param.h>
-#include <sys/time.h>
 
 Object* Action_pickFromVector(State* st, Panel* list, int x, bool followProcess) {
    Panel* panel = st->panel;

--- a/Action.h
+++ b/Action.h
@@ -7,8 +7,13 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include <stdbool.h>
+#include <sys/types.h>
+
 #include "Header.h"
+#include "Object.h"
 #include "Panel.h"
+#include "Process.h"
 #include "ProcessList.h"
 #include "Settings.h"
 #include "UsersTable.h"

--- a/Affinity.c
+++ b/Affinity.c
@@ -12,8 +12,11 @@ in the source distribution for its full text.
 
 #include <stdlib.h>
 
+#include "XUtils.h"
+
 #ifdef HAVE_LIBHWLOC
 #include <hwloc.h>
+#include <hwloc/bitmap.h>
 #ifdef __linux__
 #define HTOP_HWLOC_CPUBIND_FLAG HWLOC_CPUBIND_THREAD
 #else

--- a/Affinity.h
+++ b/Affinity.h
@@ -8,6 +8,11 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "config.h"
+
+#include <stdbool.h>
+
+#include "Object.h"
 #include "Process.h"
 #include "ProcessList.h"
 

--- a/AffinityPanel.c
+++ b/AffinityPanel.c
@@ -5,20 +5,29 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
-#include "config.h"
+#include "config.h" // IWYU pragma: keep
 
 #include "AffinityPanel.h"
 
 #include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "CRT.h"
+#include "FunctionBar.h"
+#include "Object.h"
+#include "ProvideCurses.h"
+#include "RichString.h"
+#include "Settings.h"
 #include "Vector.h"
 #include "XUtils.h"
 
 #ifdef HAVE_LIBHWLOC
 #include <hwloc.h>
+#include <hwloc/bitmap.h>
 #endif
+
 
 typedef struct MaskItem_ {
    Object super;

--- a/AvailableColumnsPanel.c
+++ b/AvailableColumnsPanel.c
@@ -7,14 +7,17 @@ in the source distribution for its full text.
 
 #include "AvailableColumnsPanel.h"
 
-#include <assert.h>
 #include <ctype.h>
+#include <stdbool.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include "ColumnsPanel.h"
-#include "Header.h"
+#include "FunctionBar.h"
+#include "ListItem.h"
+#include "Object.h"
 #include "Platform.h"
+#include "Process.h"
+#include "ProvideCurses.h"
 #include "XUtils.h"
 
 

--- a/AvailableMetersPanel.c
+++ b/AvailableMetersPanel.c
@@ -6,16 +6,21 @@ in the source distribution for its full text.
 */
 
 #include "AvailableMetersPanel.h"
-#include "MetersPanel.h"
-
-#include "CPUMeter.h"
-#include "Header.h"
-#include "ListItem.h"
-#include "Platform.h"
-#include "XUtils.h"
 
 #include <assert.h>
+#include <stdbool.h>
 #include <stdlib.h>
+
+#include "CPUMeter.h"
+#include "FunctionBar.h"
+#include "Header.h"
+#include "ListItem.h"
+#include "Meter.h"
+#include "MetersPanel.h"
+#include "Object.h"
+#include "Platform.h"
+#include "ProvideCurses.h"
+#include "XUtils.h"
 
 
 static void AvailableMetersPanel_delete(Object* object) {

--- a/AvailableMetersPanel.h
+++ b/AvailableMetersPanel.h
@@ -7,6 +7,7 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "Header.h"
 #include "Panel.h"
 #include "ProcessList.h"
 #include "ScreenManager.h"

--- a/BatteryMeter.c
+++ b/BatteryMeter.c
@@ -9,15 +9,12 @@ This meter written by Ian P. Hands (iphands@gmail.com, ihands@redhat.com).
 
 #include "BatteryMeter.h"
 
-#include "Battery.h"
-#include "ProcessList.h"
-#include "CRT.h"
-#include "Platform.h"
-#include "XUtils.h"
-
 #include <math.h>
-#include <string.h>
-#include <stdlib.h>
+
+#include "Battery.h"
+#include "CRT.h"
+#include "Object.h"
+#include "XUtils.h"
 
 
 static const int BatteryMeter_attributes[] = {

--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -7,15 +7,18 @@ in the source distribution for its full text.
 
 #include "CPUMeter.h"
 
-#include "CRT.h"
-#include "Settings.h"
-#include "Platform.h"
-#include "XUtils.h"
-
-#include <assert.h>
+#include <math.h>
 #include <stdlib.h>
 #include <string.h>
-#include <math.h>
+
+#include "CRT.h"
+#include "Object.h"
+#include "Platform.h"
+#include "ProcessList.h"
+#include "RichString.h"
+#include "Settings.h"
+#include "XUtils.h"
+
 
 static const int CPUMeter_attributes[] = {
    CPU_NICE,

--- a/CRT.c
+++ b/CRT.c
@@ -5,28 +5,26 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
-#include "config.h"
+#include "config.h" // IWYU pragma: keep
+
 #include "CRT.h"
 
-#include "RichString.h"
-#include "XUtils.h"
-
-#include <stdio.h>
 #include <errno.h>
+#include <langinfo.h>
+#include <locale.h>
 #include <signal.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <locale.h>
-#include <langinfo.h>
 #include <unistd.h>
+
+#include "ProvideCurses.h"
+#include "XUtils.h"
 
 #ifdef HAVE_EXECINFO_H
 #include <execinfo.h>
 #endif
 
-#ifdef HAVE_SETUID_ENABLED
-#include <sys/types.h>
-#endif
 
 #define ColorIndex(i,j) ((7-(i))*8+(j))
 

--- a/CRT.h
+++ b/CRT.h
@@ -7,9 +7,13 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
-#include "Macros.h"
+#include "config.h"
 
 #include <stdbool.h>
+
+#include "Macros.h"
+#include "ProvideCurses.h"
+
 
 typedef enum TreeStr_ {
    TREE_STR_HORZ,

--- a/CategoriesPanel.c
+++ b/CategoriesPanel.c
@@ -7,15 +7,21 @@ in the source distribution for its full text.
 
 #include "CategoriesPanel.h"
 
-#include "AvailableMetersPanel.h"
-#include "MetersPanel.h"
-#include "DisplayOptionsPanel.h"
-#include "ColumnsPanel.h"
-#include "ColorsPanel.h"
-#include "AvailableColumnsPanel.h"
-
-#include <assert.h>
+#include <ctype.h>
+#include <stdbool.h>
 #include <stdlib.h>
+
+#include "AvailableColumnsPanel.h"
+#include "AvailableMetersPanel.h"
+#include "ColorsPanel.h"
+#include "ColumnsPanel.h"
+#include "DisplayOptionsPanel.h"
+#include "FunctionBar.h"
+#include "ListItem.h"
+#include "MetersPanel.h"
+#include "Object.h"
+#include "ProvideCurses.h"
+#include "Vector.h"
 
 
 static const char* const CategoriesFunctions[] = {"      ", "      ", "      ", "      ", "      ", "      ", "      ", "      ", "      ", "Done  ", NULL};

--- a/CategoriesPanel.h
+++ b/CategoriesPanel.h
@@ -7,6 +7,7 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "Header.h"
 #include "Panel.h"
 #include "ProcessList.h"
 #include "ScreenManager.h"

--- a/CheckItem.c
+++ b/CheckItem.c
@@ -7,10 +7,11 @@ in the source distribution for its full text.
 
 #include "CheckItem.h"
 
-#include "CRT.h"
-
 #include <assert.h>
 #include <stdlib.h>
+
+#include "CRT.h"
+#include "RichString.h"
 
 
 static void CheckItem_delete(Object* cast) {

--- a/CheckItem.h
+++ b/CheckItem.h
@@ -7,6 +7,8 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include <stdbool.h>
+
 #include "Object.h"
 
 typedef struct CheckItem_ {

--- a/ClockMeter.c
+++ b/ClockMeter.c
@@ -5,11 +5,14 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "config.h" // IWYU pragma: keep
+
 #include "ClockMeter.h"
 
-#include "CRT.h"
-
 #include <time.h>
+
+#include "CRT.h"
+#include "Object.h"
 
 
 static const int ClockMeter_attributes[] = {

--- a/ColorsPanel.c
+++ b/ColorsPanel.c
@@ -7,13 +7,19 @@ in the source distribution for its full text.
 
 #include "ColorsPanel.h"
 
-#include "CRT.h"
+#include <stdbool.h>
+#include <stdlib.h>
+
 #include "CheckItem.h"
+#include "CRT.h"
+#include "FunctionBar.h"
+#include "Header.h"
+#include "Object.h"
+#include "ProvideCurses.h"
+#include "RichString.h"
+#include "Vector.h"
 #include "XUtils.h"
 
-#include <assert.h>
-#include <stdlib.h>
-#include <string.h>
 
 // TO ADD A NEW SCHEME:
 // * Increment the size of bool check in ColorsPanel.h

--- a/ColumnsPanel.c
+++ b/ColumnsPanel.c
@@ -6,15 +6,18 @@ in the source distribution for its full text.
 */
 
 #include "ColumnsPanel.h"
-#include "Platform.h"
 
-#include "XUtils.h"
-#include "ListItem.h"
-#include "CRT.h"
-
-#include <assert.h>
-#include <stdlib.h>
 #include <ctype.h>
+#include <stdlib.h>
+
+#include "CRT.h"
+#include "FunctionBar.h"
+#include "ListItem.h"
+#include "Object.h"
+#include "Platform.h"
+#include "Process.h"
+#include "ProvideCurses.h"
+#include "XUtils.h"
 
 
 static const char* const ColumnsFunctions[] = {"      ", "      ", "      ", "      ", "      ", "      ", "MoveUp", "MoveDn", "Remove", "Done  ", NULL};

--- a/ColumnsPanel.h
+++ b/ColumnsPanel.h
@@ -7,6 +7,8 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include <stdbool.h>
+
 #include "Panel.h"
 #include "Settings.h"
 

--- a/CommandScreen.c
+++ b/CommandScreen.c
@@ -1,15 +1,14 @@
-#include "CommandScreen.h"
+#include "config.h" // IWYU pragma: keep
 
-#include "config.h"
-#include "CRT.h"
-#include "IncSet.h"
-#include "ListItem.h"
-#include "Platform.h"
-#include "XUtils.h"
+#include "CommandScreen.h"
 
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
+
+#include "Macros.h"
+#include "Panel.h"
+#include "ProvideCurses.h"
+#include "XUtils.h"
 
 
 static void CommandScreen_scan(InfoScreen* this) {

--- a/CommandScreen.h
+++ b/CommandScreen.h
@@ -2,6 +2,9 @@
 #define HEADER_CommandScreen
 
 #include "InfoScreen.h"
+#include "Object.h"
+#include "Process.h"
+
 
 typedef struct CommandScreen_ {
    InfoScreen super;

--- a/DateMeter.c
+++ b/DateMeter.c
@@ -5,11 +5,14 @@ Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "config.h" // IWYU pragma: keep
+
 #include "DateMeter.h"
 
-#include "CRT.h"
-
 #include <time.h>
+
+#include "CRT.h"
+#include "Object.h"
 
 
 static const int DateMeter_attributes[] = {

--- a/DateTimeMeter.c
+++ b/DateTimeMeter.c
@@ -5,11 +5,14 @@ Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "config.h" // IWYU pragma: keep
+
 #include "DateTimeMeter.h"
 
-#include "CRT.h"
-
 #include <time.h>
+
+#include "CRT.h"
+#include "Object.h"
 
 
 static const int DateTimeMeter_attributes[] = {

--- a/DiskIOMeter.c
+++ b/DiskIOMeter.c
@@ -7,10 +7,14 @@ in the source distribution for its full text.
 
 #include "DiskIOMeter.h"
 
-#include <math.h>
+#include <stdio.h>
+#include <sys/time.h>
 
 #include "CRT.h"
+#include "Macros.h"
+#include "Object.h"
 #include "Platform.h"
+#include "RichString.h"
 #include "XUtils.h"
 
 

--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -5,14 +5,19 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "config.h" // IWYU pragma: keep
+
 #include "DisplayOptionsPanel.h"
 
-#include <assert.h>
+#include <stdbool.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include "CheckItem.h"
 #include "CRT.h"
+#include "FunctionBar.h"
+#include "Header.h"
+#include "Object.h"
+#include "ProvideCurses.h"
 #include "XUtils.h"
 
 

--- a/EnvScreen.c
+++ b/EnvScreen.c
@@ -1,15 +1,17 @@
-#include "EnvScreen.h"
+#include "config.h" // IWYU pragma: keep
 
-#include "config.h"
-#include "CRT.h"
-#include "IncSet.h"
-#include "ListItem.h"
-#include "Platform.h"
-#include "XUtils.h"
+#include "EnvScreen.h"
 
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
+
+#include "CRT.h"
+#include "Macros.h"
+#include "Panel.h"
+#include "Platform.h"
+#include "ProvideCurses.h"
+#include "Vector.h"
+#include "XUtils.h"
 
 
 const InfoScreenClass EnvScreen_class = {

--- a/EnvScreen.h
+++ b/EnvScreen.h
@@ -2,6 +2,8 @@
 #define HEADER_EnvScreen
 
 #include "InfoScreen.h"
+#include "Object.h"
+#include "Process.h"
 
 typedef struct EnvScreen_ {
    InfoScreen super;

--- a/FunctionBar.c
+++ b/FunctionBar.c
@@ -6,13 +6,14 @@ in the source distribution for its full text.
 */
 
 #include "FunctionBar.h"
-#include "CRT.h"
-#include "RichString.h"
-#include "XUtils.h"
 
-#include <assert.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
+
+#include "CRT.h"
+#include "Macros.h"
+#include "ProvideCurses.h"
+#include "XUtils.h"
 
 
 static const char* const FunctionBar_FKeys[] = {"F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", NULL};

--- a/Hashtable.h
+++ b/Hashtable.h
@@ -9,7 +9,6 @@ in the source distribution for its full text.
 
 #include <stdbool.h>
 
-typedef struct Hashtable_ Hashtable;
 
 typedef void(*Hashtable_PairFunction)(int, void*, void*);
 
@@ -19,12 +18,12 @@ typedef struct HashtableItem {
    struct HashtableItem* next;
 } HashtableItem;
 
-struct Hashtable_ {
+typedef struct Hashtable_ {
    int size;
    HashtableItem** buckets;
    int items;
    bool owner;
-};
+} Hashtable;
 
 #ifndef NDEBUG
 

--- a/Header.c
+++ b/Header.c
@@ -7,14 +7,18 @@ in the source distribution for its full text.
 
 #include "Header.h"
 
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "CRT.h"
+#include "Macros.h"
+#include "Object.h"
 #include "Platform.h"
+#include "ProvideCurses.h"
 #include "XUtils.h"
 
-#include <assert.h>
-#include <time.h>
-#include <string.h>
-#include <stdlib.h>
 
 Header* Header_new(struct ProcessList_* pl, Settings* settings, int nrColumns) {
    Header* this = xCalloc(1, sizeof(Header));

--- a/Header.h
+++ b/Header.h
@@ -8,6 +8,7 @@ in the source distribution for its full text.
 */
 
 #include "Meter.h"
+#include "ProcessList.h"
 #include "Settings.h"
 #include "Vector.h"
 

--- a/HostnameMeter.c
+++ b/HostnameMeter.c
@@ -5,11 +5,14 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "config.h" // IWYU pragma: keep
+
 #include "HostnameMeter.h"
 
-#include "CRT.h"
-
 #include <unistd.h>
+
+#include "CRT.h"
+#include "Object.h"
 
 
 static const int HostnameMeter_attributes[] = {

--- a/IncSet.c
+++ b/IncSet.c
@@ -5,13 +5,19 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
-#include "IncSet.h"
-#include "ListItem.h"
-#include "CRT.h"
-#include "XUtils.h"
+#include "config.h" // IWYU pragma: keep
 
+#include "IncSet.h"
+
+#include <ctype.h>
 #include <string.h>
 #include <stdlib.h>
+
+#include "CRT.h"
+#include "ListItem.h"
+#include "Object.h"
+#include "ProvideCurses.h"
+#include "XUtils.h"
 
 
 static void IncMode_reset(IncMode* mode) {

--- a/IncSet.h
+++ b/IncSet.h
@@ -8,9 +8,11 @@ in the source distribution for its full text.
 */
 
 #include <stdbool.h>
+#include <stddef.h>
 
 #include "FunctionBar.h"
 #include "Panel.h"
+#include "Vector.h"
 
 #define INCMODE_MAX 40
 

--- a/InfoScreen.c
+++ b/InfoScreen.c
@@ -1,17 +1,18 @@
+#include "config.h" // IWYU pragma: keep
+
 #include "InfoScreen.h"
 
-#include "config.h"
-#include "Object.h"
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "CRT.h"
 #include "IncSet.h"
 #include "ListItem.h"
-#include "Platform.h"
+#include "Object.h"
+#include "ProvideCurses.h"
 #include "XUtils.h"
-
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
-#include <stdarg.h>
 
 
 static const char* const InfoScreenFunctions[] = {"Search ", "Filter ", "Refresh", "Done   ", NULL};

--- a/InfoScreen.h
+++ b/InfoScreen.h
@@ -1,12 +1,25 @@
 #ifndef HEADER_InfoScreen
 #define HEADER_InfoScreen
 
+#include <stdbool.h>
+
 #include "FunctionBar.h"
 #include "IncSet.h"
+#include "Macros.h"
+#include "Object.h"
 #include "Panel.h"
 #include "Process.h"
+#include "Vector.h"
 
-typedef struct InfoScreen_ InfoScreen;
+
+typedef struct InfoScreen_ {
+   Object super;
+   const Process* process;
+   Panel* display;
+   FunctionBar* bar;
+   IncSet* inc;
+   Vector* lines;
+} InfoScreen;
 
 typedef void(*InfoScreen_Scan)(InfoScreen*);
 typedef void(*InfoScreen_Draw)(InfoScreen*);
@@ -26,15 +39,6 @@ typedef struct InfoScreenClass_ {
 #define InfoScreen_draw(this_)        As_InfoScreen(this_)->draw((InfoScreen*)(this_))
 #define InfoScreen_onErr(this_)       As_InfoScreen(this_)->onErr((InfoScreen*)(this_))
 #define InfoScreen_onKey(this_, ch_)  As_InfoScreen(this_)->onKey((InfoScreen*)(this_), ch_)
-
-struct InfoScreen_ {
-   Object super;
-   const Process* process;
-   Panel* display;
-   FunctionBar* bar;
-   IncSet* inc;
-   Vector* lines;
-};
 
 InfoScreen* InfoScreen_init(InfoScreen* this, const Process* process, FunctionBar* bar, int height, const char* panelHeader);
 

--- a/ListItem.c
+++ b/ListItem.c
@@ -5,15 +5,17 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "config.h" // IWYU pragma: keep
+
 #include "ListItem.h"
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "CRT.h"
 #include "RichString.h"
 #include "XUtils.h"
-
-#include <string.h>
-#include <assert.h>
-#include <stdlib.h>
 
 
 static void ListItem_delete(Object* cast) {

--- a/ListItem.h
+++ b/ListItem.h
@@ -7,6 +7,8 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include <stdbool.h>
+
 #include "Object.h"
 
 typedef struct ListItem_ {

--- a/LoadAverageMeter.c
+++ b/LoadAverageMeter.c
@@ -8,7 +8,9 @@ in the source distribution for its full text.
 #include "LoadAverageMeter.h"
 
 #include "CRT.h"
+#include "Object.h"
 #include "Platform.h"
+#include "RichString.h"
 #include "XUtils.h"
 
 

--- a/Macros.h
+++ b/Macros.h
@@ -1,6 +1,8 @@
 #ifndef HEADER_Macros
 #define HEADER_Macros
 
+#include <assert.h> // IWYU pragma: keep
+
 #ifndef MINIMUM
 #define MINIMUM(a, b)		((a) < (b) ? (a) : (b))
 #endif

--- a/MainPanel.c
+++ b/MainPanel.c
@@ -7,11 +7,19 @@ in the source distribution for its full text.
 */
 
 #include "MainPanel.h"
-#include "Process.h"
-#include "Platform.h"
-#include "CRT.h"
 
+#include <ctype.h>
 #include <stdlib.h>
+
+#include "CRT.h"
+#include "FunctionBar.h"
+#include "Platform.h"
+#include "Process.h"
+#include "ProcessList.h"
+#include "ProvideCurses.h"
+#include "Settings.h"
+#include "XUtils.h"
+
 
 static const char* const MainFunctions[]  = {"Help  ", "Setup ", "Search", "Filter", "Tree  ", "SortBy", "Nice -", "Nice +", "Kill  ", "Quit  ", NULL};
 

--- a/MainPanel.h
+++ b/MainPanel.h
@@ -8,9 +8,15 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include <stdbool.h>
+#include <sys/types.h>
+
 #include "Action.h"
 #include "IncSet.h"
+#include "Object.h"
 #include "Panel.h"
+#include "Process.h"
+
 
 typedef struct MainPanel_ {
    Panel super;

--- a/Makefile.am
+++ b/Makefile.am
@@ -103,6 +103,7 @@ myhtopheaders = \
 	Panel.h \
 	Process.h \
 	ProcessList.h \
+	ProvideCurses.h \
 	RichString.h \
 	ScreenManager.h \
 	Settings.h \

--- a/MemoryMeter.c
+++ b/MemoryMeter.c
@@ -8,13 +8,9 @@ in the source distribution for its full text.
 #include "MemoryMeter.h"
 
 #include "CRT.h"
+#include "Object.h"
 #include "Platform.h"
-
-#include <stdlib.h>
-#include <string.h>
-#include <math.h>
-#include <sys/param.h>
-#include <assert.h>
+#include "RichString.h"
 
 
 static const int MemoryMeter_attributes[] = {

--- a/Meter.c
+++ b/Meter.c
@@ -5,19 +5,23 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "config.h" // IWYU pragma: keep
+
 #include "Meter.h"
 
-#include "RichString.h"
-#include "Object.h"
+#include <assert.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
 #include "CRT.h"
-#include "Settings.h"
+#include "Macros.h"
+#include "Object.h"
+#include "ProvideCurses.h"
+#include "RichString.h"
 #include "XUtils.h"
 
-#include <math.h>
-#include <string.h>
-#include <stdlib.h>
-#include <stdarg.h>
-#include <assert.h>
 
 #define GRAPH_HEIGHT 4 /* Unit: rows (lines) */
 

--- a/Meter.h
+++ b/Meter.h
@@ -7,12 +7,17 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include <stdbool.h>
 #include <sys/time.h>
 
 #include "ListItem.h"
+#include "Object.h"
+#include "ProcessList.h"
+
 
 #define METER_BUFFER_LEN 256
 
+struct Meter_;
 typedef struct Meter_ Meter;
 
 typedef void(*Meter_Init)(Meter*);
@@ -67,7 +72,7 @@ struct Meter_ {
    int param;
    GraphData* drawData;
    int h;
-   struct ProcessList_* pl;
+   ProcessList* pl;
    char curItems;
    double* values;
    double total;
@@ -91,7 +96,7 @@ typedef enum {
 
 extern const MeterClass Meter_class;
 
-Meter* Meter_new(struct ProcessList_* pl, int param, const MeterClass* type);
+Meter* Meter_new(ProcessList* pl, int param, const MeterClass* type);
 
 int Meter_humanUnit(char* buffer, unsigned long int value, int size);
 

--- a/MetersPanel.c
+++ b/MetersPanel.c
@@ -8,8 +8,14 @@ in the source distribution for its full text.
 #include "MetersPanel.h"
 
 #include <stdlib.h>
-#include <assert.h>
+
 #include "CRT.h"
+#include "FunctionBar.h"
+#include "Header.h"
+#include "ListItem.h"
+#include "Meter.h"
+#include "Object.h"
+#include "ProvideCurses.h"
 
 
 // Note: In code the meters are known to have bar/text/graph "Modes", but in UI

--- a/MetersPanel.h
+++ b/MetersPanel.h
@@ -7,10 +7,15 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include <stdbool.h>
+
 #include "Panel.h"
 #include "ScreenManager.h"
 #include "Settings.h"
+#include "Vector.h"
 
+
+struct MetersPanel_;
 typedef struct MetersPanel_ MetersPanel;
 
 struct MetersPanel_ {

--- a/NetworkIOMeter.c
+++ b/NetworkIOMeter.c
@@ -1,7 +1,14 @@
 #include "NetworkIOMeter.h"
 
+#include <stddef.h>
+#include <sys/time.h>
+
 #include "CRT.h"
+#include "Macros.h"
+#include "Object.h"
 #include "Platform.h"
+#include "RichString.h"
+#include "XUtils.h"
 
 
 static const int NetworkIOMeter_attributes[] = {

--- a/Object.c
+++ b/Object.c
@@ -8,6 +8,9 @@ in the source distribution for its full text.
 
 #include "Object.h"
 
+#include <stddef.h>
+
+
 const ObjectClass Object_class = {
    .extends = NULL
 };

--- a/Object.h
+++ b/Object.h
@@ -9,10 +9,10 @@ in the source distribution for its full text.
 */
 
 #include "RichString.h"
-#include "Macros.h"
-#include "XUtils.h"
+#include "XUtils.h" // IWYU pragma: keep
 
 
+struct Object_;
 typedef struct Object_ Object;
 
 typedef void(*Object_Display)(const Object*, RichString*);
@@ -29,7 +29,7 @@ typedef void(*Object_Delete)(Object*);
 
 #define Class(class_)                 ((const ObjectClass*)(&(class_ ## _class)))
 
-#define AllocThis(class_) (class_*) xMalloc(sizeof(class_)); Object_setClass(this, Class(class_));
+#define AllocThis(class_) (class_*)   xMalloc(sizeof(class_)); Object_setClass(this, Class(class_));
 
 typedef struct ObjectClass_ {
    const void* const extends;

--- a/OpenFilesScreen.c
+++ b/OpenFilesScreen.c
@@ -5,23 +5,23 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "config.h" // IWYU pragma: keep
+
 #include "OpenFilesScreen.h"
 
-#include "CRT.h"
-#include "ProcessList.h"
-#include "IncSet.h"
-#include "FunctionBar.h"
-#include "XUtils.h"
-
-#include <string.h>
-#include <stdio.h>
-#include <unistd.h>
-#include <stdbool.h>
-#include <unistd.h>
-#include <stdlib.h>
 #include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+
+#include "Macros.h"
+#include "Panel.h"
+#include "ProvideCurses.h"
+#include "Vector.h"
+#include "XUtils.h"
 
 
 typedef struct OpenFiles_Data_ {

--- a/OpenFilesScreen.h
+++ b/OpenFilesScreen.h
@@ -7,7 +7,11 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include <sys/types.h>
+
 #include "InfoScreen.h"
+#include "Object.h"
+#include "Process.h"
 
 typedef struct OpenFilesScreen_ {
    InfoScreen super;

--- a/Panel.c
+++ b/Panel.c
@@ -7,17 +7,20 @@ in the source distribution for its full text.
 
 #include "Panel.h"
 
-#include "CRT.h"
-#include "RichString.h"
-#include "ListItem.h"
-#include "XUtils.h"
-
-#include <math.h>
+#include <assert.h>
+#include <ctype.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#include <ctype.h>
 #include <string.h>
-#include <assert.h>
+#include <strings.h>
+
+#include "CRT.h"
+#include "ListItem.h"
+#include "Macros.h"
+#include "ProvideCurses.h"
+#include "RichString.h"
+#include "XUtils.h"
+
 
 const PanelClass Panel_class = {
    .super = {

--- a/Panel.h
+++ b/Panel.h
@@ -7,10 +7,15 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include <stdbool.h>
+
 #include "FunctionBar.h"
 #include "Object.h"
+#include "RichString.h"
 #include "Vector.h"
 
+
+struct Panel_;
 typedef struct Panel_ Panel;
 
 typedef enum HandlerResult_ {

--- a/Process.c
+++ b/Process.c
@@ -6,35 +6,34 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
-#include "Process.h"
-#include "Settings.h"
+#include "config.h" // IWYU pragma: keep
 
-#include "config.h"
+#include "Process.h"
+
+#include <assert.h>
+#include <limits.h>
+#include <math.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/resource.h>
 
 #include "CRT.h"
-#include "RichString.h"
 #include "Platform.h"
+#include "RichString.h"
+#include "Settings.h"
 #include "XUtils.h"
 
-#include <stdio.h>
-#include <sys/time.h>
-#include <sys/resource.h>
-#include <sys/param.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <stdlib.h>
-#include <signal.h>
-#include <string.h>
-#include <stdbool.h>
-#include <pwd.h>
-#include <time.h>
-#include <assert.h>
-#include <math.h>
-#ifdef MAJOR_IN_MKDEV
+#if defined(MAJOR_IN_MKDEV)
 #include <sys/mkdev.h>
 #elif defined(MAJOR_IN_SYSMACROS)
 #include <sys/sysmacros.h>
 #endif
+
 
 static int Process_getuid = -1;
 

--- a/Process.h
+++ b/Process.h
@@ -8,6 +8,14 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include <stdbool.h>
+#include <unistd.h>
+#include <sys/types.h>
+
+#include "Object.h"
+#include "RichString.h"
+
+
 #ifdef __ANDROID__
 #define SYS_ioprio_get __NR_ioprio_get
 #define SYS_ioprio_set __NR_ioprio_set
@@ -19,10 +27,6 @@ in the source distribution for its full text.
 #define PAGE_SIZE ( sysconf(_SC_PAGESIZE) )
 #endif
 #define PAGE_SIZE_KB ( PAGE_SIZE / ONE_K )
-
-#include <sys/types.h>
-
-#include "Object.h"
 
 #define PROCESS_FLAG_IO 0x0001
 

--- a/ProcessList.c
+++ b/ProcessList.c
@@ -7,12 +7,11 @@ in the source distribution for its full text.
 
 #include "ProcessList.h"
 
-#include "CRT.h"
-#include "Platform.h"
-#include "XUtils.h"
-
-#include <stdlib.h>
+#include <assert.h>
 #include <string.h>
+
+#include "CRT.h"
+#include "XUtils.h"
 
 
 ProcessList* ProcessList_init(ProcessList* this, const ObjectClass* klass, UsersTable* usersTable, Hashtable* pidMatchList, uid_t userId) {

--- a/ProcessList.h
+++ b/ProcessList.h
@@ -7,9 +7,16 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "config.h" // IWYU pragma: keep
+
+#include <stdbool.h>
+#include <sys/types.h>
+
 #include "Hashtable.h"
+#include "Object.h"
 #include "Panel.h"
 #include "Process.h"
+#include "RichString.h"
 #include "Settings.h"
 #include "UsersTable.h"
 #include "Vector.h"
@@ -17,6 +24,7 @@ in the source distribution for its full text.
 #ifdef HAVE_LIBHWLOC
 #include <hwloc.h>
 #endif
+
 
 #ifndef MAX_NAME
 #define MAX_NAME 128

--- a/ProvideCurses.h
+++ b/ProvideCurses.h
@@ -1,0 +1,34 @@
+#ifndef HEADER_ProvideCurses
+#define HEADER_ProvideCurses
+/*
+htop - RichString.h
+(C) 2004,2011 Hisham H. Muhammad
+Released under the GNU GPL, see the COPYING file
+in the source distribution for its full text.
+*/
+
+
+#include "config.h"
+
+// IWYU pragma: begin_exports
+
+#ifdef HAVE_NCURSESW_CURSES_H
+#include <ncursesw/curses.h>
+#elif defined(HAVE_NCURSES_NCURSES_H)
+#include <ncurses/ncurses.h>
+#elif defined(HAVE_NCURSES_CURSES_H)
+#include <ncurses/curses.h>
+#elif defined(HAVE_NCURSES_H)
+#include <ncurses.h>
+#elif defined(HAVE_CURSES_H)
+#include <curses.h>
+#endif
+
+#ifdef HAVE_LIBNCURSESW
+#include <wchar.h>
+#include <wctype.h>
+#endif
+
+// IWYU pragma: end_exports
+
+#endif // HEADER_ProvideCurses

--- a/RichString.c
+++ b/RichString.c
@@ -6,11 +6,13 @@ in the source distribution for its full text.
 */
 
 #include "RichString.h"
-#include "Macros.h"
-#include "XUtils.h"
 
+#include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include "Macros.h"
+#include "XUtils.h"
 
 
 #define charBytes(n) (sizeof(CharType) * (n))

--- a/RichString.h
+++ b/RichString.h
@@ -7,26 +7,10 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
-
 #include "config.h"
-#include <ctype.h>
 
-#include <assert.h>
-#ifdef HAVE_NCURSESW_CURSES_H
-#include <ncursesw/curses.h>
-#elif defined(HAVE_NCURSES_NCURSES_H)
-#include <ncurses/ncurses.h>
-#elif defined(HAVE_NCURSES_CURSES_H)
-#include <ncurses/curses.h>
-#elif defined(HAVE_NCURSES_H)
-#include <ncurses.h>
-#elif defined(HAVE_CURSES_H)
-#include <curses.h>
-#endif
+#include "ProvideCurses.h"
 
-#ifdef HAVE_LIBNCURSESW
-#include <wctype.h>
-#endif
 
 #define RichString_size(this) ((this)->chlen)
 #define RichString_sizeVal(this) ((this).chlen)

--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -7,16 +7,17 @@ in the source distribution for its full text.
 
 #include "ScreenManager.h"
 
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <sys/time.h>
+
 #include "CRT.h"
-#include "MainPanel.h"
+#include "FunctionBar.h"
 #include "Object.h"
 #include "ProcessList.h"
-
-
-#include <assert.h>
-#include <time.h>
-#include <stdlib.h>
-#include <stdbool.h>
+#include "ProvideCurses.h"
+#include "XUtils.h"
 
 
 ScreenManager* ScreenManager_new(int x1, int y1, int x2, int y2, Orientation orientation, Header* header, const Settings* settings, const State* state, bool owner) {

--- a/ScreenManager.h
+++ b/ScreenManager.h
@@ -7,11 +7,14 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include <stdbool.h>
+
 #include "Action.h"
 #include "Header.h"
 #include "Panel.h"
 #include "Settings.h"
 #include "Vector.h"
+
 
 typedef enum Orientation_ {
    VERTICAL,

--- a/Settings.c
+++ b/Settings.c
@@ -7,15 +7,17 @@ in the source distribution for its full text.
 
 #include "Settings.h"
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
 #include "CRT.h"
+#include "Macros.h"
+#include "Meter.h"
 #include "Platform.h"
-#include "Vector.h"
 #include "XUtils.h"
 
-#include <sys/stat.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
 
 void Settings_delete(Settings* this) {
    free(this->filename);

--- a/Settings.h
+++ b/Settings.h
@@ -7,11 +7,14 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
-#define DEFAULT_DELAY 15
+#include "config.h" // IWYU pragma: keep
 
 #include <stdbool.h>
 
 #include "Process.h"
+
+
+#define DEFAULT_DELAY 15
 
 typedef struct {
    int len;

--- a/SignalsPanel.c
+++ b/SignalsPanel.c
@@ -5,17 +5,16 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
-#include "Panel.h"
 #include "SignalsPanel.h"
 
-#include <assert.h>
-#include <ctype.h>
 #include <signal.h>
-#include <stdlib.h>
+#include <stdbool.h>
 
+#include "FunctionBar.h"
 #include "ListItem.h"
+#include "Object.h"
+#include "Panel.h"
 #include "Platform.h"
-#include "RichString.h"
 #include "XUtils.h"
 
 

--- a/SignalsPanel.h
+++ b/SignalsPanel.h
@@ -7,6 +7,8 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "Panel.h"
+
 typedef struct SignalItem_ {
    const char* name;
    int number;

--- a/SwapMeter.c
+++ b/SwapMeter.c
@@ -8,13 +8,9 @@ in the source distribution for its full text.
 #include "SwapMeter.h"
 
 #include "CRT.h"
+#include "Object.h"
 #include "Platform.h"
-
-#include <stdlib.h>
-#include <string.h>
-#include <math.h>
-#include <sys/param.h>
-#include <assert.h>
+#include "RichString.h"
 
 
 static const int SwapMeter_attributes[] = {

--- a/TasksMeter.c
+++ b/TasksMeter.c
@@ -8,7 +8,11 @@ in the source distribution for its full text.
 #include "TasksMeter.h"
 
 #include "CRT.h"
-#include "Platform.h"
+#include "Macros.h"
+#include "Object.h"
+#include "ProcessList.h"
+#include "RichString.h"
+#include "Settings.h"
 #include "XUtils.h"
 
 

--- a/TraceScreen.c
+++ b/TraceScreen.c
@@ -5,26 +5,28 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "config.h" // IWYU pragma: keep
+
 #include "TraceScreen.h"
 
-#include "CRT.h"
-#include "ProcessList.h"
-#include "ListItem.h"
-#include "IncSet.h"
-#include "FunctionBar.h"
-#include "XUtils.h"
-
-#include <stdio.h>
-#include <unistd.h>
-#include <string.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <unistd.h>
+#include <assert.h>
 #include <fcntl.h>
-#include <sys/time.h>
-#include <sys/types.h>
-#include <sys/wait.h>
 #include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/select.h>
+#include <sys/time.h>
+#include <sys/wait.h>
+
+#include "CRT.h"
+#include "FunctionBar.h"
+#include "IncSet.h"
+#include "Panel.h"
+#include "ProvideCurses.h"
+#include "XUtils.h"
 
 
 static const char* const TraceScreenFunctions[] = {"Search ", "Filter ", "AutoScroll ", "Stop Tracing   ", "Done   ", NULL};

--- a/TraceScreen.h
+++ b/TraceScreen.h
@@ -12,6 +12,8 @@ in the source distribution for its full text.
 #include <sys/types.h>
 
 #include "InfoScreen.h"
+#include "Object.h"
+#include "Process.h"
 
 
 typedef struct TraceScreen_ {

--- a/UptimeMeter.c
+++ b/UptimeMeter.c
@@ -8,6 +8,7 @@ in the source distribution for its full text.
 #include "UptimeMeter.h"
 
 #include "CRT.h"
+#include "Object.h"
 #include "Platform.h"
 #include "XUtils.h"
 

--- a/UsersTable.c
+++ b/UsersTable.c
@@ -5,17 +5,12 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
-#include "config.h"
-
 #include "UsersTable.h"
 
-#include <stdio.h>
-#include <string.h>
-#include <strings.h>
 #include <pwd.h>
-#include <sys/types.h>
+#include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
 
 #include "XUtils.h"
 

--- a/Vector.c
+++ b/Vector.c
@@ -10,7 +10,8 @@ in the source distribution for its full text.
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdbool.h>
+
+#include "XUtils.h"
 
 
 Vector* Vector_new(const ObjectClass* type, bool owner, int size) {

--- a/Vector.h
+++ b/Vector.h
@@ -9,6 +9,8 @@ in the source distribution for its full text.
 
 #include "Object.h"
 
+#include <stdbool.h>
+
 
 #ifndef DEFAULT_SIZE
 #define DEFAULT_SIZE (-1)

--- a/XUtils.c
+++ b/XUtils.c
@@ -5,14 +5,13 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
-#include "config.h"
+#include "config.h" // IWYU pragma: keep
 
 #include "XUtils.h"
 
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <unistd.h>
 
 #include "CRT.h"

--- a/XUtils.h
+++ b/XUtils.h
@@ -7,10 +7,11 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
-#include <assert.h>
-#include <err.h>
+#include "config.h" // IWYU pragma: keep
+
 #include <stdio.h>
-#include <stdlib.h>
+#include <stdlib.h> // IWYU pragma: keep
+#include <string.h> // IWYU pragma: keep
 
 #include "Macros.h"
 

--- a/freebsd/FreeBSDProcess.h
+++ b/freebsd/FreeBSDProcess.h
@@ -7,6 +7,14 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include <stdbool.h>
+
+#include "Object.h"
+#include "Process.h"
+#include "RichString.h"
+#include "Settings.h"
+
+
 typedef enum FreeBSDProcessFields_ {
    // Add platform-specific fields here, with ids >= 100
    JID   = 100,

--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -5,24 +5,27 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
-#include "Macros.h"
-#include "ProcessList.h"
 #include "FreeBSDProcessList.h"
-#include "FreeBSDProcess.h"
-#include "zfs/ZfsArcStats.h"
-#include "zfs/openzfs_sysctl.h"
-#include "Macros.h"
 
-#include <unistd.h>
-#include <stdlib.h>
-#include <sys/types.h>
-#include <sys/sysctl.h>
-#include <sys/user.h>
+#include <assert.h>
 #include <err.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <sys/user.h>
+
+#include "FreeBSDProcess.h"
+#include "Macros.h"
+#include "ProcessList.h"
+#include "zfs/ZfsArcStats.h"
+#include "zfs/openzfs_sysctl.h"
+#include "XUtils.h"
+
 
 char jail_errmsg[JAIL_ERRMSGLEN];
 

--- a/freebsd/FreeBSDProcessList.h
+++ b/freebsd/FreeBSDProcessList.h
@@ -7,13 +7,19 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
-#include "zfs/ZfsArcStats.h"
-
 #include <kvm.h>
 #include <sys/param.h>
 #include <sys/jail.h>
 #include <sys/uio.h>
 #include <sys/resource.h>
+
+#include "FreeBSDProcess.h"
+#include "Hashtable.h"
+#include "Process.h"
+#include "ProcessList.h"
+#include "UsersTable.h"
+#include "zfs/ZfsArcStats.h"
+
 
 #define JAIL_ERRMSGLEN	1024
 extern char jail_errmsg[JAIL_ERRMSGLEN];

--- a/htop.c
+++ b/htop.c
@@ -5,28 +5,36 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
-#include "config.h"
+#include "config.h" // IWYU pragma: keep
 
-#include "FunctionBar.h"
-#include "Hashtable.h"
-#include "ColumnsPanel.h"
-#include "CRT.h"
-#include "MainPanel.h"
-#include "MetersPanel.h"
-#include "ProcessList.h"
-#include "ScreenManager.h"
-#include "Settings.h"
-#include "UsersTable.h"
-#include "Platform.h"
-#include "XUtils.h"
-
+#include <assert.h>
 #include <getopt.h>
 #include <locale.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+
+#include "Action.h"
+#include "ColumnsPanel.h"
+#include "CRT.h"
+#include "Hashtable.h"
+#include "Header.h"
+#include "IncSet.h"
+#include "MainPanel.h"
+#include "MetersPanel.h"
+#include "Panel.h"
+#include "Platform.h"
+#include "Process.h"
+#include "ProcessList.h"
+#include "ProvideCurses.h"
+#include "ScreenManager.h"
+#include "Settings.h"
+#include "UsersTable.h"
+#include "XUtils.h"
+
 
 //#link m
 

--- a/iwyu/htop.imp
+++ b/iwyu/htop.imp
@@ -1,0 +1,10 @@
+[
+    { include: ["<curses.h>", "private", "\"ProvideCurses.h\"", "public"] },
+    { include: ["<ncurses.h>", "private", "\"ProvideCurses.h\"", "public"] },
+    { include: ["<ncurses/curses.h>", "private", "\"ProvideCurses.h\"", "public"] },
+    { include: ["<ncurses/ncurses.h>", "private", "\"ProvideCurses.h\"", "public"] },
+
+    { include: ["<bits/types/struct_tm.h>", "private", "<time.h>", "public"] },
+
+    { include: ["<bits/getopt_core.h>", "private", "<unistd.h>", "public"] },
+]

--- a/iwyu/run_iwyu.sh
+++ b/iwyu/run_iwyu.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+SCRIPT=$(readlink -f "$0")
+SCRIPTDIR=$(dirname "$SCRIPT")
+SOURCEDIR="$SCRIPTDIR/.."
+
+PKG_NL3=$(pkg-config --cflags libnl-3.0)
+
+cd "$SOURCEDIR"
+
+make clean
+make -k CC="iwyu" CFLAGS="-Xiwyu --no_comments -Xiwyu --no_fwd_decl -Xiwyu --mapping_file='$SCRIPTDIR/htop.imp' $PKG_NL3"

--- a/linux/Battery.c
+++ b/linux/Battery.c
@@ -13,13 +13,17 @@ Linux battery readings written by Ian P. Hands (iphands@gmail.com, ihands@redhat
 
 #include <dirent.h>
 #include <errno.h>
-#include <unistd.h>
+#include <fcntl.h>
+#include <math.h>
+#include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <fcntl.h>
 #include <time.h>
-#include <math.h>
+#include <unistd.h>
 
+#include "BatteryMeter.h"
+#include "Macros.h"
 #include "XUtils.h"
 
 

--- a/linux/Battery.h
+++ b/linux/Battery.h
@@ -11,6 +11,7 @@ Linux battery readings written by Ian P. Hands (iphands@gmail.com, ihands@redhat
 
 #include "BatteryMeter.h"
 
+
 void Battery_getData(double* level, ACPresence* isOnAC);
 
 #endif

--- a/linux/IOPriorityPanel.c
+++ b/linux/IOPriorityPanel.c
@@ -7,6 +7,12 @@ in the source distribution for its full text.
 
 #include "IOPriorityPanel.h"
 
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "FunctionBar.h"
+#include "ListItem.h"
+#include "Object.h"
 #include "XUtils.h"
 
 

--- a/linux/IOPriorityPanel.h
+++ b/linux/IOPriorityPanel.h
@@ -9,7 +9,6 @@ in the source distribution for its full text.
 
 #include "Panel.h"
 #include "IOPriority.h"
-#include "ListItem.h"
 
 Panel* IOPriorityPanel_new(IOPriority currPrio);
 

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -6,19 +6,19 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
-#include "Process.h"
-#include "ProcessList.h"
 #include "LinuxProcess.h"
-#include "CRT.h"
-#include "Platform.h"
-#include "XUtils.h"
 
-#include <stdlib.h>
-#include <unistd.h>
-#include <string.h>
-#include <sys/syscall.h>
-#include <time.h>
 #include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <syscall.h>
+#include <unistd.h>
+
+#include "CRT.h"
+#include "Process.h"
+#include "ProvideCurses.h"
+#include "XUtils.h"
 
 
 /* semi-global */

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -8,6 +8,17 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "config.h"
+
+#include <stdbool.h>
+#include <sys/types.h>
+
+#include "IOPriority.h"
+#include "Object.h"
+#include "Process.h"
+#include "RichString.h"
+#include "Settings.h"
+
 #define PROCESS_FLAG_LINUX_IOPRIO   0x0100
 #define PROCESS_FLAG_LINUX_OPENVZ   0x0200
 #define PROCESS_FLAG_LINUX_VSERVER  0x0400
@@ -86,8 +97,6 @@ typedef enum LinuxProcessFields {
    SECATTR = 123,
    LAST_PROCESSFIELD = 124,
 } LinuxProcessField;
-
-#include "IOPriority.h"
 
 typedef struct LinuxProcess_ {
    Process super;

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -5,43 +5,51 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "config.h" // IWYU pragma: keep
+
 #include "LinuxProcessList.h"
-#include "LinuxProcess.h"
+
+#include <assert.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <math.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+
+#ifdef HAVE_DELAYACCT
+#include <linux/netlink.h>
+#include <linux/taskstats.h>
+#include <netlink/attr.h>
+#include <netlink/handlers.h>
+#include <netlink/msg.h>
+#include <netlink/netlink.h>
+#include <netlink/socket.h>
+#include <netlink/genl/genl.h>
+#include <netlink/genl/ctrl.h>
+#endif
+
 #include "CRT.h"
+#include "LinuxProcess.h"
+#include "Macros.h"
+#include "Object.h"
+#include "Process.h"
+#include "Settings.h"
 #include "XUtils.h"
 
-#include <errno.h>
-#include <sys/time.h>
-#include <sys/utsname.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <dirent.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <signal.h>
-#include <stdbool.h>
-#include <stdarg.h>
-#include <math.h>
-#include <string.h>
-#include <time.h>
-#include <assert.h>
-#include <sys/types.h>
-#include <fcntl.h>
 #ifdef MAJOR_IN_MKDEV
 #include <sys/mkdev.h>
 #elif defined(MAJOR_IN_SYSMACROS)
 #include <sys/sysmacros.h>
 #endif
 
-#ifdef HAVE_DELAYACCT
-#include <netlink/attr.h>
-#include <netlink/netlink.h>
-#include <netlink/genl/genl.h>
-#include <netlink/genl/ctrl.h>
-#include <netlink/socket.h>
-#include <netlink/msg.h>
-#include <linux/taskstats.h>
-#endif
 
 static ssize_t xread(int fd, void *buf, size_t count) {
   // Read some bytes. Retry on EINTR and when we don't get as many bytes as we requested.

--- a/linux/LinuxProcessList.h
+++ b/linux/LinuxProcessList.h
@@ -7,7 +7,14 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "config.h"
+
+#include <stdbool.h>
+#include <sys/types.h>
+
+#include "Hashtable.h"
 #include "ProcessList.h"
+#include "UsersTable.h"
 #include "zfs/ZfsArcStats.h"
 
 typedef struct CPUData_ {

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -5,39 +5,48 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "config.h"
+
 #include "Platform.h"
+
+#include <assert.h>
+#include <ctype.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "BatteryMeter.h"
+#include "ClockMeter.h"
+#include "CPUMeter.h"
+#include "DateMeter.h"
+#include "DateTimeMeter.h"
+#include "DiskIOMeter.h"
+#include "HostnameMeter.h"
 #include "IOPriority.h"
 #include "IOPriorityPanel.h"
 #include "LinuxProcess.h"
 #include "LinuxProcessList.h"
-#include "Battery.h"
-
+#include "LoadAverageMeter.h"
+#include "Macros.h"
+#include "MainPanel.h"
 #include "Meter.h"
-#include "CPUMeter.h"
-#include "DiskIOMeter.h"
 #include "MemoryMeter.h"
+#include "NetworkIOMeter.h"
+#include "Object.h"
+#include "Panel.h"
+#include "PressureStallMeter.h"
+#include "ProcessList.h"
+#include "ProvideCurses.h"
+#include "SELinuxMeter.h"
+#include "Settings.h"
 #include "SwapMeter.h"
 #include "TasksMeter.h"
-#include "LoadAverageMeter.h"
 #include "UptimeMeter.h"
-#include "PressureStallMeter.h"
-#include "ClockMeter.h"
-#include "DateMeter.h"
-#include "DateTimeMeter.h"
-#include "HostnameMeter.h"
-#include "NetworkIOMeter.h"
-#include "zfs/ZfsArcMeter.h"
-#include "zfs/ZfsCompressedArcMeter.h"
-#include "LinuxProcess.h"
-#include "SELinuxMeter.h"
 #include "XUtils.h"
 
-#include <math.h>
-#include <assert.h>
-#include <limits.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include "zfs/ZfsArcMeter.h"
+#include "zfs/ZfsArcStats.h"
+#include "zfs/ZfsCompressedArcMeter.h"
 
 
 ProcessField Platform_defaultFields[] = { PID, USER, PRIORITY, NICE, M_SIZE, M_RESIDENT, (int)M_SHARE, STATE, PERCENT_CPU, PERCENT_MEM, TIME, COMM, 0 };

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -7,10 +7,12 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include <stdbool.h>
+#include <sys/types.h>
+
 #include "Action.h"
-#include "MainPanel.h"
-#include "BatteryMeter.h"
-#include "LinuxProcess.h"
+#include "Meter.h"
+#include "Process.h"
 #include "SignalsPanel.h"
 
 extern ProcessField Platform_defaultFields[];

--- a/linux/PressureStallMeter.c
+++ b/linux/PressureStallMeter.c
@@ -8,10 +8,14 @@ in the source distribution for its full text.
 
 #include "PressureStallMeter.h"
 
+#include <stdbool.h>
 #include <string.h>
 
 #include "CRT.h"
+#include "Meter.h"
+#include "Object.h"
 #include "Platform.h"
+#include "RichString.h"
 #include "XUtils.h"
 
 

--- a/linux/SELinuxMeter.c
+++ b/linux/SELinuxMeter.c
@@ -10,12 +10,16 @@ in the source distribution for its full text.
 #include "CRT.h"
 
 #include <fcntl.h>
-#include <linux/magic.h>
-#include <sys/stat.h>
-#include <sys/statvfs.h>
-#include <sys/types.h>
-#include <sys/vfs.h>
+#include <stdbool.h>
+#include <stdio.h>
 #include <unistd.h>
+#include <linux/magic.h>
+#include <sys/statfs.h>
+#include <sys/statvfs.h>
+
+#include "Macros.h"
+#include "Object.h"
+#include "XUtils.h"
 
 
 static const int SELinuxMeter_attributes[] = {

--- a/zfs/ZfsArcMeter.c
+++ b/zfs/ZfsArcMeter.c
@@ -9,19 +9,10 @@ in the source distribution for its full text.
 #include "ZfsArcStats.h"
 
 #include "CRT.h"
+#include "Object.h"
 #include "Platform.h"
+#include "RichString.h"
 
-#include <stdlib.h>
-#include <string.h>
-#include <math.h>
-#include <sys/param.h>
-#include <assert.h>
-
-/*{
-#include "ZfsArcStats.h"
-
-#include "Meter.h"
-}*/
 
 static const int ZfsArcMeter_attributes[] = {
    ZFS_MFU, ZFS_MRU, ZFS_ANON, ZFS_HEADER, ZFS_OTHER

--- a/zfs/ZfsCompressedArcMeter.c
+++ b/zfs/ZfsCompressedArcMeter.c
@@ -6,23 +6,16 @@ in the source distribution for its full text.
 */
 
 #include "ZfsCompressedArcMeter.h"
-#include "ZfsArcStats.h"
 
 #include "CRT.h"
+#include "Meter.h"
+#include "Object.h"
 #include "Platform.h"
+#include "RichString.h"
 #include "XUtils.h"
 
-#include <stdlib.h>
-#include <string.h>
-#include <math.h>
-#include <sys/param.h>
-#include <assert.h>
+#include "zfs/ZfsArcStats.h"
 
-/*{
-#include "ZfsArcStats.h"
-
-#include "Meter.h"
-}*/
 
 static const int ZfsCompressedArcMeter_attributes[] = {
    ZFS_COMPRESSED


### PR DESCRIPTION
This updates all source files to mention exactly those includes required for compiling.

Tested with IWYU 0.12 + clang 9. Please report issues with other setups.

NB: IWYU sometimes has issues with finding certain declarations and reports compile issues in these cases. If plain `clang` compiles then this is an issue with IWYU. Such issues can usually be ignored.

FWIW: IWYU sees functions used inside defines as being used where the macro is used, not where the define is declared. This is a good reason to adopt #154 to avoid this issue.

As I'm sure there will be compile issues on some platforms with this as is I'm just drafting this for now.