### PR TITLE
New column for LXC containers name using the CGroups

### DIFF
--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -97,6 +97,7 @@ ProcessFieldData Process_fields[] = {
 #endif
 #ifdef HAVE_CGROUP
    [CGROUP] = { .name = "CGROUP", .title = "    CGROUP ", .description = "Which cgroup the process is in", .flags = PROCESS_FLAG_LINUX_CGROUP, },
+   [LXC] = { .name = "LXC", .title = "       LXC ", .description = "Which LXC constainer the process is in", .flags = PROCESS_FLAG_LINUX_CGROUP, },
 #endif
    [OOM] = { .name = "OOM", .title = " OOM ", .description = "OOM (Out-of-Memory) killer score", .flags = PROCESS_FLAG_LINUX_OOM, },
    [IO_PRIORITY] = { .name = "IO_PRIORITY", .title = "IO ", .description = "I/O priority", .flags = PROCESS_FLAG_LINUX_IOPRIO, },
@@ -148,6 +149,7 @@ void Process_delete(Object* cast) {
    Process_done((Process*)cast);
 #ifdef HAVE_CGROUP
    free(this->cgroup);
+   free(this->lxc);
 #endif
    free(this->secattr);
    free(this->ttyDevice);
@@ -261,6 +263,7 @@ void LinuxProcess_writeField(Process* this, RichString* str, ProcessField field)
    #endif
    #ifdef HAVE_CGROUP
    case CGROUP: xSnprintf(buffer, n, "%-10s ", lp->cgroup ? lp->cgroup : ""); break;
+   case LXC:    xSnprintf(buffer, n, "%-10s ", lp->lxc ? lp->lxc : ""); break;
    #endif
    case OOM: xSnprintf(buffer, n, "%4u ", lp->oom); break;
    case IO_PRIORITY: {
@@ -362,6 +365,8 @@ long LinuxProcess_compare(const void* v1, const void* v2) {
    #ifdef HAVE_CGROUP
    case CGROUP:
       return strcmp(p1->cgroup ? p1->cgroup : "", p2->cgroup ? p2->cgroup : "");
+   case LXC:
+      return strcmp(p1->lxc ? p1->lxc : "", p2->lxc ? p2->lxc : "");
    #endif
    case OOM:
       return ((int)p2->oom - (int)p1->oom);

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -84,7 +84,10 @@ typedef enum LinuxProcessFields {
    M_PSSWP = 121,
    CTXT = 122,
    SECATTR = 123,
-   LAST_PROCESSFIELD = 124,
+   #ifdef HAVE_CGROUP
+   LXC = 124,
+   #endif
+   LAST_PROCESSFIELD = 125,
 } LinuxProcessField;
 
 #include "IOPriority.h"
@@ -130,6 +133,7 @@ typedef struct LinuxProcess_ {
    #endif
    #ifdef HAVE_CGROUP
    char* cgroup;
+   char* lxc;
    #endif
    unsigned int oom;
    char* ttyDevice;

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -533,6 +533,33 @@ static void LinuxProcessList_readCGroupFile(LinuxProcess* process, const char* d
       if (!ok) break;
       char* group = strchr(buffer, ':');
       if (!group) break;
+
+      if (!process->lxc) {
+         // Each line have 3 columns separated by a ':', the 3rd column contains the pathname
+         char* groupPathname = strchr(group + 1, ':') + 1;
+         if (groupPathname) {
+            if ( String_startsWith(groupPathname, "/lxc.payload/") || String_startsWith(groupPathname, "/lxc.payload.") ) {
+               // The process is inside a LXC container using CGroup V2 (/lxc.payload.) or a modern CGroup V1 terminology (/lxc.payload/), for a better readability, only the container name is kept
+               char *slashpostion = strchr((groupPathname + 13), '/');
+               if (slashpostion) {
+                  // There is a '/' in the CGroup string (after the initial "/lxc.payload"), a '\0' will truncate the string at this position
+                  groupPathname[(slashpostion - groupPathname)] = '\0';
+               }
+               free(process->lxc);
+               process->lxc = String_trim(groupPathname + 13);
+            } else if (String_startsWith(groupPathname, "/lxc/")) {
+               // The process is inside a LXC container using a legacy CGroup V1 (/lxc/), for a better readability, only the container name is kept
+               char *slashpostion = strchr((groupPathname + 5), '/');
+               if (slashpostion) {
+                  // There is a '/' in the CGroup string (after the initial "/lxc/"), a '\0' will truncate the string at this position
+                  groupPathname[(slashpostion - groupPathname)] = '\0';
+               }
+               free(process->lxc);
+               process->lxc = String_trim(groupPathname + 5);
+            }
+         }
+      }
+
       if (at != output) {
          *at = ';';
          at++;
@@ -542,6 +569,12 @@ static void LinuxProcessList_readCGroupFile(LinuxProcess* process, const char* d
       left -= wrote;
    }
    fclose(file);
+   if (!process->lxc) {
+      // The process is not in a LXC container
+      free(process->lxc);
+      // To show an empty value instead of (null)
+      process->lxc = NULL;
+   }
    free(process->cgroup);
    process->cgroup = xStrdup(output);
 }


### PR DESCRIPTION
Fixed the issues listed on https://github.com/htop-dev/htop/issues/216.

I feel like there should be a `break` to exit the while loop parsing each line of the CGroup file if the LXC container name has been found and if the CGroup column is not used (or at least skip the LXC part if both columns are used and the LXC name has been found).
But it seems that the CGroup files are always parsed even if the CGroup column is not used which is not ideal.