### PR TITLE
OpenFilesScreen update

### DIFF
--- a/OpenFilesScreen.h
+++ b/OpenFilesScreen.h
@@ -9,21 +9,6 @@ in the source distribution for its full text.
 
 #include "InfoScreen.h"
 
-typedef struct OpenFiles_Data_ {
-   char* data[256];
-} OpenFiles_Data;
-
-typedef struct OpenFiles_ProcessData_ {
-   OpenFiles_Data data;
-   int error;
-   struct OpenFiles_FileData_* files;
-} OpenFiles_ProcessData;
-
-typedef struct OpenFiles_FileData_ {
-   OpenFiles_Data data;
-   struct OpenFiles_FileData_* next;
-} OpenFiles_FileData;
-
 typedef struct OpenFilesScreen_ {
    InfoScreen super;
    pid_t pid;
@@ -31,12 +16,8 @@ typedef struct OpenFilesScreen_ {
 
 extern const InfoScreenClass OpenFilesScreen_class;
 
-OpenFilesScreen* OpenFilesScreen_new(Process* process);
+OpenFilesScreen* OpenFilesScreen_new(const Process* process);
 
 void OpenFilesScreen_delete(Object* this);
-
-void OpenFilesScreen_draw(InfoScreen* this);
-
-void OpenFilesScreen_scan(InfoScreen* this);
 
 #endif


### PR DESCRIPTION
- Remove local types and function from header file
- Reduce OpenFiles_Data to neccessary size
- Print file access mode (r/w/u)
- Fix memory leak on consecutive items without an intermediate file item:

    ==15257==ERROR: LeakSanitizer: detected memory leaks

    Direct leak of 120 byte(s) in 12 object(s) allocated from:
        #0 0x48c864 in strdup (htop/htop+0x48c864)
        #1 0x542f68 in xStrdup htop/XAlloc.c:71:17
        #2 0x50e225 in OpenFilesScreen_getProcessData htop/OpenFilesScreen.c:112:25
        #3 0x50cd17 in OpenFilesScreen_scan htop/OpenFilesScreen.c:141:35
        #4 0x4fd3eb in InfoScreen_run htop/InfoScreen.c:81:35
        #5 0x4d58bb in actionLsof htop/Action.c:361:4
        #6 0x501766 in MainPanel_eventHandler htop/MainPanel.c:80:19
        #7 0x5289fa in ScreenManager_run htop/ScreenManager.c:227:19
        #8 0x4f748e in main htop/htop.c:300:4
        #9 0x7ff73e0d8cc9 in __libc_start_main csu/../csu/libc-start.c:308:16

    SUMMARY: AddressSanitizer: 120 byte(s) leaked in 12 allocation(s).