### PR TITLE
Drop configure options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,11 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: ./configure --enable-werror --enable-openvz --enable-cgroup --enable-vserver --enable-ancient-vserver --enable-taskstats --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors
+      run: ./configure --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-taskstats --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors
     - name: Build
       run: make -k
     - name: Distcheck
-      run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror --enable-openvz --enable-cgroup --enable-vserver --enable-ancient-vserver --enable-taskstats --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors'
+      run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-taskstats --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors'
 
   build-ubuntu-latest-full-featured-clang:
     runs-on: ubuntu-latest
@@ -71,11 +71,11 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: ./configure --enable-werror --enable-openvz --enable-cgroup --enable-vserver --enable-ancient-vserver --enable-taskstats --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors
+      run: ./configure --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-taskstats --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors
     - name: Build
       run: make -k
     - name: Distcheck
-      run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror --enable-openvz --enable-cgroup --enable-vserver --enable-ancient-vserver --enable-taskstats --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors'
+      run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-taskstats --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors'
 
   build-ubuntu-latest-clang-analyzer:
     runs-on: ubuntu-latest
@@ -93,7 +93,7 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: scan-build-11 -analyze-headers --status-bugs ./configure --enable-debug --enable-werror --enable-openvz --enable-cgroup --enable-vserver --enable-ancient-vserver --enable-taskstats --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors
+      run: scan-build-11 -analyze-headers --status-bugs ./configure --enable-debug --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-taskstats --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors
     - name: Build
       run: scan-build-11 -analyze-headers --status-bugs make -j"$(nproc)"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: ./configure --enable-werror --enable-linux-affinity --disable-taskstats --disable-unicode --disable-sensors
+      run: ./configure --enable-werror --enable-linux-affinity --disable-unicode --disable-sensors
     - name: Build
       run: make -k
     - name: Distcheck
-      run: make distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-werror --enable-linux-affinity --disable-taskstats --disable-unicode --disable-sensors"
+      run: make distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-werror --enable-linux-affinity --disable-unicode --disable-sensors"
 
   build-ubuntu-latest-minimal-clang:
     runs-on: ubuntu-latest
@@ -34,11 +34,11 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: ./configure --enable-werror --enable-linux-affinity --disable-taskstats --disable-unicode --disable-sensors
+      run: ./configure --enable-werror --enable-linux-affinity --disable-unicode --disable-sensors
     - name: Build
       run: make -k
     - name: Distcheck
-      run: make distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-werror --enable-linux-affinity --disable-taskstats --disable-unicode --disable-sensors"
+      run: make distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-werror --enable-linux-affinity --disable-unicode --disable-sensors"
 
   build-ubuntu-latest-full-featured-gcc:
     runs-on: ubuntu-latest
@@ -49,11 +49,11 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: ./configure --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-taskstats --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors
+      run: ./configure --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors
     - name: Build
       run: make -k
     - name: Distcheck
-      run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-taskstats --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors'
+      run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors'
 
   build-ubuntu-latest-full-featured-clang:
     runs-on: ubuntu-latest
@@ -71,11 +71,11 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: ./configure --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-taskstats --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors
+      run: ./configure --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors
     - name: Build
       run: make -k
     - name: Distcheck
-      run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-taskstats --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors'
+      run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors'
 
   build-ubuntu-latest-clang-analyzer:
     runs-on: ubuntu-latest
@@ -93,7 +93,7 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: scan-build-11 -analyze-headers --status-bugs ./configure --enable-debug --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-taskstats --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors
+      run: scan-build-11 -analyze-headers --status-bugs ./configure --enable-debug --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors
     - name: Build
       run: scan-build-11 -analyze-headers --status-bugs make -j"$(nproc)"
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -280,7 +280,7 @@ coverage:
 	$(MAKE) all AM_CPPFLAGS="-fprofile-arcs -ftest-coverage -DDEBUG" AM_LDFLAGS="-lgcov"
 
 cppcheck:
-	cppcheck -q -v . --enable=all -DHAVE_OPENVZ -DHAVE_TASKSTATS
+	cppcheck -q -v . --enable=all -DHAVE_OPENVZ
 
 dist-hook: $(top_distdir)/configure
 	@if grep 'pkg_m4_absent' '$(top_distdir)/configure'; then \

--- a/Makefile.am
+++ b/Makefile.am
@@ -280,7 +280,7 @@ coverage:
 	$(MAKE) all AM_CPPFLAGS="-fprofile-arcs -ftest-coverage -DDEBUG" AM_LDFLAGS="-lgcov"
 
 cppcheck:
-	cppcheck -q -v . --enable=all -DHAVE_CGROUP -DHAVE_OPENVZ -DHAVE_TASKSTATS
+	cppcheck -q -v . --enable=all -DHAVE_OPENVZ -DHAVE_TASKSTATS
 
 dist-hook: $(top_distdir)/configure
 	@if grep 'pkg_m4_absent' '$(top_distdir)/configure'; then \

--- a/configure.ac
+++ b/configure.ac
@@ -134,11 +134,6 @@ if test "x$enable_ancient_vserver" = xyes; then
     AC_DEFINE(HAVE_ANCIENT_VSERVER, 1, [Define if ancient vserver support enabled.])
 fi
 
-AC_ARG_ENABLE(taskstats, [AS_HELP_STRING([--enable-taskstats], [enable per-task IO Stats (taskstats kernel sup required)])], ,enable_taskstats="yes")
-if test "x$enable_taskstats" = xyes; then
-    AC_DEFINE(HAVE_TASKSTATS, 1, [Define if taskstats support enabled.])
-fi
-
 # HTOP_CHECK_SCRIPT(LIBNAME, FUNCTION, DEFINE, CONFIG_SCRIPT, ELSE_PART)
 m4_define([HTOP_CHECK_SCRIPT],
 [
@@ -387,7 +382,6 @@ AC_MSG_RESULT([
   (Linux) openvz:            $enable_openvz
   (Linux) vserver:           $enable_vserver
   (Linux) ancient vserver:   $enable_ancient_vserver
-  (Linux) taskstats:         $enable_taskstats
   (Linux) affinity:          $enable_linux_affinity
   (Linux) delay accounting:  $enable_delayacct
   (Linux) sensors:           $enable_sensors

--- a/configure.ac
+++ b/configure.ac
@@ -123,11 +123,6 @@ if test "x$enable_openvz" = xyes; then
    AC_DEFINE(HAVE_OPENVZ, 1, [Define if openvz support enabled.])
 fi
 
-AC_ARG_ENABLE(cgroup, [AS_HELP_STRING([--enable-cgroup], [enable cgroups support])], ,enable_cgroup="no")
-if test "x$enable_cgroup" = xyes; then
-   AC_DEFINE(HAVE_CGROUP, 1, [Define if cgroup support enabled.])
-fi
-
 AC_ARG_ENABLE(vserver, [AS_HELP_STRING([--enable-vserver], [enable VServer support])], ,enable_vserver="no")
 if test "x$enable_vserver" = xyes; then
     AC_DEFINE(HAVE_VSERVER, 1, [Define if vserver support enabled.])
@@ -390,7 +385,6 @@ AC_MSG_RESULT([
   platform:                  $my_htop_platform
   (Linux) proc directory:    $PROCDIR
   (Linux) openvz:            $enable_openvz
-  (Linux) cgroup:            $enable_cgroup
   (Linux) vserver:           $enable_vserver
   (Linux) ancient vserver:   $enable_ancient_vserver
   (Linux) taskstats:         $enable_taskstats

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -102,9 +102,7 @@ ProcessFieldData Process_fields[] = {
    [IO_WRITE_RATE] = { .name = "IO_WRITE_RATE", .title = " DISK WRITE ", .description = "The I/O rate of write(2) in bytes per second for the process", .flags = PROCESS_FLAG_IO, },
    [IO_RATE] = { .name = "IO_RATE", .title = "   DISK R/W ", .description = "Total I/O rate in bytes per second", .flags = PROCESS_FLAG_IO, },
 #endif
-#ifdef HAVE_CGROUP
    [CGROUP] = { .name = "CGROUP", .title = "    CGROUP ", .description = "Which cgroup the process is in", .flags = PROCESS_FLAG_LINUX_CGROUP, },
-#endif
    [OOM] = { .name = "OOM", .title = " OOM ", .description = "OOM (Out-of-Memory) killer score", .flags = PROCESS_FLAG_LINUX_OOM, },
    [IO_PRIORITY] = { .name = "IO_PRIORITY", .title = "IO ", .description = "I/O priority", .flags = PROCESS_FLAG_LINUX_IOPRIO, },
 #ifdef HAVE_DELAYACCT
@@ -156,9 +154,7 @@ Process* LinuxProcess_new(const Settings* settings) {
 void Process_delete(Object* cast) {
    LinuxProcess* this = (LinuxProcess*) cast;
    Process_done((Process*)cast);
-#ifdef HAVE_CGROUP
    free(this->cgroup);
-#endif
 #ifdef HAVE_OPENVZ
    free(this->ctid);
 #endif
@@ -680,9 +676,7 @@ static void LinuxProcess_writeField(const Process* this, RichString* str, Proces
    #ifdef HAVE_VSERVER
    case VXID: xSnprintf(buffer, n, "%5u ", lp->vxid); break;
    #endif
-   #ifdef HAVE_CGROUP
    case CGROUP: xSnprintf(buffer, n, "%-10s ", lp->cgroup ? lp->cgroup : ""); break;
-   #endif
    case OOM: xSnprintf(buffer, n, "%4u ", lp->oom); break;
    case IO_PRIORITY: {
       int klass = IOPriority_class(lp->ioPriority);
@@ -821,10 +815,8 @@ static long LinuxProcess_compare(const void* v1, const void* v2) {
    case VXID:
       return SPACESHIP_NUMBER(p2->vxid, p1->vxid);
    #endif
-   #ifdef HAVE_CGROUP
    case CGROUP:
       return SPACESHIP_NULLSTR(p1->cgroup, p2->cgroup);
-   #endif
    case OOM:
       return SPACESHIP_NUMBER(p2->oom, p1->oom);
    #ifdef HAVE_DELAYACCT

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -90,7 +90,6 @@ ProcessFieldData Process_fields[] = {
 #ifdef HAVE_VSERVER
    [VXID] = { .name = "VXID", .title = " VXID ", .description = "VServer process ID", .flags = PROCESS_FLAG_LINUX_VSERVER, },
 #endif
-#ifdef HAVE_TASKSTATS
    [RCHAR] = { .name = "RCHAR", .title = "    RD_CHAR ", .description = "Number of bytes the process has read", .flags = PROCESS_FLAG_IO, },
    [WCHAR] = { .name = "WCHAR", .title = "    WR_CHAR ", .description = "Number of bytes the process has written", .flags = PROCESS_FLAG_IO, },
    [SYSCR] = { .name = "SYSCR", .title = "    RD_SYSC ", .description = "Number of read(2) syscalls for the process", .flags = PROCESS_FLAG_IO, },
@@ -101,7 +100,6 @@ ProcessFieldData Process_fields[] = {
    [IO_READ_RATE] = { .name = "IO_READ_RATE", .title = "  DISK READ ", .description = "The I/O rate of read(2) in bytes per second for the process", .flags = PROCESS_FLAG_IO, },
    [IO_WRITE_RATE] = { .name = "IO_WRITE_RATE", .title = " DISK WRITE ", .description = "The I/O rate of write(2) in bytes per second for the process", .flags = PROCESS_FLAG_IO, },
    [IO_RATE] = { .name = "IO_RATE", .title = "   DISK R/W ", .description = "Total I/O rate in bytes per second", .flags = PROCESS_FLAG_IO, },
-#endif
    [CGROUP] = { .name = "CGROUP", .title = "    CGROUP ", .description = "Which cgroup the process is in", .flags = PROCESS_FLAG_LINUX_CGROUP, },
    [OOM] = { .name = "OOM", .title = " OOM ", .description = "OOM (Out-of-Memory) killer score", .flags = PROCESS_FLAG_LINUX_OOM, },
    [IO_PRIORITY] = { .name = "IO_PRIORITY", .title = "IO ", .description = "I/O priority", .flags = PROCESS_FLAG_LINUX_IOPRIO, },
@@ -646,7 +644,6 @@ static void LinuxProcess_writeField(const Process* this, RichString* str, Proces
    case STIME: Process_printTime(str, lp->stime); return;
    case CUTIME: Process_printTime(str, lp->cutime); return;
    case CSTIME: Process_printTime(str, lp->cstime); return;
-   #ifdef HAVE_TASKSTATS
    case RCHAR:  Process_colorNumber(str, lp->io_rchar, coloring); return;
    case WCHAR:  Process_colorNumber(str, lp->io_wchar, coloring); return;
    case SYSCR:  Process_colorNumber(str, lp->io_syscr, coloring); return;
@@ -668,7 +665,6 @@ static void LinuxProcess_writeField(const Process* this, RichString* str, Proces
          totalRate = NAN;
       Process_outputRate(str, buffer, n, totalRate, coloring); return;
    }
-   #endif
    #ifdef HAVE_OPENVZ
    case CTID: xSnprintf(buffer, n, "%-8s ", lp->ctid ? lp->ctid : ""); break;
    case VPID: xSnprintf(buffer, n, Process_pidFormat, lp->vpid); break;
@@ -783,7 +779,6 @@ static long LinuxProcess_compare(const void* v1, const void* v2) {
       return SPACESHIP_NUMBER(p2->stime, p1->stime);
    case CSTIME:
       return SPACESHIP_NUMBER(p2->cstime, p1->cstime);
-   #ifdef HAVE_TASKSTATS
    case RCHAR:
       return SPACESHIP_NUMBER(p2->io_rchar, p1->io_rchar);
    case WCHAR:
@@ -804,7 +799,6 @@ static long LinuxProcess_compare(const void* v1, const void* v2) {
       return SPACESHIP_NUMBER(p2->io_rate_write_bps, p1->io_rate_write_bps);
    case IO_RATE:
       return SPACESHIP_NUMBER(p2->io_rate_read_bps + p2->io_rate_write_bps, p1->io_rate_read_bps + p1->io_rate_write_bps);
-   #endif
    #ifdef HAVE_OPENVZ
    case CTID:
       return SPACESHIP_NULLSTR(p1->ctid, p2->ctid);

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -68,7 +68,6 @@ typedef enum LinuxProcessFields {
    #ifdef HAVE_VSERVER
    VXID = 102,
    #endif
-   #ifdef HAVE_TASKSTATS
    RCHAR = 103,
    WCHAR = 104,
    SYSCR = 105,
@@ -79,7 +78,6 @@ typedef enum LinuxProcessFields {
    IO_READ_RATE = 110,
    IO_WRITE_RATE = 111,
    IO_RATE = 112,
-   #endif
    CGROUP = 113,
    OOM = 114,
    IO_PRIORITY = 115,
@@ -148,7 +146,6 @@ typedef struct LinuxProcess_ {
    long m_drs;
    long m_lrs;
    long m_dt;
-   #ifdef HAVE_TASKSTATS
    unsigned long long io_rchar;
    unsigned long long io_wchar;
    unsigned long long io_syscr;
@@ -160,7 +157,6 @@ typedef struct LinuxProcess_ {
    unsigned long long io_rate_write_time;
    double io_rate_read_bps;
    double io_rate_write_bps;
-   #endif
    #ifdef HAVE_OPENVZ
    char* ctid;
    pid_t vpid;

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -80,9 +80,7 @@ typedef enum LinuxProcessFields {
    IO_WRITE_RATE = 111,
    IO_RATE = 112,
    #endif
-   #ifdef HAVE_CGROUP
    CGROUP = 113,
-   #endif
    OOM = 114,
    IO_PRIORITY = 115,
    #ifdef HAVE_DELAYACCT
@@ -170,9 +168,7 @@ typedef struct LinuxProcess_ {
    #ifdef HAVE_VSERVER
    unsigned int vxid;
    #endif
-   #ifdef HAVE_CGROUP
    char* cgroup;
-   #endif
    unsigned int oom;
    char* ttyDevice;
    #ifdef HAVE_DELAYACCT

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -644,8 +644,6 @@ static void LinuxProcessList_readOpenVZData(LinuxProcess* process, const char* d
 
 #endif
 
-#ifdef HAVE_CGROUP
-
 static void LinuxProcessList_readCGroupFile(LinuxProcess* process, const char* dirname, const char* name) {
    char filename[MAX_NAME + 1];
    xSnprintf(filename, MAX_NAME, "%s/%s/cgroup", dirname, name);
@@ -683,8 +681,6 @@ static void LinuxProcessList_readCGroupFile(LinuxProcess* process, const char* d
    free(process->cgroup);
    process->cgroup = xStrdup(output);
 }
-
-#endif
 
 #ifdef HAVE_VSERVER
 
@@ -1294,11 +1290,9 @@ static bool LinuxProcessList_recurseProcTree(LinuxProcessList* this, const char*
       LinuxProcessList_readDelayAcctData(this, lp);
       #endif
 
-      #ifdef HAVE_CGROUP
       if (settings->flags & PROCESS_FLAG_LINUX_CGROUP) {
          LinuxProcessList_readCGroupFile(lp, dirname, name);
       }
-      #endif
 
       if (settings->flags & PROCESS_FLAG_LINUX_OOM) {
          LinuxProcessList_readOomData(lp, dirname, name);

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -410,8 +410,6 @@ static bool LinuxProcessList_statProcessDir(Process* process, const char* dirnam
    return true;
 }
 
-#ifdef HAVE_TASKSTATS
-
 static void LinuxProcessList_readIoFile(LinuxProcess* process, const char* dirname, const char* name, unsigned long long now) {
    char filename[MAX_NAME + 1];
    filename[MAX_NAME] = '\0';
@@ -480,10 +478,6 @@ static void LinuxProcessList_readIoFile(LinuxProcess* process, const char* dirna
       }
    }
 }
-
-#endif
-
-
 
 static bool LinuxProcessList_readStatmFile(LinuxProcess* process, const char* dirname, const char* name) {
    char filename[MAX_NAME + 1];
@@ -1130,14 +1124,11 @@ static bool LinuxProcessList_recurseProcTree(LinuxProcessList* this, const char*
    const struct dirent* entry;
    const Settings* settings = pl->settings;
 
-   #ifdef HAVE_TASKSTATS
-   unsigned long long now = tv.tv_sec * 1000LL + tv.tv_usec / 1000LL;
-   #endif
-
    dir = opendir(dirname);
    if (!dir)
       return false;
 
+   unsigned long long now = tv.tv_sec * 1000ULL + tv.tv_usec / 1000ULL;
    int cpus = pl->cpuCount;
    bool hideKernelThreads = settings->hideKernelThreads;
    bool hideUserlandThreads = settings->hideUserlandThreads;
@@ -1200,10 +1191,8 @@ static bool LinuxProcessList_recurseProcTree(LinuxProcessList* this, const char*
          continue;
       }
 
-      #ifdef HAVE_TASKSTATS
       if (settings->flags & PROCESS_FLAG_IO)
          LinuxProcessList_readIoFile(lp, dirname, name, now);
-      #endif
 
       if (! LinuxProcessList_readStatmFile(lp, dirname, name))
          goto errorReadingProcess;


### PR DESCRIPTION
Drop configure options, which have no compile time dependency and are only checked at runtime if specific process columns are selected.

Dropping these reduces the maintenance cost.