### PR TITLE
Minor cleanups to platform-specific init and done

### DIFF
--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -131,11 +131,20 @@ const MeterClass* const Platform_meterTypes[] = {
    NULL
 };
 
-void Platform_setBindings(Htop_Action* keys) {
-   (void) keys;
+int Platform_numberOfFields = 100;
+
+void Platform_init(void) {
+   /* no platform-specific setup needed */
 }
 
-int Platform_numberOfFields = 100;
+void Platform_done(void) {
+   /* no platform-specific cleanup needed */
+}
+
+void Platform_setBindings(Htop_Action* keys) {
+   /* no platform-specific key bindings */
+   (void) keys;
+}
 
 int Platform_getUptime() {
    struct timeval bootTime, currTime;

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -19,20 +19,23 @@ in the source distribution for its full text.
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
 
+extern ProcessFieldData Process_fields[];
 
 extern ProcessField Platform_defaultFields[];
+
+extern int Platform_numberOfFields;
 
 extern const SignalItem Platform_signals[];
 
 extern const unsigned int Platform_numberOfSignals;
 
-extern ProcessFieldData Process_fields[];
-
 extern const MeterClass* const Platform_meterTypes[];
 
-void Platform_setBindings(Htop_Action* keys);
+void Platform_init(void);
 
-extern int Platform_numberOfFields;
+void Platform_done(void);
+
+void Platform_setBindings(Htop_Action* keys);
 
 int Platform_getUptime(void);
 

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -74,10 +74,6 @@ const SignalItem Platform_signals[] = {
 
 const unsigned int Platform_numberOfSignals = ARRAYSIZE(Platform_signals);
 
-void Platform_setBindings(Htop_Action* keys) {
-   (void) keys;
-}
-
 const MeterClass* const Platform_meterTypes[] = {
    &CPUMeter_class,
    &ClockMeter_class,
@@ -106,6 +102,19 @@ const MeterClass* const Platform_meterTypes[] = {
    &BlankMeter_class,
    NULL
 };
+
+void Platform_init(void) {
+   /* no platform-specific setup needed */
+}
+
+void Platform_done(void) {
+   /* no platform-specific cleanup needed */
+}
+
+void Platform_setBindings(Htop_Action* keys) {
+   /* no platform-specific key bindings */
+   (void) keys;
+}
 
 int Platform_getUptime() {
    struct timeval bootTime, currTime;

--- a/dragonflybsd/Platform.h
+++ b/dragonflybsd/Platform.h
@@ -27,9 +27,13 @@ extern const SignalItem Platform_signals[];
 
 extern const unsigned int Platform_numberOfSignals;
 
-void Platform_setBindings(Htop_Action* keys);
-
 extern const MeterClass* const Platform_meterTypes[];
+
+void Platform_init(void);
+
+void Platform_done(void);
+
+void Platform_setBindings(Htop_Action* keys);
 
 int Platform_getUptime(void);
 

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -81,10 +81,6 @@ const SignalItem Platform_signals[] = {
 
 const unsigned int Platform_numberOfSignals = ARRAYSIZE(Platform_signals);
 
-void Platform_setBindings(Htop_Action* keys) {
-   (void) keys;
-}
-
 const MeterClass* const Platform_meterTypes[] = {
    &CPUMeter_class,
    &ClockMeter_class,
@@ -117,6 +113,19 @@ const MeterClass* const Platform_meterTypes[] = {
    &NetworkIOMeter_class,
    NULL
 };
+
+void Platform_init(void) {
+   /* no platform-specific setup needed */
+}
+
+void Platform_done(void) {
+   /* no platform-specific cleanup needed */
+}
+
+void Platform_setBindings(Htop_Action* keys) {
+   /* no platform-specific key bindings */
+   (void) keys;
+}
 
 int Platform_getUptime() {
    struct timeval bootTime, currTime;

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -26,9 +26,13 @@ extern const SignalItem Platform_signals[];
 
 extern const unsigned int Platform_numberOfSignals;
 
+extern const MeterClass* const Platform_meterTypes[];
+
 void Platform_setBindings(Htop_Action* keys);
 
-extern const MeterClass* const Platform_meterTypes[];
+void Platform_init(void);
+
+void Platform_done(void);
 
 int Platform_getUptime(void);
 

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -28,11 +28,11 @@ extern const unsigned int Platform_numberOfSignals;
 
 extern const MeterClass* const Platform_meterTypes[];
 
-void Platform_setBindings(Htop_Action* keys);
-
 void Platform_init(void);
 
 void Platform_done(void);
+
+void Platform_setBindings(Htop_Action* keys);
 
 int Platform_getUptime(void);
 

--- a/htop.c
+++ b/htop.c
@@ -35,18 +35,12 @@ in the source distribution for its full text.
 #include "UsersTable.h"
 #include "XUtils.h"
 
-
-#ifdef HAVE_LIBSENSORS
-#include <sensors/sensors.h>
-#endif
-
-
 static void printVersionFlag(void) {
-   fputs("htop " VERSION "\n", stdout);
+   fputs(PACKAGE " " VERSION "\n", stdout);
 }
 
 static void printHelpFlag(void) {
-   fputs("htop " VERSION "\n"
+   fputs(PACKAGE " " VERSION "\n"
          COPYRIGHT "\n"
          "Released under the GNU GPLv2.\n\n"
          "-C --no-color                   Use a monochrome color scheme\n"
@@ -63,8 +57,8 @@ static void printHelpFlag(void) {
          "-V --version                    Print version info\n"
          "\n"
          "Long options may be passed with a single dash.\n\n"
-         "Press F1 inside htop for online help.\n"
-         "See 'man htop' for more information.\n",
+         "Press F1 inside " PACKAGE " for online help.\n"
+         "See 'man " PACKAGE "' for more information.\n",
          stdout);
 }
 
@@ -270,22 +264,16 @@ static void setCommFilter(State* state, char** commFilter) {
 int main(int argc, char** argv) {
 
    char *lc_ctype = getenv("LC_CTYPE");
-   if (lc_ctype != NULL) {
+   if (lc_ctype != NULL)
       setlocale(LC_CTYPE, lc_ctype);
-   } else if ((lc_ctype = getenv("LC_ALL"))) {
+   else if ((lc_ctype = getenv("LC_ALL")))
       setlocale(LC_CTYPE, lc_ctype);
-   } else {
+   else
       setlocale(LC_CTYPE, "");
-   }
 
-   CommandLineSettings flags = parseArguments(argc, argv); // may exit()
+   CommandLineSettings flags = parseArguments(argc, argv);
 
-#ifdef HTOP_LINUX
-   if (access(PROCDIR, R_OK) != 0) {
-      fprintf(stderr, "Error: could not read procfs (compiled to look in %s).\n", PROCDIR);
-      exit(1);
-   }
-#endif
+   Platform_init();
 
    Process_setupColumnWidths();
 
@@ -299,30 +287,20 @@ int main(int argc, char** argv) {
 
    Header_populateFromSettings(header);
 
-   if (flags.delay != -1) {
+   if (flags.delay != -1)
       settings->delay = flags.delay;
-   }
-   if (!flags.useColors) {
+   if (!flags.useColors)
       settings->colorScheme = COLORSCHEME_MONOCHROME;
-   }
-   if (!flags.enableMouse) {
+   if (!flags.enableMouse)
       settings->enableMouse = false;
-   }
-   if (flags.treeView) {
+   if (flags.treeView)
       settings->treeView = true;
-   }
-   if (flags.highlightChanges) {
+   if (flags.highlightChanges)
       settings->highlightChanges = true;
-   }
-   if (flags.highlightDelaySecs != -1) {
+   if (flags.highlightDelaySecs != -1)
       settings->highlightDelaySecs = flags.highlightDelaySecs;
-   }
 
    CRT_init(settings->delay, settings->colorScheme, flags.allowUnicode);
-
-#ifdef HAVE_LIBSENSORS
-   sensors_init(NULL);
-#endif
 
    MainPanel* panel = MainPanel_new();
    ProcessList_setPanel(pl, (Panel*) panel);
@@ -346,9 +324,8 @@ int main(int argc, char** argv) {
    };
 
    MainPanel_setState(panel, &state);
-   if (flags.commFilter) {
+   if (flags.commFilter)
       setCommFilter(&state, &(flags.commFilter));
-   }
 
    ScreenManager* scr = ScreenManager_new(0, header->height, 0, -1, HORIZONTAL, header, settings, &state, true);
    ScreenManager_add(scr, (Panel*) panel, -1);
@@ -364,9 +341,7 @@ int main(int argc, char** argv) {
    attroff(CRT_colors[RESET_COLOR]);
    refresh();
 
-#ifdef HAVE_LIBSENSORS
-   sensors_cleanup();
-#endif
+   Platform_done();
 
    CRT_done();
    if (settings->changed)
@@ -380,8 +355,8 @@ int main(int argc, char** argv) {
    UsersTable_delete(ut);
    Settings_delete(settings);
 
-   if(flags.pidMatchList) {
+   if (flags.pidMatchList)
       Hashtable_delete(flags.pidMatchList);
-   }
+
    return 0;
 }

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -113,6 +113,7 @@ void Platform_init(void) {
       fprintf(stderr, "Error: could not read procfs (compiled to look in %s).\n", PROCDIR);
       exit(1);
    }
+
 #ifdef HAVE_LIBSENSORS
    sensors_init(NULL);
 #endif

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -26,9 +26,13 @@ extern const SignalItem Platform_signals[];
 
 extern const unsigned int Platform_numberOfSignals;
 
-void Platform_setBindings(Htop_Action* keys);
-
 extern const MeterClass* const Platform_meterTypes[];
+
+void Platform_init(void);
+
+void Platform_done(void);
+
+void Platform_setBindings(Htop_Action* keys);
 
 int Platform_getUptime(void);
 

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -89,10 +89,6 @@ const SignalItem Platform_signals[] = {
 
 const unsigned int Platform_numberOfSignals = ARRAYSIZE(Platform_signals);
 
-void Platform_setBindings(Htop_Action* keys) {
-   (void) keys;
-}
-
 const MeterClass* const Platform_meterTypes[] = {
    &CPUMeter_class,
    &ClockMeter_class,
@@ -121,6 +117,19 @@ const MeterClass* const Platform_meterTypes[] = {
    &BlankMeter_class,
    NULL
 };
+
+void Platform_init(void) {
+   /* no platform-specific setup needed */
+}
+
+void Platform_done(void) {
+   /* no platform-specific cleanup needed */
+}
+
+void Platform_setBindings(Htop_Action* keys) {
+   /* no platform-specific key bindings */
+   (void) keys;
+}
 
 // preserved from FreeBSD port
 int Platform_getUptime() {

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -28,9 +28,13 @@ extern const SignalItem Platform_signals[];
 
 extern const unsigned int Platform_numberOfSignals;
 
-void Platform_setBindings(Htop_Action* keys);
-
 extern const MeterClass* const Platform_meterTypes[];
+
+void Platform_init(void);
+
+void Platform_done(void);
+
+void Platform_setBindings(Htop_Action* keys);
 
 int Platform_getUptime(void);
 

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -119,13 +119,22 @@ const MeterClass* const Platform_meterTypes[] = {
    NULL
 };
 
-void Platform_setBindings(Htop_Action* keys) {
-   (void) keys;
-}
-
 int Platform_numberOfFields = LAST_PROCESSFIELD;
 
 extern char Process_pidFormat[20];
+
+void Platform_init(void) {
+   /* no platform-specific setup needed */
+}
+
+void Platform_done(void) {
+   /* no platform-specific cleanup needed */
+}
+
+void Platform_setBindings(Htop_Action* keys) {
+   /* no platform-specific key bindings */
+   (void) keys;
+}
 
 int Platform_getUptime() {
    int boot_time = 0;

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -45,11 +45,15 @@ extern ProcessField Platform_defaultFields[];
 
 extern const MeterClass* const Platform_meterTypes[];
 
-void Platform_setBindings(Htop_Action* keys);
-
 extern int Platform_numberOfFields;
 
 extern char Process_pidFormat[20];
+
+void Platform_init(void);
+
+void Platform_done(void);
+
+void Platform_setBindings(Htop_Action* keys);
 
 int Platform_getUptime(void);
 

--- a/unsupported/Platform.c
+++ b/unsupported/Platform.c
@@ -88,17 +88,24 @@ const MeterClass* const Platform_meterTypes[] = {
    NULL
 };
 
-void Platform_setBindings(Htop_Action* keys) {
-   (void) keys;
-}
-
 int Platform_numberOfFields = 100;
-
-extern char Process_pidFormat[20];
 
 ProcessPidColumn Process_pidColumns[] = {
    { .id = 0, .label = NULL },
 };
+
+void Platform_init(void) {
+   /* no platform-specific setup needed */
+}
+
+void Platform_done(void) {
+   /* no platform-specific cleanup needed */
+}
+
+void Platform_setBindings(Htop_Action* keys) {
+   /* no platform-specific key bindings */
+   (void) keys;
+}
 
 int Platform_getUptime() {
    return 0;

--- a/unsupported/Platform.h
+++ b/unsupported/Platform.h
@@ -25,13 +25,17 @@ extern ProcessFieldData Process_fields[];
 
 extern const MeterClass* const Platform_meterTypes[];
 
-void Platform_setBindings(Htop_Action* keys);
-
 extern int Platform_numberOfFields;
 
 extern char Process_pidFormat[20];
 
 extern ProcessPidColumn Process_pidColumns[];
+
+void Platform_init(void);
+
+void Platform_done(void);
+
+void Platform_setBindings(Htop_Action* keys);
 
 int Platform_getUptime(void);
 


### PR DESCRIPTION
Move platform-specific code out of the htop.c main function
and into the platform sub-directories - primarily this is
the Linux procfs path check and sensors setup/teardown; not
needed on any other platforms.  No functional changes here.