### PR TITLE
Avoid calling Object_isA from inside Vector_isConsistent

### DIFF
--- a/Object.c
+++ b/Object.c
@@ -21,13 +21,10 @@ bool Object_isA(const Object* o, const ObjectClass* klass) {
    if (!o)
       return false;
 
-   const ObjectClass* type = o->klass;
-   while (type) {
+   for (const ObjectClass* type = o->klass; type; type = type->extends) {
       if (type == klass) {
          return true;
       }
-
-      type = type->extends;
    }
 
    return false;

--- a/Vector.c
+++ b/Vector.c
@@ -48,16 +48,16 @@ void Vector_delete(Vector* this) {
 
 static bool Vector_isConsistent(const Vector* this) {
    assert(this->items <= this->arraySize);
+
    if (this->owner) {
       for (int i = 0; i < this->items; i++) {
-         if (this->array[i] && !Object_isA(this->array[i], this->type)) {
+         if (!this->array[i]) {
             return false;
          }
       }
-      return true;
-   } else {
-      return true;
    }
+
+   return true;
 }
 
 int Vector_count(const Vector* this) {
@@ -71,10 +71,10 @@ int Vector_count(const Vector* this) {
    return items;
 }
 
-Object* Vector_get(Vector* this, int idx) {
+Object* Vector_get(const Vector* this, int idx) {
    assert(idx >= 0 && idx < this->items);
-   assert(Vector_isConsistent(this));
    assert(this->array[idx]);
+   assert(Object_isA(this->array[idx], this->type));
    return this->array[idx];
 }
 

--- a/Vector.h
+++ b/Vector.h
@@ -52,7 +52,7 @@ void Vector_set(Vector* this, int idx, void* data_);
 
 #ifndef NDEBUG
 
-Object* Vector_get(Vector* this, int idx);
+Object* Vector_get(const Vector* this, int idx);
 int Vector_size(const Vector* this);
 int Vector_count(const Vector* this);
 


### PR DESCRIPTION
This makes usage of `--enable-debug` somewhat bearable again.

Addresses #314 (probably still incomplete).
Basically drops `Object_isA` check from `Vector_isConsistent` as this gives O(n²) behaviour for most callers. Removes full consistency check from `Vector_get` to avoid O(n²) runtime there, but introduces `Object_isA` check on return value, so that all inserts and all fetches from the `Vector` perform storage type checking on accessed objects.

This still lacks the counterpart fixes for `Hashtable_isConsistent`, but given #277 is still pending similar precautions might better be addressed there instead.