### PR TITLE
Add DeepCode inline suppression

### DIFF
--- a/htop.c
+++ b/htop.c
@@ -172,6 +172,7 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
 
             while(pid) {
                 unsigned int num_pid = atoi(pid);
+                //  deepcode ignore CastIntegerToAddress: we just want a non-NUll pointer here
                 Hashtable_put(flags.pidMatchList, num_pid, (void *) 1);
                 pid = strtok_r(NULL, ",", &saveptr);
             }


### PR DESCRIPTION
We just want a non-NUll pointer in the matching pid hashtable.
The pointer is not dereferenced anyways.