### PR TITLE
Revamp keyboard input

### DIFF
--- a/AvailableColumnsPanel.c
+++ b/AvailableColumnsPanel.c
@@ -53,7 +53,7 @@ static HandlerResult AvailableColumnsPanel_eventHandler(Panel* super, int ch) {
       }
       default:
       {
-         if (0 < ch && ch < 255 && isalpha((unsigned char)ch))
+         if (0 < ch && ch < 255 && isgraph((unsigned char)ch))
             result = Panel_selectByTyping(super, ch);
          break;
       }

--- a/CategoriesPanel.c
+++ b/CategoriesPanel.c
@@ -87,7 +87,7 @@ static HandlerResult CategoriesPanel_eventHandler(Panel* super, int ch) {
          break;
       }
       default:
-         if (0 < ch && ch < 255 && isalpha((unsigned char)ch))
+         if (0 < ch && ch < 255 && isgraph((unsigned char)ch))
             result = Panel_selectByTyping(super, ch);
          if (result == BREAK_LOOP)
             result = IGNORED;

--- a/ColumnsPanel.c
+++ b/ColumnsPanel.c
@@ -95,7 +95,7 @@ static HandlerResult ColumnsPanel_eventHandler(Panel* super, int ch) {
       }
       default:
       {
-         if (0 < ch && ch < 255 && isalpha((unsigned char)ch))
+         if (0 < ch && ch < 255 && isgraph((unsigned char)ch))
             result = Panel_selectByTyping(super, ch);
          if (result == BREAK_LOOP)
             result = IGNORED;

--- a/InfoScreen.c
+++ b/InfoScreen.c
@@ -144,8 +144,8 @@ void InfoScreen_run(InfoScreen* this) {
          clear();
          InfoScreen_draw(this);
          break;
-      case 'q':
       case 27:
+      case 'q':
       case KEY_F(10):
          looping = false;
          break;

--- a/Panel.c
+++ b/Panel.c
@@ -430,7 +430,7 @@ HandlerResult Panel_selectByTyping(Panel* this, int ch) {
       this->eventHandlerState = xCalloc(100, sizeof(char));
    char* buffer = this->eventHandlerState;
 
-   if (0 < ch && ch < 255 && isalnum((unsigned char)ch)) {
+   if (0 < ch && ch < 255 && isgraph((unsigned char)ch)) {
       int len = strlen(buffer);
       if (!len) {
          if ('/' == ch) {

--- a/Panel.c
+++ b/Panel.c
@@ -330,22 +330,20 @@ bool Panel_onKey(Panel* this, int key) {
    switch (key) {
    case KEY_DOWN:
    case KEY_CTRL('N'):
-      this->selected++;
-      break;
-   case KEY_UP:
-   case KEY_CTRL('P'):
-      this->selected--;
-      break;
    #ifdef KEY_C_DOWN
    case KEY_C_DOWN:
+   #endif
       this->selected++;
       break;
-   #endif
+
+   case KEY_UP:
+   case KEY_CTRL('P'):
    #ifdef KEY_C_UP
    case KEY_C_UP:
+   #endif
       this->selected--;
       break;
-   #endif
+
    case KEY_LEFT:
    case KEY_CTRL('B'):
       if (this->scrollH > 0) {

--- a/Panel.c
+++ b/Panel.c
@@ -327,6 +327,10 @@ bool Panel_onKey(Panel* this, int key) {
    assert (this != NULL);
 
    int size = Vector_size(this->items);
+
+   #define CLAMP_INDEX(var, delta, min, max) \
+      CLAMP((var) + (delta), (min), MAXIMUM(0, (max)))
+
    switch (key) {
    case KEY_DOWN:
    case KEY_CTRL('N'):
@@ -358,27 +362,23 @@ bool Panel_onKey(Panel* this, int key) {
       break;
    case KEY_PPAGE:
       this->selected -= (this->h - 1);
-      this->scrollV = MAXIMUM(0, this->scrollV - this->h + 1);
+      this->scrollV = CLAMP_INDEX(this->scrollV, -(this->h - 1), 0, size - this->h);
       this->needsRedraw = true;
       break;
    case KEY_NPAGE:
       this->selected += (this->h - 1);
-      this->scrollV = MAXIMUM(0, MINIMUM(Vector_size(this->items) - this->h,
-                                 this->scrollV + this->h - 1));
+      this->scrollV = CLAMP_INDEX(this->scrollV, +(this->h - 1), 0, size - this->h);
       this->needsRedraw = true;
       break;
    case KEY_WHEELUP:
       this->selected -= CRT_scrollWheelVAmount;
-      this->scrollV -= CRT_scrollWheelVAmount;
+      this->scrollV = CLAMP_INDEX(this->scrollV, -CRT_scrollWheelVAmount, 0, size - this->h);
       this->needsRedraw = true;
       break;
    case KEY_WHEELDOWN:
    {
       this->selected += CRT_scrollWheelVAmount;
-      this->scrollV += CRT_scrollWheelVAmount;
-      if (this->scrollV > Vector_size(this->items) - this->h) {
-         this->scrollV = Vector_size(this->items) - this->h;
-      }
+      this->scrollV = CLAMP_INDEX(this->scrollV, +CRT_scrollWheelVAmount, 0, size - this->h);
       this->needsRedraw = true;
       break;
    }
@@ -401,6 +401,8 @@ bool Panel_onKey(Panel* this, int key) {
    default:
       return false;
    }
+
+   #undef CLAMP_INDEX
 
    // ensure selection within bounds
    if (this->selected < 0 || size == 0) {

--- a/Panel.c
+++ b/Panel.c
@@ -355,39 +355,45 @@ bool Panel_onKey(Panel* this, int key) {
          this->needsRedraw = true;
       }
       break;
+
    case KEY_RIGHT:
    case KEY_CTRL('F'):
       this->scrollH += CRT_scrollHAmount;
       this->needsRedraw = true;
       break;
+
    case KEY_PPAGE:
       this->selected -= (this->h - 1);
       this->scrollV = CLAMP_INDEX(this->scrollV, -(this->h - 1), 0, size - this->h);
       this->needsRedraw = true;
       break;
+
    case KEY_NPAGE:
       this->selected += (this->h - 1);
       this->scrollV = CLAMP_INDEX(this->scrollV, +(this->h - 1), 0, size - this->h);
       this->needsRedraw = true;
       break;
+
    case KEY_WHEELUP:
       this->selected -= CRT_scrollWheelVAmount;
       this->scrollV = CLAMP_INDEX(this->scrollV, -CRT_scrollWheelVAmount, 0, size - this->h);
       this->needsRedraw = true;
       break;
+
    case KEY_WHEELDOWN:
-   {
       this->selected += CRT_scrollWheelVAmount;
       this->scrollV = CLAMP_INDEX(this->scrollV, +CRT_scrollWheelVAmount, 0, size - this->h);
       this->needsRedraw = true;
       break;
-   }
+
    case KEY_HOME:
       this->selected = 0;
       break;
+
    case KEY_END:
       this->selected = size - 1;
       break;
+
    case KEY_CTRL('A'):
    case '^':
       this->scrollH = 0;
@@ -412,12 +418,14 @@ bool Panel_onKey(Panel* this, int key) {
       this->selected = size - 1;
       this->needsRedraw = true;
    }
+
    return true;
 }
 
 
 HandlerResult Panel_selectByTyping(Panel* this, int ch) {
    int size = Panel_size(this);
+
    if (!this->eventHandlerState)
       this->eventHandlerState = xCalloc(100, sizeof(char));
    char* buffer = this->eventHandlerState;
@@ -438,17 +446,21 @@ HandlerResult Panel_selectByTyping(Panel* this, int ch) {
                return HANDLED;
             }
          }
+
          // if current word did not match,
          // retry considering the character the start of a new word.
          buffer[0] = ch;
          buffer[1] = '\0';
       }
+
       return HANDLED;
    } else if (ch != ERR) {
       buffer[0] = '\0';
    }
+
    if (ch == 13) {
       return BREAK_LOOP;
    }
+
    return IGNORED;
 }

--- a/Panel.c
+++ b/Panel.c
@@ -432,10 +432,21 @@ HandlerResult Panel_selectByTyping(Panel* this, int ch) {
 
    if (0 < ch && ch < 255 && isalnum((unsigned char)ch)) {
       int len = strlen(buffer);
+      if (!len) {
+         if ('/' == ch) {
+            ch = '\001';
+         } else if ('q' == ch) {
+            return BREAK_LOOP;
+         }
+      } else if (1 == len && '\001' == buffer[0]) {
+         len--;
+      }
+
       if (len < 99) {
          buffer[len] = ch;
          buffer[len+1] = '\0';
       }
+
       for (int try = 0; try < 2; try++) {
          len = strlen(buffer);
          for (int i = 0; i < size; i++) {

--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -296,9 +296,9 @@ tryRight:
          }
 
          break;
-      case KEY_F(10):
-      case 'q':
       case 27:
+      case 'q':
+      case KEY_F(10):
          quit = true;
          continue;
       default:

--- a/htop.1.in
+++ b/htop.1.in
@@ -141,6 +141,10 @@ select which columns are displayed, in which order.
 Incrementally search the command lines of all the displayed processes. The
 currently selected (highlighted) command will update as you type. While in
 search mode, pressing F3 will cycle through matching occurrences.
+
+Alternatively the search can be started by simply typing the command
+you are looking for, although for the first character normal key
+bindings take precedence.
 .TP
 .B F4, \\\\
 Incremental process filtering: type in part of a process command line and


### PR DESCRIPTION
This cleans up the keyboard input stuff somewhat and allows for using 'q' to exit any of the info screens.

The downside is, that this interferes with the inline search, thus searching for anything that starts with 'q' is no longer possible.