### PR TITLE
Assert Vector_get returns an object

### DIFF
--- a/Panel.c
+++ b/Panel.c
@@ -261,7 +261,6 @@ void Panel_draw(Panel* this, bool focus) {
       int line = 0;
       for(int i = first; line < h && i < upTo; i++) {
          Object* itemObj = Vector_get(this->items, i);
-         assert(itemObj); if(!itemObj) continue;
          RichString_begin(item);
          Object_display(itemObj, &item);
          int itemLen = RichString_sizeVal(item);
@@ -288,7 +287,6 @@ void Panel_draw(Panel* this, bool focus) {
 
    } else {
       Object* oldObj = Vector_get(this->items, this->oldSelected);
-      assert(oldObj);
       RichString_begin(old);
       Object_display(oldObj, &old);
       int oldLen = RichString_sizeVal(old);

--- a/Vector.c
+++ b/Vector.c
@@ -65,8 +65,9 @@ int Vector_count(const Vector* this) {
 }
 
 Object* Vector_get(Vector* this, int idx) {
-   assert(idx < this->items);
+   assert(idx >= 0 && idx < this->items);
    assert(Vector_isConsistent(this));
+   assert(this->array[idx]);
    return this->array[idx];
 }
 


### PR DESCRIPTION
It is generally assumed Vector_get returns a non-NULL object.
Use a generic assert in Vector_get instead of in callers.

Spotted by @BenBE 