### PR TITLE
Consider the ZFS ARC as cache on Linux

### DIFF
--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -202,6 +202,8 @@ double Platform_setCPUValues(Meter* this, int cpu) {
 
 void Platform_setMemoryValues(Meter* this) {
    ProcessList* pl = (ProcessList*) this->pl;
+   LinuxProcessList* lpl = (LinuxProcessList*) this->pl;
+
    long int usedMem = pl->usedMem;
    long int buffersMem = pl->buffersMem;
    long int cachedMem = pl->cachedMem;
@@ -210,6 +212,11 @@ void Platform_setMemoryValues(Meter* this) {
    this->values[0] = usedMem;
    this->values[1] = buffersMem;
    this->values[2] = cachedMem;
+
+   if (lpl->zfs.enabled != 0) {
+      this->values[0] -= lpl->zfs.size;
+      this->values[2] += lpl->zfs.size;
+   }
 }
 
 void Platform_setSwapValues(Meter* this) {


### PR DESCRIPTION
This is based on a [patch](https://gist.github.com/edef1c/73cc02efcdad39fbcc15f577dbc1922a) which @edef1c and I wrote against htop 2.x, which I've adapted for htop 3.x to use the existing ZFS support code which was merged in 3.0.

The Linux kernel doesn't report ZFS ARC usage as cache memory, which means that the ARC is included in the total used system memory. This means that tools such as `free(1)` will misreport the total memory consumed, as will htop without this patch. With this commit, if ZFS is detected, then htop will adjust the kernel-reported overall used/cache memory using the ARC size read from procfs.