### PR TITLE
Handle data wraparounds in IO Meters

### DIFF
--- a/DiskIOMeter.c
+++ b/DiskIOMeter.c
@@ -53,14 +53,25 @@ static void DiskIOMeter_updateValues(Meter* this, char* buffer, int len) {
          return;
       }
 
-      cached_read_diff = (data.totalBytesRead - cached_read_total) / 1024; /* Meter_humanUnit() expects unit in kilo */
+      if (data.totalBytesRead > cached_read_total) {
+         cached_read_diff = (data.totalBytesRead - cached_read_total) / 1024; /* Meter_humanUnit() expects unit in kilo */
+      } else {
+         cached_read_diff = 0;
+      }
       cached_read_total = data.totalBytesRead;
 
-      cached_write_diff = (data.totalBytesWritten - cached_write_total) / 1024; /* Meter_humanUnit() expects unit in kilo */
+      if (data.totalBytesWritten > cached_write_total) {
+         cached_write_diff = (data.totalBytesWritten - cached_write_total) / 1024; /* Meter_humanUnit() expects unit in kilo */
+      } else {
+         cached_write_diff = 0;
+      }
       cached_write_total = data.totalBytesWritten;
 
-      cached_utilisation_diff = 100 * (double)(data.totalMsTimeSpend - cached_msTimeSpend_total) / passedTimeInMs;
-
+      if (data.totalMsTimeSpend > cached_msTimeSpend_total) {
+         cached_utilisation_diff = 100 * (double)(data.totalMsTimeSpend - cached_msTimeSpend_total) / passedTimeInMs;
+      } else {
+         cached_utilisation_diff = 0.0;
+      }
       cached_msTimeSpend_total = data.totalMsTimeSpend;
    }
 

--- a/NetworkIOMeter.c
+++ b/NetworkIOMeter.c
@@ -46,18 +46,34 @@ static void NetworkIOMeter_updateValues(ATTR_UNUSED Meter* this, char* buffer, i
          return;
       }
 
-      cached_rxb_diff = (bytesReceived - cached_rxb_total) / 1024; /* Meter_humanUnit() expects unit in kilo */
-      cached_rxb_diff = 1000.0 * cached_rxb_diff / passedTimeInMs; /* convert to per second */
+      if (bytesReceived > cached_rxb_total) {
+         cached_rxb_diff = (bytesReceived - cached_rxb_total) / 1024; /* Meter_humanUnit() expects unit in kilo */
+         cached_rxb_diff = 1000.0 * cached_rxb_diff / passedTimeInMs; /* convert to per second */
+      } else {
+         cached_rxb_diff = 0;
+      }
       cached_rxb_total = bytesReceived;
 
-      cached_rxp_diff = packetsReceived - cached_rxp_total;
+      if (packetsReceived > cached_rxp_total) {
+         cached_rxp_diff = packetsReceived - cached_rxp_total;
+      } else {
+         cached_rxp_diff = 0;
+      }
       cached_rxp_total = packetsReceived;
 
-      cached_txb_diff = (bytesTransmitted - cached_txb_total) / 1024; /* Meter_humanUnit() expects unit in kilo */
-      cached_txb_diff = 1000.0 * cached_txb_diff / passedTimeInMs; /* convert to per second */
+      if (bytesTransmitted > cached_txb_total) {
+         cached_txb_diff = (bytesTransmitted - cached_txb_total) / 1024; /* Meter_humanUnit() expects unit in kilo */
+         cached_txb_diff = 1000.0 * cached_txb_diff / passedTimeInMs; /* convert to per second */
+      } else {
+         cached_txb_diff = 0;
+      }
       cached_txb_total = bytesTransmitted;
 
-      cached_txp_diff = packetsTransmitted - cached_txp_total;
+      if (packetsTransmitted > cached_txp_total) {
+         cached_txp_diff = packetsTransmitted - cached_txp_total;
+      } else {
+         cached_txp_diff = 0;
+      }
       cached_txp_total = packetsTransmitted;
    }
 


### PR DESCRIPTION
If the current data is smaller than the previous one, either by a retrieve error
or a device removal or a original data wraparound, sanitize the value to zero.

Fixes: #299