### PR TITLE
Fix column sorting

### DIFF
--- a/ColumnsPanel.c
+++ b/ColumnsPanel.c
@@ -135,15 +135,6 @@ ColumnsPanel* ColumnsPanel_new(Settings* settings) {
    return this;
 }
 
-int ColumnsPanel_fieldNameToIndex(const char* name) {
-   for (int j = 1; j <= Platform_numberOfFields; j++) {
-      if (String_eq(name, Process_fields[j].name)) {
-         return j;
-      }
-   }
-   return -1;
-}
-
 void ColumnsPanel_update(Panel* super) {
    ColumnsPanel* this = (ColumnsPanel*) super;
    int size = Panel_size(super);

--- a/ColumnsPanel.h
+++ b/ColumnsPanel.h
@@ -23,8 +23,6 @@ extern const PanelClass ColumnsPanel_class;
 
 ColumnsPanel* ColumnsPanel_new(Settings* settings);
 
-int ColumnsPanel_fieldNameToIndex(const char* name);
-
 void ColumnsPanel_update(Panel* super);
 
 #endif

--- a/htop.c
+++ b/htop.c
@@ -131,12 +131,11 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
             }
             flags.sortKey = -1;
             for (int j = 1; j <= Platform_numberOfFields; j++) {
-                printf("%s %d\n", Process_fields[j].name, j);
-                if(Process_fields[j].name == NULL) continue;
-                if (String_eq(optarg, Process_fields[j].name)) {
-                    flags.sortKey = j;
-                    break;
-                }
+               if(Process_fields[j].name == NULL) continue;
+               if (String_eq(optarg, Process_fields[j].name)) {
+                  flags.sortKey = j;
+                  break;
+               }
             }
             if (flags.sortKey == -1) {
                fprintf(stderr, "Error: invalid column \"%s\".\n", optarg);

--- a/htop.c
+++ b/htop.c
@@ -129,7 +129,15 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
                }
                exit(0);
             }
-            flags.sortKey = ColumnsPanel_fieldNameToIndex(optarg);
+            flags.sortKey = -1;
+            for (int j = 1; j <= Platform_numberOfFields; j++) {
+                printf("%s %d\n", Process_fields[j].name, j);
+                if(Process_fields[j].name == NULL) continue;
+                if (String_eq(optarg, Process_fields[j].name)) {
+                    flags.sortKey = j;
+                    break;
+                }
+            }
             if (flags.sortKey == -1) {
                fprintf(stderr, "Error: invalid column \"%s\".\n", optarg);
                exit(1);


### PR DESCRIPTION
Fix segmentation fault when column name is NULL when sorting argument is invalid column (ex: ./htop -s --help).

So, some columns (ex: SECATTR) can be sortable now.

NOTE: This is my first PR for htop-dev/htop.