### PR TITLE
limit max screen title length to window width

### DIFF
--- a/CommandScreen.c
+++ b/CommandScreen.c
@@ -45,14 +45,7 @@ static void CommandScreen_scan(InfoScreen* this) {
 }
 
 static void CommandScreen_draw(InfoScreen* this) {
-   char* title = xMalloc(COLS + 1);
-   int len = snprintf(title, COLS + 1, "Command of process %d - %s", this->process->pid, this->process->comm);
-   if (len > COLS) {
-      memset(&title[COLS - 3], '.', 3);
-   }
-
-   InfoScreen_drawTitled(this, "%s", title);
-   free(title);
+   InfoScreen_drawTitled(this, "Command of process %d - %s", this->process->pid, this->process->comm);
 }
 
 InfoScreenClass CommandScreen_class = {

--- a/InfoScreen.c
+++ b/InfoScreen.c
@@ -42,14 +42,21 @@ InfoScreen* InfoScreen_done(InfoScreen* this) {
 void InfoScreen_drawTitled(InfoScreen* this, const char* fmt, ...) {
    va_list ap;
    va_start(ap, fmt);
+
+   char* title = xMalloc(COLS + 1);
+   int len = vsnprintf(title, COLS + 1, fmt, ap);
+   if (len > COLS) {
+      memset(&title[COLS - 3], '.', 3);
+   }
+
    attrset(CRT_colors[METER_TEXT]);
    mvhline(0, 0, ' ', COLS);
-   (void) wmove(stdscr, 0, 0);
-   vw_printw(stdscr, fmt, ap);
+   mvwprintw(stdscr, 0, 0, title);
    attrset(CRT_colors[DEFAULT_COLOR]);
    this->display->needsRedraw = true;
    Panel_draw(this->display, true);
    IncSet_drawBar(this->inc);
+   free(title);
    va_end(ap);
 }
 


### PR DESCRIPTION
Applies screen title truncating to all InfoScreen classes.

@cgzones Possible to take a look? Thank you!
