### PR TITLE
Hide process selection on ESC

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -341,7 +341,7 @@ static Htop_Reaction actionKill(State* st) {
    if (sgn) {
       if (sgn->key != 0) {
          Panel_setHeader(st->panel, "Sending...");
-         Panel_draw(st->panel, true);
+         Panel_draw(st->panel, true, true);
          refresh();
          MainPanel_foreachProcess((MainPanel*)st->panel, Process_sendSignal, (Arg) { .i = sgn->key }, NULL);
          napms(500);

--- a/Action.h
+++ b/Action.h
@@ -38,6 +38,7 @@ typedef struct State_ {
    Panel* panel;
    Header* header;
    bool pauseProcessUpdate;
+   bool hideProcessSelection;
 } State;
 
 typedef Htop_Reaction (*Htop_Action)(State* st);

--- a/InfoScreen.c
+++ b/InfoScreen.c
@@ -55,7 +55,7 @@ void InfoScreen_drawTitled(InfoScreen* this, const char* fmt, ...) {
    mvwprintw(stdscr, 0, 0, title);
    attrset(CRT_colors[DEFAULT_COLOR]);
    this->display->needsRedraw = true;
-   Panel_draw(this->display, true);
+   Panel_draw(this->display, true, true);
    IncSet_drawBar(this->inc);
    free(title);
    va_end(ap);
@@ -89,7 +89,7 @@ void InfoScreen_run(InfoScreen* this) {
    bool looping = true;
    while (looping) {
 
-      Panel_draw(panel, true);
+      Panel_draw(panel, true, true);
 
       if (this->inc->active) {
          (void) move(LINES - 1, CRT_cursorX);

--- a/MainPanel.c
+++ b/MainPanel.c
@@ -57,6 +57,9 @@ static HandlerResult MainPanel_eventHandler(Panel* super, int ch) {
 
    Htop_Reaction reaction = HTOP_OK;
 
+   if (ch != ERR)
+      this->state->hideProcessSelection = false;
+
    if (EVENT_IS_HEADER_CLICK(ch)) {
       int x = EVENT_HEADER_CLICK_GET_X(ch);
       const ProcessList* pl = this->state->pl;
@@ -83,6 +86,7 @@ static HandlerResult MainPanel_eventHandler(Panel* super, int ch) {
       }
       result = HANDLED;
    } else if (ch == 27) {
+      this->state->hideProcessSelection = true;
       return HANDLED;
    } else if (ch != ERR && ch > 0 && ch < KEY_MAX && this->keys[ch]) {
       reaction |= (this->keys[ch])(this->state);

--- a/Panel.c
+++ b/Panel.c
@@ -217,7 +217,7 @@ void Panel_splice(Panel* this, Vector* from) {
    this->needsRedraw = true;
 }
 
-void Panel_draw(Panel* this, bool focus) {
+void Panel_draw(Panel* this, bool focus, bool highlightSelected) {
    assert (this != NULL);
 
    int size = Vector_size(this->items);
@@ -273,7 +273,7 @@ void Panel_draw(Panel* this, bool focus) {
          Object_display(itemObj, &item);
          int itemLen = RichString_sizeVal(item);
          int amt = MINIMUM(itemLen - scrollH, this->w);
-         if (i == this->selected) {
+         if (highlightSelected && i == this->selected) {
             item.highlightAttr = selectionColor;
          }
          if (item.highlightAttr) {

--- a/Panel.h
+++ b/Panel.h
@@ -109,7 +109,7 @@ int Panel_size(Panel* this);
 
 void Panel_setSelected(Panel* this, int selected);
 
-void Panel_draw(Panel* this, bool focus);
+void Panel_draw(Panel* this, bool focus, bool highlightSelected);
 
 void Panel_splice(Panel* this, Vector* from);
 

--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -123,7 +123,7 @@ static void ScreenManager_drawPanels(ScreenManager* this, int focus) {
    const int nPanels = this->panelCount;
    for (int i = 0; i < nPanels; i++) {
       Panel* panel = (Panel*) Vector_get(this->panels, i);
-      Panel_draw(panel, i == focus);
+      Panel_draw(panel, i == focus, !((panel == this->state->panel) && this->state->hideProcessSelection));
       mvvline(panel->y, panel->x + panel->w, ' ', panel->h + 1);
    }
 }

--- a/htop.c
+++ b/htop.c
@@ -320,6 +320,7 @@ int main(int argc, char** argv) {
       .panel = (Panel*) panel,
       .header = header,
       .pauseProcessUpdate = false,
+      .hideProcessSelection = false,
    };
 
    MainPanel_setState(panel, &state);


### PR DESCRIPTION
Do not highlight the current process line after pressing ESC in the main
screen.
Restore after pressing any key.

Normal:
![pre](https://user-images.githubusercontent.com/6131885/99999374-57816280-2dc0-11eb-92d3-9112d2cd674a.jpg)

After ESC:
![post](https://user-images.githubusercontent.com/6131885/99999380-5a7c5300-2dc0-11eb-8d90-da18093d115a.jpg)

