### PR TITLE
LinuxProcessList: use openat instead of building path strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ jobs:
       run: ./autogen.sh
     - name: Configure
       run: ./configure --enable-werror --enable-linux-affinity --disable-unicode --disable-sensors
+    - name: Enable compatibility modes
+      run: |
+        sed -i 's/#define HAVE_FSTATAT 1/#undef HAVE_FSTATAT/g' config.h
+        sed -i 's/#define HAVE_OPENAT 1/#undef HAVE_OPENAT/g' config.h
+        sed -i 's/#define HAVE_READLINKAT 1/#undef HAVE_READLINKAT/g' config.h
     - name: Build
       run: make -k
     - name: Distcheck

--- a/Compat.c
+++ b/Compat.c
@@ -80,6 +80,20 @@ int Compat_fstatat(int dirfd,
 #endif
 }
 
+#ifndef HAVE_OPENAT
+
+int Compat_openat(const char* dirpath,
+                  const char* pathname,
+                  int flags) {
+
+   char path[4096];
+   xSnprintf(path, sizeof(path), "%s/%s", dirpath, pathname);
+
+   return open(path, flags);
+}
+
+#endif /* !HAVE_OPENAT */
+
 int Compat_readlinkat(int dirfd,
                       const char* dirpath,
                       const char* pathname,

--- a/Compat.h
+++ b/Compat.h
@@ -7,7 +7,11 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "config.h" // IWYU pragma: keep
+
+#include <fcntl.h>
 #include <stddef.h>
+#include <unistd.h>
 #include <sys/stat.h>
 
 
@@ -21,6 +25,30 @@ int Compat_fstatat(int dirfd,
                    const char* pathname,
                    struct stat* statbuf,
                    int flags);
+
+#ifdef HAVE_OPENAT
+
+typedef int openat_arg_t;
+
+static inline void Compat_openatArgClose(openat_arg_t dirfd) {
+   close(dirfd);
+}
+
+static inline int Compat_openat(openat_arg_t dirfd, const char* pathname, int flags) {
+   return openat(dirfd, pathname, flags);
+}
+
+#else /* HAVE_OPENAT */
+
+typedef const char* openat_arg_t;
+
+static inline void Compat_openatArgClose(openat_arg_t dirpath) {
+   (void)dirpath;
+}
+
+int Compat_openat(openat_arg_t dirpath, const char* pathname, int flags);
+
+#endif /* HAVE_OPENAT */
 
 int Compat_readlinkat(int dirfd,
                    const char* dirpath,

--- a/configure.ac
+++ b/configure.ac
@@ -92,7 +92,7 @@ AC_TYPE_UINT64_T
 # ----------------------------------------------------------------------
 AC_FUNC_CLOSEDIR_VOID
 AC_FUNC_STAT
-AC_CHECK_FUNCS([faccessat fstatat memmove readlinkat strdup strncasecmp strstr])
+AC_CHECK_FUNCS([faccessat fstatat memmove openat readlinkat strdup strncasecmp strstr])
 
 AC_SEARCH_LIBS([dlopen], [dl dld])
 

--- a/configure.ac
+++ b/configure.ac
@@ -92,7 +92,12 @@ AC_TYPE_UINT64_T
 # ----------------------------------------------------------------------
 AC_FUNC_CLOSEDIR_VOID
 AC_FUNC_STAT
-AC_CHECK_FUNCS([faccessat fstatat memmove openat readlinkat strdup strncasecmp strstr])
+AC_CHECK_FUNCS([\
+   faccessat\
+   fstatat\
+   openat\
+   readlinkat\
+])
 
 AC_SEARCH_LIBS([dlopen], [dl dld])
 


### PR DESCRIPTION
openat() is available since Linux 2.6.16