### PR TITLE
Avoid unsigned integer overflow

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -329,7 +329,7 @@ static Htop_Reaction actionFilterByUser(State* st) {
    ListItem* picked = (ListItem*) Action_pickFromVector(st, usersPanel, 20, false);
    if (picked) {
       if (picked == allUsers) {
-         st->pl->userId = -1;
+         st->pl->userId = (uid_t)-1;
       } else {
          Action_setUserOnly(ListItem_getRef(picked), &(st->pl->userId));
       }


### PR DESCRIPTION
unsigned integer overflows are well-defined, but they might point to a counting issue.
Having the code free of unsigned overflows makes it easier to spot potential bugs.

    Action.c:332:27: runtime error: implicit conversion from type 'int' of value -1 (32-bit, signed) to type 'uid_t' (aka 'unsigned int') changed the value to 4294967295 (32-bit, unsigned)
    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior Action.c:332:27 in