### PR TITLE
command screen: fill current line when scanning

### DIFF
--- a/CommandScreen.c
+++ b/CommandScreen.c
@@ -12,33 +12,33 @@
 #include <unistd.h>
 
 
-static void CommandScreen_addLine(InfoScreen* this, char* line, const char* p, int line_offset, int len) {
-   memcpy(line, p - line_offset, len);
-   line[len] = '\0';
-   InfoScreen_addLine(this, line);
-}
-
 static void CommandScreen_scan(InfoScreen* this) {
    Panel* panel = this->display;
    int idx = MAXIMUM(Panel_getSelectedIndex(panel), 0);
-
    Panel_prune(panel);
 
    const char* p = this->process->comm;
    char* line = xMalloc(COLS + 1);
    int line_offset = 0, last_spc = -1, len;
    for (; *p != '\0'; p++, line_offset++) {
+      line[line_offset] = *p;
       if (*p == ' ') last_spc = line_offset;
 
       if (line_offset == COLS) {
          len = (last_spc == -1) ? line_offset : last_spc;
-         CommandScreen_addLine(this, line, p, line_offset, len);
+         line[len] = '\0';
+         InfoScreen_addLine(this, line);
+
          line_offset -= len;
          last_spc = -1;
+         memcpy(line, p - line_offset, line_offset + 1);
       }
    }
 
-   if (line_offset > 0) CommandScreen_addLine(this, line, p, line_offset, line_offset);
+   if (line_offset > 0) {
+      line[line_offset] = '\0';
+      InfoScreen_addLine(this, line);
+   }
 
    free(line);
    Panel_setSelected(panel, idx);


### PR DESCRIPTION
After pr #67 got merged, @BenBE proposed the option to fill the current line 
while scanning the command, rather than using a separate `memcpy` afterward.
So I gave it a try and [measured the difference][1].

For short commands there's not much difference, but when a command is relatively 
long, e.g., the longest I could find, of a java process, is about 7k+ 
characters, per my test, in the best case, it's about 30 vs 28 (ms) on average
before and after, So the copy-on-scan approach won with a little margin.


[1]: https://github.com/ryenus/htop/commit/d96a931de437ea027d51af393523b21d4b2bea25
