### PR TITLE
Optimize vector

### DIFF
--- a/Vector.c
+++ b/Vector.c
@@ -190,8 +190,8 @@ void Vector_insert(Vector* this, int idx, void* data_) {
 
    Vector_checkArraySize(this);
    //assert(this->array[this->items] == NULL);
-   for (int i = this->items; i > idx; i--) {
-      this->array[i] = this->array[i-1];
+   if(idx < this->items) {
+      memmove(&this->array[idx + 1], &this->array[idx], (this->items - idx) * sizeof(this->array[0]));
    }
    this->array[idx] = data;
    this->items++;

--- a/Vector.c
+++ b/Vector.c
@@ -204,8 +204,9 @@ Object* Vector_take(Vector* this, int idx) {
    Object* removed = this->array[idx];
    //assert (removed != NULL);
    this->items--;
-   for (int i = idx; i < this->items; i++)
-      this->array[i] = this->array[i+1];
+   if(idx < this->items) {
+      memmove(&this->array[idx], &this->array[idx + 1], (this->items - idx) * sizeof(this->array[0]));
+   }
    //this->array[this->items] = NULL;
    assert(Vector_isConsistent(this));
    return removed;


### PR DESCRIPTION
This contains two small patches based on values gathered by using `callgrind`.
The overall effect should be a ~3-4% performance improvement.

This is split out from #220, as the major savings would require rewriting two core functions/core data structures in htop.