### PR TITLE
Continue to update generic data in paused mode

### DIFF
--- a/ProcessList.c
+++ b/ProcessList.c
@@ -281,7 +281,13 @@ Process* ProcessList_getProcess(ProcessList* this, pid_t pid, bool* preExisting,
    return proc;
 }
 
-void ProcessList_scan(ProcessList* this) {
+void ProcessList_scan(ProcessList* this, bool pauseProcessUpdate) {
+
+   // in pause mode only gather global data for meters (CPU/memory/...)
+   if (pauseProcessUpdate) {
+      ProcessList_goThroughEntries(this, true);
+      return;
+   }
 
    // mark all process as "dirty"
    for (int i = 0; i < Vector_size(this->processes); i++) {
@@ -295,7 +301,7 @@ void ProcessList_scan(ProcessList* this) {
    this->kernelThreads = 0;
    this->runningTasks = 0;
 
-   ProcessList_goThroughEntries(this);
+   ProcessList_goThroughEntries(this, false);
 
    for (int i = Vector_size(this->processes) - 1; i >= 0; i--) {
       Process* p = (Process*) Vector_get(this->processes, i);

--- a/ProcessList.h
+++ b/ProcessList.h
@@ -74,7 +74,7 @@ typedef struct ProcessList_ {
 
 ProcessList* ProcessList_new(UsersTable* ut, Hashtable* pidMatchList, uid_t userId);
 void ProcessList_delete(ProcessList* pl);
-void ProcessList_goThroughEntries(ProcessList* pl);
+void ProcessList_goThroughEntries(ProcessList* pl, bool pauseProcessUpdate);
 
 
 ProcessList* ProcessList_init(ProcessList* this, const ObjectClass* klass, UsersTable* usersTable, Hashtable* pidMatchList, uid_t userId);
@@ -103,6 +103,6 @@ void ProcessList_rebuildPanel(ProcessList* this);
 
 Process* ProcessList_getProcess(ProcessList* this, pid_t pid, bool* preExisting, Process_New constructor);
 
-void ProcessList_scan(ProcessList* this);
+void ProcessList_scan(ProcessList* this, bool pauseProcessUpdate);
 
 #endif

--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -105,9 +105,9 @@ static void checkRecalculation(ScreenManager* this, double* oldTime, int* sortTi
    *timedOut = (newTime - *oldTime > this->settings->delay);
    *rescan = *rescan || *timedOut;
    if (newTime < *oldTime) *rescan = true; // clock was adjusted?
-   if (*rescan && !this->state->pauseProcessUpdate) {
+   if (*rescan) {
       *oldTime = newTime;
-      ProcessList_scan(pl);
+      ProcessList_scan(pl, this->state->pauseProcessUpdate);
       if (*sortTimeout == 0 || this->settings->treeView) {
          ProcessList_sort(pl);
          *sortTimeout = 1;

--- a/darwin/DarwinProcessList.c
+++ b/darwin/DarwinProcessList.c
@@ -144,7 +144,7 @@ void ProcessList_delete(ProcessList* this) {
    free(this);
 }
 
-void ProcessList_goThroughEntries(ProcessList* super) {
+void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
     DarwinProcessList *dpl = (DarwinProcessList *)super;
 	bool preExisting = true;
 	struct kinfo_proc *ps;
@@ -157,6 +157,10 @@ void ProcessList_goThroughEntries(ProcessList* super) {
     ProcessList_allocateCPULoadInfo(&dpl->curr_load);
     ProcessList_getVMStats(&dpl->vm_stats);
     openzfs_sysctl_updateArcStats(&dpl->zfs);
+
+    // in pause mode only gather global data for meters (CPU/memory/...)
+    if (pauseProcessUpdate)
+       return;
 
     /* Get the time difference */
     dpl->global_diff = 0;

--- a/darwin/DarwinProcessList.h
+++ b/darwin/DarwinProcessList.h
@@ -51,6 +51,6 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidMatchList, ui
 
 void ProcessList_delete(ProcessList* this);
 
-void ProcessList_goThroughEntries(ProcessList* super);
+void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate);
 
 #endif

--- a/dragonflybsd/DragonFlyBSDProcessList.c
+++ b/dragonflybsd/DragonFlyBSDProcessList.c
@@ -358,7 +358,7 @@ char* DragonFlyBSDProcessList_readJailName(DragonFlyBSDProcessList* dfpl, int ja
    return jname;
 }
 
-void ProcessList_goThroughEntries(ProcessList* this) {
+void ProcessList_goThroughEntries(ProcessList* this, bool pauseProcessUpdate) {
    DragonFlyBSDProcessList* dfpl = (DragonFlyBSDProcessList*) this;
    Settings* settings = this->settings;
    bool hideKernelThreads = settings->hideKernelThreads;
@@ -367,6 +367,10 @@ void ProcessList_goThroughEntries(ProcessList* this) {
    DragonFlyBSDProcessList_scanMemoryInfo(this);
    DragonFlyBSDProcessList_scanCPUTime(this);
    DragonFlyBSDProcessList_scanJails(dfpl);
+
+   // in pause mode only gather global data for meters (CPU/memory/...)
+   if (pauseProcessUpdate)
+      return;
 
    int count = 0;
 

--- a/dragonflybsd/DragonFlyBSDProcessList.h
+++ b/dragonflybsd/DragonFlyBSDProcessList.h
@@ -59,6 +59,6 @@ char* DragonFlyBSDProcessList_readProcessName(kvm_t* kd, struct kinfo_proc* kpro
 
 char* DragonFlyBSDProcessList_readJailName(DragonFlyBSDProcessList* dfpl, int jailid);
 
-void ProcessList_goThroughEntries(ProcessList* this);
+void ProcessList_goThroughEntries(ProcessList* this, pauseProcessUpdate);
 
 #endif

--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -379,7 +379,7 @@ IGNORE_WCASTQUAL_END
    return jname;
 }
 
-void ProcessList_goThroughEntries(ProcessList* this) {
+void ProcessList_goThroughEntries(ProcessList* this, bool pauseProcessUpdate) {
    FreeBSDProcessList* fpl = (FreeBSDProcessList*) this;
    Settings* settings = this->settings;
    bool hideKernelThreads = settings->hideKernelThreads;
@@ -388,6 +388,10 @@ void ProcessList_goThroughEntries(ProcessList* this) {
    openzfs_sysctl_updateArcStats(&fpl->zfs);
    FreeBSDProcessList_scanMemoryInfo(this);
    FreeBSDProcessList_scanCPUTime(this);
+
+   // in pause mode only gather global data for meters (CPU/memory/...)
+   if (pauseProcessUpdate)
+      return;
 
    int count = 0;
    struct kinfo_proc* kprocs = kvm_getprocs(fpl->kd, KERN_PROC_PROC, 0, &count);

--- a/freebsd/FreeBSDProcessList.h
+++ b/freebsd/FreeBSDProcessList.h
@@ -62,6 +62,6 @@ char* FreeBSDProcessList_readProcessName(kvm_t* kd, struct kinfo_proc* kproc, in
 
 char* FreeBSDProcessList_readJailName(struct kinfo_proc* kproc);
 
-void ProcessList_goThroughEntries(ProcessList* this);
+void ProcessList_goThroughEntries(ProcessList* this, bool pauseProcessUpdate);
 
 #endif

--- a/htop.c
+++ b/htop.c
@@ -303,9 +303,9 @@ int main(int argc, char** argv) {
    ScreenManager* scr = ScreenManager_new(0, header->height, 0, -1, HORIZONTAL, header, settings, &state, true);
    ScreenManager_add(scr, (Panel*) panel, -1);
 
-   ProcessList_scan(pl);
+   ProcessList_scan(pl, false);
    millisleep(75);
-   ProcessList_scan(pl);
+   ProcessList_scan(pl, false);
 
    ScreenManager_run(scr, NULL, NULL);
 

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -1382,7 +1382,7 @@ static void LinuxProcessList_scanCPUFrequency(LinuxProcessList* this) {
    scanCPUFreqencyFromCPUinfo(this);
 }
 
-void ProcessList_goThroughEntries(ProcessList* super) {
+void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
    LinuxProcessList* this = (LinuxProcessList*) super;
    const Settings* settings = super->settings;
 
@@ -1395,6 +1395,10 @@ void ProcessList_goThroughEntries(ProcessList* super) {
 
    if (settings->showCPUFrequency)
       LinuxProcessList_scanCPUFrequency(this);
+
+   // in pause mode only gather global data for meters (CPU/memory/...)
+   if (pauseProcessUpdate)
+      return;
 
    struct timeval tv;
    gettimeofday(&tv, NULL);

--- a/linux/LinuxProcessList.h
+++ b/linux/LinuxProcessList.h
@@ -101,6 +101,6 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidMatchList, ui
 
 void ProcessList_delete(ProcessList* pl);
 
-void ProcessList_goThroughEntries(ProcessList* super);
+void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate);
 
 #endif

--- a/openbsd/OpenBSDProcessList.c
+++ b/openbsd/OpenBSDProcessList.c
@@ -340,10 +340,15 @@ static void OpenBSDProcessList_scanCPUTime(OpenBSDProcessList* this) {
    kernelCPUTimesToHtop(avg, this->cpus);
 }
 
-void ProcessList_goThroughEntries(ProcessList* this) {
+void ProcessList_goThroughEntries(ProcessList* this, bool pauseProcessUpdate) {
    OpenBSDProcessList* opl = (OpenBSDProcessList*) this;
 
    OpenBSDProcessList_scanMemoryInfo(this);
-   OpenBSDProcessList_scanProcs(opl);
    OpenBSDProcessList_scanCPUTime(opl);
+
+   // in pause mode only gather global data for meters (CPU/memory/...)
+   if (pauseProcessUpdate)
+      return;
+
+   OpenBSDProcessList_scanProcs(opl);
 }

--- a/openbsd/OpenBSDProcessList.h
+++ b/openbsd/OpenBSDProcessList.h
@@ -45,6 +45,6 @@ void ProcessList_delete(ProcessList* this);
 
 char *OpenBSDProcessList_readProcessName(kvm_t* kd, struct kinfo_proc* kproc, int* basenameEnd);
 
-void ProcessList_goThroughEntries(ProcessList* this);
+void ProcessList_goThroughEntries(ProcessList* this, bool pauseProcessUpdate);
 
 #endif

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -374,10 +374,15 @@ int SolarisProcessList_walkproc(psinfo_t *_psinfo, lwpsinfo_t *_lwpsinfo, void *
    return 0;
 }
 
-void ProcessList_goThroughEntries(ProcessList* this) {
+void ProcessList_goThroughEntries(ProcessList* this, bool pauseProcessUpdate) {
    SolarisProcessList_scanCPUTime(this);
    SolarisProcessList_scanMemoryInfo(this);
    SolarisProcessList_scanZfsArcstats(this);
+
+   // in pause mode only gather global data for meters (CPU/memory/...)
+   if (pauseProcessUpdate)
+      return;
+
    this->kernelThreads = 1;
    proc_walk(&SolarisProcessList_walkproc, this, PR_WALK_LWP);
 }

--- a/solaris/SolarisProcessList.h
+++ b/solaris/SolarisProcessList.h
@@ -60,6 +60,6 @@ void ProcessList_delete(ProcessList* pl);
 
 int SolarisProcessList_walkproc(psinfo_t *_psinfo, lwpsinfo_t *_lwpsinfo, void *listptr);
 
-void ProcessList_goThroughEntries(ProcessList* this);
+void ProcessList_goThroughEntries(ProcessList* this, bool pauseProcessUpdate);
 
 #endif

--- a/unsupported/UnsupportedProcessList.c
+++ b/unsupported/UnsupportedProcessList.c
@@ -24,8 +24,13 @@ void ProcessList_delete(ProcessList* this) {
    free(this);
 }
 
-void ProcessList_goThroughEntries(ProcessList* super) {
-	bool preExisting = true;
+void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
+
+   // in pause mode only gather global data for meters (CPU/memory/...)
+   if (pauseProcessUpdate)
+      return;
+
+    bool preExisting = true;
     Process *proc;
 
     proc = ProcessList_getProcess(super, 1, &preExisting, UnsupportedProcess_new);

--- a/unsupported/UnsupportedProcessList.h
+++ b/unsupported/UnsupportedProcessList.h
@@ -11,6 +11,6 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidMatchList, ui
 
 void ProcessList_delete(ProcessList* this);
 
-void ProcessList_goThroughEntries(ProcessList* super);
+void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate);
 
 #endif


### PR DESCRIPTION
Generic data, as CPU and memory usage, are used by Meters.
In paused mode they would stop receiving updates and especially Graph
Meters would stop showing continuous data.

Improves: #214
Closes: #253