### PR TITLE
Drop unneeded parameters to the ScreenManager constructor

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -46,7 +46,7 @@ Object* Action_pickFromVector(State* st, Panel* list, int x, bool followProcess)
    Settings* settings = st->settings;
 
    int y = panel->y;
-   ScreenManager* scr = ScreenManager_new(0, header->height, 0, -1, HORIZONTAL, header, settings, st, false);
+   ScreenManager* scr = ScreenManager_new(header, settings, st, false);
    scr->allowFocusChange = false;
    ScreenManager_add(scr, list, x - 1);
    ScreenManager_add(scr, panel, -1);
@@ -83,7 +83,7 @@ Object* Action_pickFromVector(State* st, Panel* list, int x, bool followProcess)
 // ----------------------------------------
 
 static void Action_runSetup(State* st) {
-   ScreenManager* scr = ScreenManager_new(0, st->header->height, 0, -1, HORIZONTAL, st->header, st->settings, st, true);
+   ScreenManager* scr = ScreenManager_new(st->header, st->settings, st, true);
    CategoriesPanel* panelCategories = CategoriesPanel_new(scr, st->settings, st->header, st->pl);
    ScreenManager_add(scr, (Panel*) panelCategories, 16);
    CategoriesPanel_makeMetersPage(panelCategories);

--- a/Header.h
+++ b/Header.h
@@ -15,7 +15,7 @@ in the source distribution for its full text.
 typedef struct Header_ {
    Vector** columns;
    Settings* settings;
-   struct ProcessList_* pl;
+   ProcessList* pl;
    int nrColumns;
    int pad;
    int height;
@@ -23,7 +23,7 @@ typedef struct Header_ {
 
 #define Header_forEachColumn(this_, i_) for (int (i_)=0; (i_) < (this_)->nrColumns; ++(i_))
 
-Header* Header_new(struct ProcessList_* pl, Settings* settings, int nrColumns);
+Header* Header_new(ProcessList* pl, Settings* settings, int nrColumns);
 
 void Header_delete(Header* this);
 

--- a/ScreenManager.h
+++ b/ScreenManager.h
@@ -16,17 +16,11 @@ in the source distribution for its full text.
 #include "Vector.h"
 
 
-typedef enum Orientation_ {
-   VERTICAL,
-   HORIZONTAL
-} Orientation;
-
 typedef struct ScreenManager_ {
    int x1;
    int y1;
    int x2;
    int y2;
-   Orientation orientation;
    Vector* panels;
    int panelCount;
    Header* header;
@@ -36,7 +30,7 @@ typedef struct ScreenManager_ {
    bool allowFocusChange;
 } ScreenManager;
 
-ScreenManager* ScreenManager_new(int x1, int y1, int x2, int y2, Orientation orientation, Header* header, const Settings* settings, const State* state, bool owner);
+ScreenManager* ScreenManager_new(Header* header, const Settings* settings, const State* state, bool owner);
 
 void ScreenManager_delete(ScreenManager* this);
 

--- a/htop.c
+++ b/htop.c
@@ -326,7 +326,7 @@ int main(int argc, char** argv) {
    if (flags.commFilter)
       setCommFilter(&state, &(flags.commFilter));
 
-   ScreenManager* scr = ScreenManager_new(0, header->height, 0, -1, HORIZONTAL, header, settings, &state, true);
+   ScreenManager* scr = ScreenManager_new(header, settings, &state, true);
    ScreenManager_add(scr, (Panel*) panel, -1);
 
    ProcessList_scan(pl, false);


### PR DESCRIPTION
All calls to ScreenManager_new always pass the same first
five values, the orientation is always HORIZONTAL and the
y1 parameter is always the height of the passed-in header
struct pointer.  I think its safe to assert at this point
that no VERTICAL orientation will arrive (if it does, its
no harm in re-adding this then) - so we can remove unused
conditionals (and TODOs) based on orientation too.