### PR TITLE
Misc Cleanup

### DIFF
--- a/Meter.c
+++ b/Meter.c
@@ -31,7 +31,7 @@ const MeterClass Meter_class = {
    }
 };
 
-Meter* Meter_new(struct ProcessList_* pl, int param, const MeterClass* type) {
+Meter* Meter_new(const struct ProcessList_* pl, int param, const MeterClass* type) {
    Meter* this = xCalloc(1, sizeof(Meter));
    Object_setClass(this, type);
    this->h = 1;

--- a/Meter.h
+++ b/Meter.h
@@ -74,7 +74,7 @@ struct Meter_ {
    int param;
    GraphData* drawData;
    int h;
-   ProcessList* pl;
+   const ProcessList* pl;
    char curItems;
    double* values;
    double total;
@@ -98,7 +98,7 @@ typedef enum {
 
 extern const MeterClass Meter_class;
 
-Meter* Meter_new(ProcessList* pl, int param, const MeterClass* type);
+Meter* Meter_new(const ProcessList* pl, int param, const MeterClass* type);
 
 int Meter_humanUnit(char* buffer, unsigned long int value, int size);
 

--- a/Process.c
+++ b/Process.c
@@ -399,7 +399,7 @@ const ProcessClass Process_class = {
    .writeField = Process_writeField,
 };
 
-void Process_init(Process* this, struct Settings_* settings) {
+void Process_init(Process* this, const struct Settings_* settings) {
    this->settings = settings;
    this->tag = false;
    this->showChildren = true;

--- a/Process.h
+++ b/Process.h
@@ -59,7 +59,7 @@ struct Settings_;
 typedef struct Process_ {
    Object super;
 
-   struct Settings_* settings;
+   const struct Settings_* settings;
 
    unsigned long long int time;
    pid_t pid;
@@ -119,7 +119,7 @@ extern ProcessFieldData Process_fields[];
 extern ProcessPidColumn Process_pidColumns[];
 extern char Process_pidFormat[20];
 
-typedef Process*(*Process_New)(struct Settings_*);
+typedef Process*(*Process_New)(const struct Settings_*);
 typedef void (*Process_WriteField)(const Process*, RichString*, ProcessField);
 
 typedef struct ProcessClass_ {
@@ -164,7 +164,7 @@ void Process_done(Process* this);
 
 extern const ProcessClass Process_class;
 
-void Process_init(Process* this, struct Settings_* settings);
+void Process_init(Process* this, const struct Settings_* settings);
 
 void Process_toggleTag(Process* this);
 

--- a/ProcessList.c
+++ b/ProcessList.c
@@ -67,7 +67,7 @@ void ProcessList_setPanel(ProcessList* this, Panel* panel) {
 
 void ProcessList_printHeader(ProcessList* this, RichString* header) {
    RichString_prune(header);
-   ProcessField* fields = this->settings->fields;
+   const ProcessField* fields = this->settings->fields;
    for (int i = 0; fields[i]; i++) {
       const char* field = Process_fields[fields[i]].title;
       if (!field) field = "- ";
@@ -142,20 +142,21 @@ static void ProcessList_buildTree(ProcessList* this, pid_t pid, int level, int i
    Vector_delete(children);
 }
 
+static long ProcessList_treeProcessCompare(const void* v1, const void* v2) {
+   const Process *p1 = (const Process*)v1;
+   const Process *p2 = (const Process*)v2;
+
+   return p1->pid - p2->pid;
+}
+
 void ProcessList_sort(ProcessList* this) {
    if (!this->settings->treeView) {
       Vector_insertionSort(this->processes);
    } else {
       // Save settings
       int direction = this->settings->direction;
-      int sortKey = this->settings->sortKey;
       // Sort by PID
-      this->settings->sortKey = PID;
-      this->settings->direction = 1;
-      Vector_quickSort(this->processes);
-      // Restore settings
-      this->settings->sortKey = sortKey;
-      this->settings->direction = direction;
+      Vector_quickSortCustomCompare(this->processes, ProcessList_treeProcessCompare);
       int vsize = Vector_size(this->processes);
       // Find all processes whose parent is not visible
       int size;
@@ -214,7 +215,7 @@ void ProcessList_sort(ProcessList* this) {
 
 ProcessField ProcessList_keyAt(ProcessList* this, int at) {
    int x = 0;
-   ProcessField* fields = this->settings->fields;
+   const ProcessField* fields = this->settings->fields;
    ProcessField field;
    for (int i = 0; (field = fields[i]); i++) {
       const char* title = Process_fields[field].title;

--- a/ProcessList.h
+++ b/ProcessList.h
@@ -35,7 +35,7 @@ in the source distribution for its full text.
 #endif
 
 typedef struct ProcessList_ {
-   Settings* settings;
+   const Settings* settings;
 
    Vector* processes;
    Vector* processes2;

--- a/TasksMeter.c
+++ b/TasksMeter.c
@@ -24,7 +24,7 @@ static const int TasksMeter_attributes[] = {
 };
 
 static void TasksMeter_updateValues(Meter* this, char* buffer, int len) {
-   ProcessList* pl = this->pl;
+   const ProcessList* pl = this->pl;
    this->values[0] = pl->kernelThreads;
    this->values[1] = pl->userlandThreads;
    this->values[2] = pl->totalTasks - pl->kernelThreads - pl->userlandThreads;
@@ -32,7 +32,7 @@ static void TasksMeter_updateValues(Meter* this, char* buffer, int len) {
    if (pl->totalTasks > this->total) {
       this->total = pl->totalTasks;
    }
-   if (this->pl->settings->hideKernelThreads) {
+   if (pl->settings->hideKernelThreads) {
       this->values[0] = 0;
    }
    xSnprintf(buffer, len, "%d/%d", (int) this->values[3], (int) this->total);

--- a/Vector.c
+++ b/Vector.c
@@ -161,10 +161,10 @@ static void insertionSort(Object** array, int left, int right, Object_Compare co
    }
 }
 
-void Vector_quickSort(Vector* this) {
-   assert(this->type->compare);
+void Vector_quickSortCustomCompare(Vector* this, Object_Compare compare) {
+   assert(compare);
    assert(Vector_isConsistent(this));
-   quickSort(this->array, 0, this->items - 1, this->type->compare);
+   quickSort(this->array, 0, this->items - 1, compare);
    assert(Vector_isConsistent(this));
 }
 

--- a/Vector.h
+++ b/Vector.h
@@ -31,7 +31,10 @@ void Vector_delete(Vector* this);
 
 void Vector_prune(Vector* this);
 
-void Vector_quickSort(Vector* this);
+void Vector_quickSortCustomCompare(Vector* this, Object_Compare compare);
+static inline void Vector_quickSort(Vector* this) {
+   Vector_quickSortCustomCompare(this, this->type->compare);
+}
 
 void Vector_insertionSort(Vector* this);
 

--- a/darwin/DarwinProcess.c
+++ b/darwin/DarwinProcess.c
@@ -28,7 +28,7 @@ const ProcessClass DarwinProcess_class = {
    .writeField = Process_writeField,
 };
 
-DarwinProcess* DarwinProcess_new(Settings* settings) {
+Process* DarwinProcess_new(const Settings* settings) {
    DarwinProcess* this = xCalloc(1, sizeof(DarwinProcess));
    Object_setClass(this, Class(DarwinProcess));
    Process_init(&this->super, settings);
@@ -37,7 +37,7 @@ DarwinProcess* DarwinProcess_new(Settings* settings) {
    this->stime = 0;
    this->taskAccess = true;
 
-   return this;
+   return &this->super;
 }
 
 void Process_delete(Object* cast) {

--- a/darwin/DarwinProcess.h
+++ b/darwin/DarwinProcess.h
@@ -22,7 +22,7 @@ typedef struct DarwinProcess_ {
 
 extern const ProcessClass DarwinProcess_class;
 
-DarwinProcess* DarwinProcess_new(Settings* settings);
+Process* DarwinProcess_new(const Settings* settings);
 
 void Process_delete(Object* cast);
 

--- a/darwin/DarwinProcessList.c
+++ b/darwin/DarwinProcessList.c
@@ -186,7 +186,7 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
     ps = ProcessList_getKInfoProcs(&count);
 
     for(size_t i = 0; i < count; ++i) {
-       proc = (DarwinProcess *)ProcessList_getProcess(super, ps[i].kp_proc.p_pid, &preExisting, (Process_New)DarwinProcess_new);
+       proc = (DarwinProcess *)ProcessList_getProcess(super, ps[i].kp_proc.p_pid, &preExisting, DarwinProcess_new);
 
        DarwinProcess_setFromKInfoProc(&proc->super, &ps[i], preExisting);
        DarwinProcess_setFromLibprocPidinfo(proc, dpl);

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -176,8 +176,8 @@ ProcessPidColumn Process_pidColumns[] = {
 };
 
 static double Platform_setCPUAverageValues(Meter* mtr) {
-   DarwinProcessList *dpl = (DarwinProcessList *)mtr->pl;
-   int cpus = dpl->super.cpuCount;
+   const ProcessList *dpl = mtr->pl;
+   int cpus = dpl->cpuCount;
    double sumNice = 0.0;
    double sumNormal = 0.0;
    double sumKernel = 0.0;
@@ -200,9 +200,9 @@ double Platform_setCPUValues(Meter* mtr, int cpu) {
       return Platform_setCPUAverageValues(mtr);
    }
 
-   DarwinProcessList *dpl = (DarwinProcessList *)mtr->pl;
-   processor_cpu_load_info_t prev = &dpl->prev_load[cpu-1];
-   processor_cpu_load_info_t curr = &dpl->curr_load[cpu-1];
+   const DarwinProcessList *dpl = (const DarwinProcessList *)mtr->pl;
+   const processor_cpu_load_info_t prev = &dpl->prev_load[cpu-1];
+   const processor_cpu_load_info_t curr = &dpl->curr_load[cpu-1];
    double total = 0;
 
    /* Take the sums */
@@ -228,8 +228,8 @@ double Platform_setCPUValues(Meter* mtr, int cpu) {
 }
 
 void Platform_setMemoryValues(Meter* mtr) {
-   DarwinProcessList *dpl = (DarwinProcessList *)mtr->pl;
-   vm_statistics_t vm = &dpl->vm_stats;
+   const DarwinProcessList *dpl = (const DarwinProcessList *)mtr->pl;
+   const struct vm_statistics* vm = &dpl->vm_stats;
    double page_K = (double)vm_page_size / (double)1024;
 
    mtr->total = dpl->host_info.max_mem / 1024;
@@ -249,13 +249,13 @@ void Platform_setSwapValues(Meter* mtr) {
 }
 
 void Platform_setZfsArcValues(Meter* this) {
-   DarwinProcessList* dpl = (DarwinProcessList*) this->pl;
+   const DarwinProcessList* dpl = (const DarwinProcessList*) this->pl;
 
    ZfsArcMeter_readStats(this, &(dpl->zfs));
 }
 
 void Platform_setZfsCompressedArcValues(Meter* this) {
-   DarwinProcessList* dpl = (DarwinProcessList*) this->pl;
+   const DarwinProcessList* dpl = (const DarwinProcessList*) this->pl;
 
    ZfsCompressedArcMeter_readStats(this, &(dpl->zfs));
 }

--- a/dragonflybsd/DragonFlyBSDProcess.c
+++ b/dragonflybsd/DragonFlyBSDProcess.c
@@ -69,11 +69,11 @@ ProcessPidColumn Process_pidColumns[] = {
    { .id = 0, .label = NULL },
 };
 
-DragonFlyBSDProcess* DragonFlyBSDProcess_new(Settings* settings) {
+Process* DragonFlyBSDProcess_new(const Settings* settings) {
    DragonFlyBSDProcess* this = xCalloc(1, sizeof(DragonFlyBSDProcess));
    Object_setClass(this, Class(DragonFlyBSDProcess));
    Process_init(&this->super, settings);
-   return this;
+   return &this->super;
 }
 
 void Process_delete(Object* cast) {

--- a/dragonflybsd/DragonFlyBSDProcess.c
+++ b/dragonflybsd/DragonFlyBSDProcess.c
@@ -25,7 +25,7 @@ const ProcessClass DragonFlyBSDProcess_class = {
       .delete = Process_delete,
       .compare = DragonFlyBSDProcess_compare
    },
-   .writeField = (Process_WriteField) DragonFlyBSDProcess_writeField,
+   .writeField = DragonFlyBSDProcess_writeField,
 };
 
 ProcessFieldData Process_fields[] = {
@@ -83,8 +83,8 @@ void Process_delete(Object* cast) {
    free(this);
 }
 
-void DragonFlyBSDProcess_writeField(Process* this, RichString* str, ProcessField field) {
-   DragonFlyBSDProcess* fp = (DragonFlyBSDProcess*) this;
+void DragonFlyBSDProcess_writeField(const Process* this, RichString* str, ProcessField field) {
+   const DragonFlyBSDProcess* fp = (const DragonFlyBSDProcess*) this;
    char buffer[256]; buffer[255] = '\0';
    int attr = CRT_colors[DEFAULT_COLOR];
    int n = sizeof(buffer) - 1;

--- a/dragonflybsd/DragonFlyBSDProcess.h
+++ b/dragonflybsd/DragonFlyBSDProcess.h
@@ -37,7 +37,7 @@ DragonFlyBSDProcess* DragonFlyBSDProcess_new(Settings* settings);
 
 void Process_delete(Object* cast);
 
-void DragonFlyBSDProcess_writeField(Process* this, RichString* str, ProcessField field);
+void DragonFlyBSDProcess_writeField(const Process* this, RichString* str, ProcessField field);
 
 long DragonFlyBSDProcess_compare(const void* v1, const void* v2);
 

--- a/dragonflybsd/DragonFlyBSDProcess.h
+++ b/dragonflybsd/DragonFlyBSDProcess.h
@@ -33,7 +33,7 @@ extern ProcessFieldData Process_fields[];
 
 extern ProcessPidColumn Process_pidColumns[];
 
-DragonFlyBSDProcess* DragonFlyBSDProcess_new(Settings* settings);
+Process* DragonFlyBSDProcess_new(const Settings* settings);
 
 void Process_delete(Object* cast);
 

--- a/dragonflybsd/DragonFlyBSDProcessList.c
+++ b/dragonflybsd/DragonFlyBSDProcessList.c
@@ -362,7 +362,7 @@ char* DragonFlyBSDProcessList_readJailName(DragonFlyBSDProcessList* dfpl, int ja
 
 void ProcessList_goThroughEntries(ProcessList* this, bool pauseProcessUpdate) {
    DragonFlyBSDProcessList* dfpl = (DragonFlyBSDProcessList*) this;
-   Settings* settings = this->settings;
+   const Settings* settings = this->settings;
    bool hideKernelThreads = settings->hideKernelThreads;
    bool hideUserlandThreads = settings->hideUserlandThreads;
 

--- a/dragonflybsd/DragonFlyBSDProcessList.c
+++ b/dragonflybsd/DragonFlyBSDProcessList.c
@@ -385,7 +385,7 @@ void ProcessList_goThroughEntries(ProcessList* this, bool pauseProcessUpdate) {
       bool ATTR_UNUSED isIdleProcess = false;
 
       // note: dragonflybsd kernel processes all have the same pid, so we misuse the kernel thread address to give them a unique identifier
-      Process* proc = ProcessList_getProcess(this, kproc->kp_ktaddr ? (pid_t)kproc->kp_ktaddr : kproc->kp_pid, &preExisting, (Process_New) DragonFlyBSDProcess_new);
+      Process* proc = ProcessList_getProcess(this, kproc->kp_ktaddr ? (pid_t)kproc->kp_ktaddr : kproc->kp_pid, &preExisting, DragonFlyBSDProcess_new);
       DragonFlyBSDProcess* dfp = (DragonFlyBSDProcess*) proc;
 
       proc->show = ! ((hideKernelThreads && Process_isKernelThread(dfp)) || (hideUserlandThreads && Process_isUserlandThread(proc)));

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -149,9 +149,9 @@ int Platform_getMaxPid() {
 }
 
 double Platform_setCPUValues(Meter* this, int cpu) {
-   DragonFlyBSDProcessList* fpl = (DragonFlyBSDProcessList*) this->pl;
+   const DragonFlyBSDProcessList* fpl = (const DragonFlyBSDProcessList*) this->pl;
    int cpus = this->pl->cpuCount;
-   CPUData* cpuData;
+   const CPUData* cpuData;
 
    if (cpus == 1) {
      // single CPU box has everything in fpl->cpus[0]
@@ -186,7 +186,7 @@ double Platform_setCPUValues(Meter* this, int cpu) {
 
 void Platform_setMemoryValues(Meter* this) {
    // TODO
-   ProcessList* pl = (ProcessList*) this->pl;
+   const ProcessList* pl = this->pl;
 
    this->total = pl->totalMem;
    this->values[0] = pl->usedMem;
@@ -195,7 +195,7 @@ void Platform_setMemoryValues(Meter* this) {
 }
 
 void Platform_setSwapValues(Meter* this) {
-   ProcessList* pl = (ProcessList*) this->pl;
+   const ProcessList* pl = this->pl;
    this->total = pl->totalSwap;
    this->values[0] = pl->usedSwap;
 }

--- a/freebsd/FreeBSDProcess.c
+++ b/freebsd/FreeBSDProcess.c
@@ -24,7 +24,7 @@ const ProcessClass FreeBSDProcess_class = {
       .delete = Process_delete,
       .compare = FreeBSDProcess_compare
    },
-   .writeField = (Process_WriteField) FreeBSDProcess_writeField,
+   .writeField = FreeBSDProcess_writeField,
 };
 
 ProcessFieldData Process_fields[] = {
@@ -83,8 +83,8 @@ void Process_delete(Object* cast) {
    free(this);
 }
 
-void FreeBSDProcess_writeField(Process* this, RichString* str, ProcessField field) {
-   FreeBSDProcess* fp = (FreeBSDProcess*) this;
+void FreeBSDProcess_writeField(const Process* this, RichString* str, ProcessField field) {
+   const FreeBSDProcess* fp = (const FreeBSDProcess*) this;
    char buffer[256]; buffer[255] = '\0';
    int attr = CRT_colors[DEFAULT_COLOR];
    int n = sizeof(buffer) - 1;

--- a/freebsd/FreeBSDProcess.c
+++ b/freebsd/FreeBSDProcess.c
@@ -69,11 +69,11 @@ ProcessPidColumn Process_pidColumns[] = {
    { .id = 0, .label = NULL },
 };
 
-FreeBSDProcess* FreeBSDProcess_new(Settings* settings) {
+Process* FreeBSDProcess_new(const Settings* settings) {
    FreeBSDProcess* this = xCalloc(1, sizeof(FreeBSDProcess));
    Object_setClass(this, Class(FreeBSDProcess));
    Process_init(&this->super, settings);
-   return this;
+   return &this->super;
 }
 
 void Process_delete(Object* cast) {

--- a/freebsd/FreeBSDProcess.h
+++ b/freebsd/FreeBSDProcess.h
@@ -43,7 +43,7 @@ FreeBSDProcess* FreeBSDProcess_new(Settings* settings);
 
 void Process_delete(Object* cast);
 
-void FreeBSDProcess_writeField(Process* this, RichString* str, ProcessField field);
+void FreeBSDProcess_writeField(const Process* this, RichString* str, ProcessField field);
 
 long FreeBSDProcess_compare(const void* v1, const void* v2);
 

--- a/freebsd/FreeBSDProcess.h
+++ b/freebsd/FreeBSDProcess.h
@@ -39,7 +39,7 @@ extern ProcessFieldData Process_fields[];
 
 extern ProcessPidColumn Process_pidColumns[];
 
-FreeBSDProcess* FreeBSDProcess_new(Settings* settings);
+Process* FreeBSDProcess_new(const Settings* settings);
 
 void Process_delete(Object* cast);
 

--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -401,7 +401,7 @@ void ProcessList_goThroughEntries(ProcessList* this, bool pauseProcessUpdate) {
       struct kinfo_proc* kproc = &kprocs[i];
       bool preExisting = false;
       // TODO: bool isIdleProcess = false;
-      Process* proc = ProcessList_getProcess(this, kproc->ki_pid, &preExisting, (Process_New) FreeBSDProcess_new);
+      Process* proc = ProcessList_getProcess(this, kproc->ki_pid, &preExisting, FreeBSDProcess_new);
       FreeBSDProcess* fp = (FreeBSDProcess*) proc;
 
       proc->show = ! ((hideKernelThreads && Process_isKernelThread(fp)) || (hideUserlandThreads && Process_isUserlandThread(proc)));

--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -382,7 +382,7 @@ IGNORE_WCASTQUAL_END
 
 void ProcessList_goThroughEntries(ProcessList* this, bool pauseProcessUpdate) {
    FreeBSDProcessList* fpl = (FreeBSDProcessList*) this;
-   Settings* settings = this->settings;
+   const Settings* settings = this->settings;
    bool hideKernelThreads = settings->hideKernelThreads;
    bool hideUserlandThreads = settings->hideUserlandThreads;
 

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -157,9 +157,9 @@ int Platform_getMaxPid() {
 }
 
 double Platform_setCPUValues(Meter* this, int cpu) {
-   FreeBSDProcessList* fpl = (FreeBSDProcessList*) this->pl;
+   const FreeBSDProcessList* fpl = (const FreeBSDProcessList*) this->pl;
    int cpus = this->pl->cpuCount;
-   CPUData* cpuData;
+   const CPUData* cpuData;
 
    if (cpus == 1) {
      // single CPU box has everything in fpl->cpus[0]
@@ -194,7 +194,7 @@ double Platform_setCPUValues(Meter* this, int cpu) {
 
 void Platform_setMemoryValues(Meter* this) {
    // TODO
-   ProcessList* pl = (ProcessList*) this->pl;
+   const ProcessList* pl = this->pl;
 
    this->total = pl->totalMem;
    this->values[0] = pl->usedMem;
@@ -203,19 +203,19 @@ void Platform_setMemoryValues(Meter* this) {
 }
 
 void Platform_setSwapValues(Meter* this) {
-   ProcessList* pl = (ProcessList*) this->pl;
+   const ProcessList* pl = this->pl;
    this->total = pl->totalSwap;
    this->values[0] = pl->usedSwap;
 }
 
 void Platform_setZfsArcValues(Meter* this) {
-   FreeBSDProcessList* fpl = (FreeBSDProcessList*) this->pl;
+   const FreeBSDProcessList* fpl = (const FreeBSDProcessList*) this->pl;
 
    ZfsArcMeter_readStats(this, &(fpl->zfs));
 }
 
 void Platform_setZfsCompressedArcValues(Meter* this) {
-   FreeBSDProcessList* fpl = (FreeBSDProcessList*) this->pl;
+   const FreeBSDProcessList* fpl = (const FreeBSDProcessList*) this->pl;
 
    ZfsCompressedArcMeter_readStats(this, &(fpl->zfs));
 }

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -138,11 +138,11 @@ const ProcessClass LinuxProcess_class = {
    .writeField = LinuxProcess_writeField,
 };
 
-LinuxProcess* LinuxProcess_new(Settings* settings) {
+Process* LinuxProcess_new(const Settings* settings) {
    LinuxProcess* this = xCalloc(1, sizeof(LinuxProcess));
    Object_setClass(this, Class(LinuxProcess));
    Process_init(&this->super, settings);
-   return this;
+   return &this->super;
 }
 
 void Process_delete(Object* cast) {

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -135,7 +135,7 @@ const ProcessClass LinuxProcess_class = {
       .delete = Process_delete,
       .compare = LinuxProcess_compare
    },
-   .writeField = (Process_WriteField) LinuxProcess_writeField,
+   .writeField = LinuxProcess_writeField,
 };
 
 LinuxProcess* LinuxProcess_new(Settings* settings) {
@@ -197,8 +197,8 @@ void LinuxProcess_printDelay(float delay_percent, char* buffer, int n) {
 }
 #endif
 
-void LinuxProcess_writeField(Process* this, RichString* str, ProcessField field) {
-   LinuxProcess* lp = (LinuxProcess*) this;
+void LinuxProcess_writeField(const Process* this, RichString* str, ProcessField field) {
+   const LinuxProcess* lp = (const LinuxProcess*) this;
    bool coloring = this->settings->highlightMegabytes;
    char buffer[256]; buffer[255] = '\0';
    int attr = CRT_colors[DEFAULT_COLOR];

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -189,7 +189,7 @@ bool LinuxProcess_setIOPriority(LinuxProcess* this, Arg ioprio);
 void LinuxProcess_printDelay(float delay_percent, char* buffer, int n);
 #endif
 
-void LinuxProcess_writeField(Process* this, RichString* str, ProcessField field);
+void LinuxProcess_writeField(const Process* this, RichString* str, ProcessField field);
 
 long LinuxProcess_compare(const void* v1, const void* v2);
 

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -167,7 +167,7 @@ extern ProcessPidColumn Process_pidColumns[];
 
 extern const ProcessClass LinuxProcess_class;
 
-LinuxProcess* LinuxProcess_new(Settings* settings);
+Process* LinuxProcess_new(const Settings* settings);
 
 void Process_delete(Object* cast);
 

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -936,7 +936,7 @@ static bool LinuxProcessList_recurseProcTree(LinuxProcessList* this, const char*
    ProcessList* pl = (ProcessList*) this;
    DIR* dir;
    struct dirent* entry;
-   Settings* settings = pl->settings;
+   const Settings* settings = pl->settings;
 
    #ifdef HAVE_TASKSTATS
    unsigned long long now = tv.tv_sec*1000LL+tv.tv_usec/1000LL;

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -971,7 +971,7 @@ static bool LinuxProcessList_recurseProcTree(LinuxProcessList* this, const char*
          continue;
 
       bool preExisting = false;
-      Process* proc = ProcessList_getProcess(pl, pid, &preExisting, (Process_New) LinuxProcess_new);
+      Process* proc = ProcessList_getProcess(pl, pid, &preExisting, LinuxProcess_new);
       proc->tgid = parent ? parent->pid : pid;
 
       LinuxProcess* lp = (LinuxProcess*) proc;

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -189,8 +189,8 @@ int Platform_getMaxPid() {
 }
 
 double Platform_setCPUValues(Meter* this, int cpu) {
-   LinuxProcessList* pl = (LinuxProcessList*) this->pl;
-   CPUData* cpuData = &(pl->cpus[cpu]);
+   const LinuxProcessList* pl = (const LinuxProcessList*) this->pl;
+   const CPUData* cpuData = &(pl->cpus[cpu]);
    double total = (double) ( cpuData->totalPeriod == 0 ? 1 : cpuData->totalPeriod);
    double percent;
    double* v = this->values;
@@ -224,8 +224,8 @@ double Platform_setCPUValues(Meter* this, int cpu) {
 }
 
 void Platform_setMemoryValues(Meter* this) {
-   ProcessList* pl = this->pl;
-   LinuxProcessList* lpl = (LinuxProcessList*) this->pl;
+   const ProcessList* pl = this->pl;
+   const LinuxProcessList* lpl = (const LinuxProcessList*) pl;
 
    long int usedMem = pl->usedMem;
    long int buffersMem = pl->buffersMem;
@@ -243,19 +243,19 @@ void Platform_setMemoryValues(Meter* this) {
 }
 
 void Platform_setSwapValues(Meter* this) {
-   ProcessList* pl = (ProcessList*) this->pl;
+   const ProcessList* pl = this->pl;
    this->total = pl->totalSwap;
    this->values[0] = pl->usedSwap;
 }
 
 void Platform_setZfsArcValues(Meter* this) {
-   LinuxProcessList* lpl = (LinuxProcessList*) this->pl;
+   const LinuxProcessList* lpl = (const LinuxProcessList*) this->pl;
 
    ZfsArcMeter_readStats(this, &(lpl->zfs));
 }
 
 void Platform_setZfsCompressedArcValues(Meter* this) {
-   LinuxProcessList* lpl = (LinuxProcessList*) this->pl;
+   const LinuxProcessList* lpl = (const LinuxProcessList*) this->pl;
 
    ZfsCompressedArcMeter_readStats(this, &(lpl->zfs));
 }

--- a/openbsd/OpenBSDProcess.c
+++ b/openbsd/OpenBSDProcess.c
@@ -165,11 +165,11 @@ ProcessPidColumn Process_pidColumns[] = {
    { .id = 0, .label = NULL },
 };
 
-OpenBSDProcess* OpenBSDProcess_new(Settings* settings) {
+Process* OpenBSDProcess_new(const Settings* settings) {
    OpenBSDProcess* this = xCalloc(sizeof(OpenBSDProcess), 1);
    Object_setClass(this, Class(OpenBSDProcess));
    Process_init(&this->super, settings);
-   return this;
+   return &this->this;
 }
 
 void Process_delete(Object* cast) {

--- a/openbsd/OpenBSDProcess.c
+++ b/openbsd/OpenBSDProcess.c
@@ -24,7 +24,7 @@ const ProcessClass OpenBSDProcess_class = {
       .delete = Process_delete,
       .compare = OpenBSDProcess_compare
    },
-   .writeField = (Process_WriteField) OpenBSDProcess_writeField,
+   .writeField = OpenBSDProcess_writeField,
 };
 
 ProcessFieldData Process_fields[] = {
@@ -178,7 +178,7 @@ void Process_delete(Object* cast) {
    free(this);
 }
 
-void OpenBSDProcess_writeField(Process* this, RichString* str, ProcessField field) {
+void OpenBSDProcess_writeField(const Process* this, RichString* str, ProcessField field) {
    //OpenBSDProcess* fp = (OpenBSDProcess*) this;
    char buffer[256]; buffer[255] = '\0';
    int attr = CRT_colors[DEFAULT_COLOR];

--- a/openbsd/OpenBSDProcess.h
+++ b/openbsd/OpenBSDProcess.h
@@ -27,7 +27,7 @@ extern ProcessFieldData Process_fields[];
 
 extern ProcessPidColumn Process_pidColumns[];
 
-OpenBSDProcess* OpenBSDProcess_new(Settings* settings);
+Process* OpenBSDProcess_new(const Settings* settings);
 
 void Process_delete(Object* cast);
 

--- a/openbsd/OpenBSDProcess.h
+++ b/openbsd/OpenBSDProcess.h
@@ -31,7 +31,7 @@ OpenBSDProcess* OpenBSDProcess_new(Settings* settings);
 
 void Process_delete(Object* cast);
 
-void OpenBSDProcess_writeField(Process* this, RichString* str, ProcessField field);
+void OpenBSDProcess_writeField(const Process* this, RichString* str, ProcessField field);
 
 long OpenBSDProcess_compare(const void* v1, const void* v2);
 

--- a/openbsd/OpenBSDProcessList.c
+++ b/openbsd/OpenBSDProcessList.c
@@ -203,7 +203,7 @@ static inline void OpenBSDProcessList_scanProcs(OpenBSDProcessList* this) {
       kproc = &kprocs[i];
 
       preExisting = false;
-      proc = ProcessList_getProcess(&this->super, kproc->p_pid, &preExisting, (Process_New) OpenBSDProcess_new);
+      proc = ProcessList_getProcess(&this->super, kproc->p_pid, &preExisting, OpenBSDProcess_new);
       fp = (OpenBSDProcess*) proc;
 
       proc->show = ! ((hideKernelThreads && Process_isKernelThread(proc))

--- a/openbsd/OpenBSDProcessList.c
+++ b/openbsd/OpenBSDProcessList.c
@@ -185,7 +185,7 @@ static double getpcpu(const struct kinfo_proc *kp) {
 }
 
 static inline void OpenBSDProcessList_scanProcs(OpenBSDProcessList* this) {
-   Settings* settings = this->super.settings;
+   const Settings* settings = this->super.settings;
    bool hideKernelThreads = settings->hideKernelThreads;
    bool hideUserlandThreads = settings->hideUserlandThreads;
    struct kinfo_proc* kproc;

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -189,7 +189,7 @@ double Platform_setCPUValues(Meter* this, int cpu) {
 }
 
 void Platform_setMemoryValues(Meter* this) {
-   ProcessList* pl = (ProcessList*) this->pl;
+   const ProcessList* pl = this->pl;
    long int usedMem = pl->usedMem;
    long int buffersMem = pl->buffersMem;
    long int cachedMem = pl->cachedMem;
@@ -207,7 +207,7 @@ void Platform_setMemoryValues(Meter* this) {
  * Taken almost directly from OpenBSD's top(1)
  */
 void Platform_setSwapValues(Meter* this) {
-   ProcessList* pl = (ProcessList*) this->pl;
+   const ProcessList* pl = this->pl;
    struct swapent *swdev;
    unsigned long long int total, used;
    int nswap, rnswap, i;

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -167,9 +167,9 @@ int Platform_getMaxPid() {
 }
 
 double Platform_setCPUValues(Meter* this, int cpu) {
-   SolarisProcessList* spl = (SolarisProcessList*) this->pl;
+   const SolarisProcessList* spl = (const SolarisProcessList*) this->pl;
    int cpus = this->pl->cpuCount;
-   CPUData* cpuData = NULL;
+   const CPUData* cpuData = NULL;
 
    if (cpus == 1) {
      // single CPU box has everything in spl->cpus[0]
@@ -203,7 +203,7 @@ double Platform_setCPUValues(Meter* this, int cpu) {
 }
 
 void Platform_setMemoryValues(Meter* this) {
-   ProcessList* pl = (ProcessList*) this->pl;
+   const ProcessList* pl = this->pl;
    this->total = pl->totalMem;
    this->values[0] = pl->usedMem;
    this->values[1] = pl->buffersMem;
@@ -211,19 +211,19 @@ void Platform_setMemoryValues(Meter* this) {
 }
 
 void Platform_setSwapValues(Meter* this) {
-   ProcessList* pl = (ProcessList*) this->pl;
+   const ProcessList* pl = this->pl;
    this->total = pl->totalSwap;
    this->values[0] = pl->usedSwap;
 }
 
 void Platform_setZfsArcValues(Meter* this) {
-   SolarisProcessList* spl = (SolarisProcessList*) this->pl;
+   const SolarisProcessList* spl = (const SolarisProcessList*) this->pl;
 
    ZfsArcMeter_readStats(this, &(spl->zfs));
 }
 
 void Platform_setZfsCompressedArcValues(Meter* this) {
-   SolarisProcessList* spl = (SolarisProcessList*) this->pl;
+   const SolarisProcessList* spl = (const SolarisProcessList*) this->pl;
 
    ZfsCompressedArcMeter_readStats(this, &(spl->zfs));
 }

--- a/solaris/SolarisProcess.c
+++ b/solaris/SolarisProcess.c
@@ -79,11 +79,11 @@ ProcessPidColumn Process_pidColumns[] = {
    { .id = 0, .label = NULL },
 };
 
-SolarisProcess* SolarisProcess_new(Settings* settings) {
+Process* SolarisProcess_new(const Settings* settings) {
    SolarisProcess* this = xCalloc(1, sizeof(SolarisProcess));
    Object_setClass(this, Class(SolarisProcess));
    Process_init(&this->super, settings);
-   return this;
+   return &this->super;
 }
 
 void Process_delete(Object* cast) {

--- a/solaris/SolarisProcess.c
+++ b/solaris/SolarisProcess.c
@@ -25,7 +25,7 @@ const ProcessClass SolarisProcess_class = {
       .delete = Process_delete,
       .compare = SolarisProcess_compare
    },
-   .writeField = (Process_WriteField) SolarisProcess_writeField,
+   .writeField = SolarisProcess_writeField,
 };
 
 ProcessFieldData Process_fields[] = {
@@ -93,8 +93,8 @@ void Process_delete(Object* cast) {
    free(sp);
 }
 
-void SolarisProcess_writeField(Process* this, RichString* str, ProcessField field) {
-   SolarisProcess* sp = (SolarisProcess*) this;
+void SolarisProcess_writeField(const Process* this, RichString* str, ProcessField field) {
+   const SolarisProcess* sp = (const SolarisProcess*) this;
    char buffer[256]; buffer[255] = '\0';
    int attr = CRT_colors[DEFAULT_COLOR];
    int n = sizeof(buffer) - 1;

--- a/solaris/SolarisProcess.h
+++ b/solaris/SolarisProcess.h
@@ -54,7 +54,7 @@ SolarisProcess* SolarisProcess_new(Settings* settings);
 
 void Process_delete(Object* cast);
 
-void SolarisProcess_writeField(Process* this, RichString* str, ProcessField field);
+void SolarisProcess_writeField(const Process* this, RichString* str, ProcessField field);
 
 long SolarisProcess_compare(const void* v1, const void* v2);
 

--- a/solaris/SolarisProcess.h
+++ b/solaris/SolarisProcess.h
@@ -50,7 +50,7 @@ extern ProcessFieldData Process_fields[];
 
 extern ProcessPidColumn Process_pidColumns[];
 
-SolarisProcess* SolarisProcess_new(Settings* settings);
+Process* SolarisProcess_new(const Settings* settings);
 
 void Process_delete(Object* cast);
 

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -279,7 +279,7 @@ int SolarisProcessList_walkproc(psinfo_t *_psinfo, lwpsinfo_t *_lwpsinfo, void *
    } else {
       getpid = lwpid;
    }
-   Process *proc             = ProcessList_getProcess(pl, getpid, &preExisting, (Process_New) SolarisProcess_new);
+   Process *proc             = ProcessList_getProcess(pl, getpid, &preExisting, SolarisProcess_new);
    SolarisProcess *sproc     = (SolarisProcess*) proc;
 
    // Common code pass 1

--- a/zfs/ZfsArcMeter.c
+++ b/zfs/ZfsArcMeter.c
@@ -18,7 +18,7 @@ static const int ZfsArcMeter_attributes[] = {
    ZFS_MFU, ZFS_MRU, ZFS_ANON, ZFS_HEADER, ZFS_OTHER
 };
 
-void ZfsArcMeter_readStats(Meter* this, ZfsArcStats* stats) {
+void ZfsArcMeter_readStats(Meter* this, const ZfsArcStats* stats) {
    this->total = stats->max;
    this->values[0] = stats->MFU;
    this->values[1] = stats->MRU;

--- a/zfs/ZfsArcMeter.h
+++ b/zfs/ZfsArcMeter.h
@@ -11,7 +11,7 @@ in the source distribution for its full text.
 
 #include "Meter.h"
 
-void ZfsArcMeter_readStats(Meter* this, ZfsArcStats* stats);
+void ZfsArcMeter_readStats(Meter* this, const ZfsArcStats* stats);
 
 extern const MeterClass ZfsArcMeter_class;
 

--- a/zfs/ZfsCompressedArcMeter.c
+++ b/zfs/ZfsCompressedArcMeter.c
@@ -21,7 +21,7 @@ static const int ZfsCompressedArcMeter_attributes[] = {
    ZFS_COMPRESSED
 };
 
-void ZfsCompressedArcMeter_readStats(Meter* this, ZfsArcStats* stats) {
+void ZfsCompressedArcMeter_readStats(Meter* this, const ZfsArcStats* stats) {
    if ( stats->isCompressed ) {
       this->total = stats->uncompressed;
       this->values[0] = stats->compressed;

--- a/zfs/ZfsCompressedArcMeter.h
+++ b/zfs/ZfsCompressedArcMeter.h
@@ -11,7 +11,7 @@ in the source distribution for its full text.
 
 #include "Meter.h"
 
-void ZfsCompressedArcMeter_readStats(Meter* this, ZfsArcStats* stats);
+void ZfsCompressedArcMeter_readStats(Meter* this, const ZfsArcStats* stats);
 
 extern const MeterClass ZfsCompressedArcMeter_class;
 


### PR DESCRIPTION
Mark several structure members const.
E.g. settings should only be changed by the Settings Screen and not through a Process pointer.

(Dropped the hashtable changes)