### PR TITLE
HTOP in a Docker Container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.12
+MAINTAINER Pranav Shikarpur <contact@snpranav.com>
+
+RUN apk --update --no-cache add htop && \
+	rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["htop"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:edge
 MAINTAINER Pranav Shikarpur <contact@snpranav.com>
 
 RUN apk --update --no-cache add htop && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,4 +26,3 @@ For example, to run version 3.0.2
 ```sh
 docker run --rm -it --pid=host snpranav/htop:3.0.2
 ```
-

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,19 @@
+HTOP the Docker Way
+---
+To run HTOP in a docker container,
+
+* Build the docker image
+```sh
+wget https://raw.githubusercontent.com/htop-dev/htop/master/docker/Dockerfile
+docker build -t htop .
+
+# Run the image using
+docker run --rm -it --pid=host htop
+```
+### -OR-
+* Use a pre-built docker image (**easier way**)
+```sh
+docker run --rm -it --pid=host snpranav/htop
+```
+
+This  will pull the docker image from [docker hub](https://hub.docker.com/snpranav/htop) and run htop in a docker container.

--- a/docker/README.md
+++ b/docker/README.md
@@ -15,5 +15,15 @@ docker run --rm -it --pid=host htop
 ```sh
 docker run --rm -it --pid=host snpranav/htop
 ```
-
 This  will pull the docker image from [docker hub](https://hub.docker.com/snpranav/htop) and run htop in a docker container.
+
+**That's it!**
+
+---
+If you would like to use certain version of HTOP on pre-built images, visit the [docker hub](https://hub.docker.com/snpranav/htop) repo and you'll find some tags of different versions of htop.
+
+For example, to run version 3.0.2
+```sh
+docker run --rm -it --pid=host snpranav/htop:3.0.2
+```
+


### PR DESCRIPTION
Created a Dockerfile that creates a docker image (<=3MB) which can run htop.

I've created a README inside the docker folder (along with the Dockerfile) which provides instructions on how to run htop in a docker container.
Containerizing htop makes htop more cross compatible on many operating systems and devices that can run Docker containers.