### PR TITLE
Handle Panel_getSelected() returning NULL

### DIFF
--- a/AvailableColumnsPanel.c
+++ b/AvailableColumnsPanel.c
@@ -28,7 +28,6 @@ static void AvailableColumnsPanel_delete(Object* object) {
 
 static HandlerResult AvailableColumnsPanel_eventHandler(Panel* super, int ch) {
    AvailableColumnsPanel* this = (AvailableColumnsPanel*) super;
-   int key = ((ListItem*) Panel_getSelected(super))->key;
    HandlerResult result = IGNORED;
 
    switch(ch) {
@@ -36,6 +35,11 @@ static HandlerResult AvailableColumnsPanel_eventHandler(Panel* super, int ch) {
       case KEY_ENTER:
       case KEY_F(5):
       {
+         const ListItem* selected = (ListItem*) Panel_getSelected(super);
+         if (!selected)
+            break;
+
+         int key = selected->key;
          int at = Panel_getSelectedIndex(this->columns);
          Panel_insert(this->columns, at, (Object*) ListItem_new(Process_fields[key].name, key));
          Panel_setSelected(this->columns, at+1);

--- a/AvailableMetersPanel.c
+++ b/AvailableMetersPanel.c
@@ -36,7 +36,10 @@ static HandlerResult AvailableMetersPanel_eventHandler(Panel* super, int ch) {
    AvailableMetersPanel* this = (AvailableMetersPanel*) super;
    Header* header = this->header;
 
-   ListItem* selected = (ListItem*) Panel_getSelected(super);
+   const ListItem* selected = (ListItem*) Panel_getSelected(super);
+   if (!selected)
+      return IGNORED;
+
    int param = selected->key & 0xff;
    int type = selected->key >> 16;
    HandlerResult result = IGNORED;

--- a/ColumnsPanel.c
+++ b/ColumnsPanel.c
@@ -43,7 +43,9 @@ static HandlerResult ColumnsPanel_eventHandler(Panel* super, int ch) {
          if (selected < size - 1) {
             this->moving = !(this->moving);
             Panel_setSelectionColor(super, this->moving ? CRT_colors[PANEL_SELECTION_FOLLOW] : CRT_colors[PANEL_SELECTION_FOCUS]);
-            ((ListItem*)Panel_getSelected(super))->moving = this->moving;
+            ListItem* selectedItem = (ListItem*) Panel_getSelected(super);
+            if (selectedItem)
+               selectedItem->moving = this->moving;
             result = HANDLED;
          }
          break;

--- a/linux/IOPriorityPanel.c
+++ b/linux/IOPriorityPanel.c
@@ -34,5 +34,6 @@ Panel* IOPriorityPanel_new(IOPriority currPrio) {
 }
 
 IOPriority IOPriorityPanel_getIOPriority(Panel* this) {
-   return (IOPriority) ( ((ListItem*) Panel_getSelected(this))->key );
+   const ListItem* selected = (ListItem*) Panel_getSelected(this);
+   return selected ? selected->key : IOPriority_None;
 }


### PR DESCRIPTION
Found by compiling with LTO:

    ColumnsPanel.c: In function ‘ColumnsPanel_eventHandler’:
    ColumnsPanel.c:46:59: error: potential null pointer dereference [-Werror=null-dereference]
       46 |             ((ListItem*)Panel_getSelected(super))->moving = this->moving;
          |                                                           ^
    AvailableColumnsPanel.c: In function ‘AvailableColumnsPanel_eventHandler’:
    AvailableColumnsPanel.c:31:8: error: potential null pointer dereference [-Werror=null-dereference]
       31 |    int key = ((ListItem*) Panel_getSelected(super))->key;
          |        ^
    AvailableMetersPanel.c: In function ‘AvailableMetersPanel_eventHandler’:
    AvailableMetersPanel.c:40:24: error: potential null pointer dereference [-Werror=null-dereference]
       40 |    int param = selected->key & 0xff;
          |                        ^
    linux/IOPriorityPanel.c: In function ‘IOPriorityPanel_getIOPriority’:
    linux/IOPriorityPanel.c:37:11: error: potential null pointer dereference [-Werror=null-dereference]
       37 |    return (IOPriority) ( ((ListItem*) Panel_getSelected(this))->key );
          |           ^