### PR TITLE
use 'w' for command wrapping as 'M' is already used

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -423,8 +423,8 @@ static const struct { const char* key; const char* info; } helpRight[] = {
    { .key = "      e: ", .info = "show process environment" },
    { .key = "      i: ", .info = "set IO priority" },
    { .key = "      l: ", .info = "list open files with lsof" },
-   { .key = "      M: ", .info = "show process command in multiple lines" },
    { .key = "      s: ", .info = "trace syscalls with strace" },
+   { .key = "      w: ", .info = "wrap process command in multiple lines" },
    { .key = " F2 C S: ", .info = "setup" },
    { .key = "   F1 h: ", .info = "show this help screen" },
    { .key = "  F10 q: ", .info = "quit" },
@@ -595,5 +595,5 @@ void Action_setBindings(Htop_Action* keys) {
    keys['U'] = actionUntagAll;
    keys['c'] = actionTagAllChildren;
    keys['e'] = actionShowEnvScreen;
-   keys['M'] = actionShowCommandScreen;
+   keys['w'] = actionShowCommandScreen;
 }

--- a/htop.1.in
+++ b/htop.1.in
@@ -119,8 +119,9 @@ update of system calls issued by the process.
 Display open files for a process: if lsof(1) is installed, pressing this key
 will display the list of file descriptors opened by the process.
 .TP
-.B M
-Display the command line of the highlighted process in multiple lines.
+.B w
+Display the command line of the selected process in a separate screen, wrapped
+onto multiple lines as needed.
 .TP
 .B F1, h, ?
 Go to the help screen


### PR DESCRIPTION
...since 'M' is already used for sort-by-memory, as with:

    keys['M'] = actionSortByMemory;

Sorry that when changing the key from `L`, to `m`, then `M` and I forgot `M` is already taken :P
Meanwhile `w` actually makes a lot of sense, since we're wrapping the command into multiple lines.
