### PR TITLE
Drop unused global ProcessList memory fields

### DIFF
--- a/ProcessList.h
+++ b/ProcessList.h
@@ -60,8 +60,6 @@ typedef struct ProcessList_ {
 
    unsigned long long int totalMem;
    unsigned long long int usedMem;
-   unsigned long long int freeMem;
-   unsigned long long int sharedMem;
    unsigned long long int buffersMem;
    unsigned long long int cachedMem;
    unsigned long long int totalSwap;

--- a/dragonflybsd/DragonFlyBSDProcessList.c
+++ b/dragonflybsd/DragonFlyBSDProcessList.c
@@ -253,12 +253,6 @@ static inline void DragonFlyBSDProcessList_scanMemoryInfo(ProcessList* pl) {
    pl->cachedMem *= pageSizeKb;
    pl->usedMem = dfpl->memActive + dfpl->memWire;
 
-   //currently unused, same as with arc, custom meter perhaps
-   //sysctl(MIB_vm_stats_vm_v_inactive_count, 4, &(dfpl->memInactive), &len, NULL, 0);
-   //sysctl(MIB_vm_stats_vm_v_free_count, 4, &(dfpl->memFree), &len, NULL, 0);
-   //pl->freeMem  = dfpl->memInactive + dfpl->memFree;
-   //pl->freeMem *= pageSizeKb;
-
    struct kvm_swap swap[16];
    int nswap = kvm_getswapinfo(dfpl->kd, swap, ARRAYSIZE(swap), 0);
    pl->totalSwap = 0;
@@ -269,8 +263,6 @@ static inline void DragonFlyBSDProcessList_scanMemoryInfo(ProcessList* pl) {
    }
    pl->totalSwap *= pageSizeKb;
    pl->usedSwap *= pageSizeKb;
-
-   pl->sharedMem = 0;  // currently unused
 }
 
 char* DragonFlyBSDProcessList_readProcessName(kvm_t* kd, struct kinfo_proc* kproc, int* basenameEnd) {

--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -314,12 +314,6 @@ static inline void FreeBSDProcessList_scanMemoryInfo(ProcessList* pl) {
 
    pl->usedMem = fpl->memActive + fpl->memWire;
 
-   //currently unused, same as with arc, custom meter perhaps
-   //sysctl(MIB_vm_stats_vm_v_inactive_count, 4, &(fpl->memInactive), &len, NULL, 0);
-   //sysctl(MIB_vm_stats_vm_v_free_count, 4, &(fpl->memFree), &len, NULL, 0);
-   //pl->freeMem  = fpl->memInactive + fpl->memFree;
-   //pl->freeMem *= pageSizeKb;
-
    struct kvm_swap swap[16];
    int nswap = kvm_getswapinfo(fpl->kd, swap, ARRAYSIZE(swap), 0);
    pl->totalSwap = 0;
@@ -330,8 +324,6 @@ static inline void FreeBSDProcessList_scanMemoryInfo(ProcessList* pl) {
    }
    pl->totalSwap *= pageSizeKb;
    pl->usedSwap *= pageSizeKb;
-
-   pl->sharedMem = 0;  // currently unused
 }
 
 static void FreeBSDProcessList_scanTTYs(ProcessList* pl) {

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -1502,6 +1502,7 @@ errorReadingProcess:
 }
 
 static inline void LinuxProcessList_scanMemoryInfo(ProcessList* this) {
+   unsigned long long int freeMem = 0;
    unsigned long long int swapFree = 0;
    unsigned long long int shmem = 0;
    unsigned long long int sreclaimable = 0;
@@ -1522,8 +1523,7 @@ static inline void LinuxProcessList_scanMemoryInfo(ProcessList* this) {
       switch (buffer[0]) {
       case 'M':
          tryRead("MemTotal:", &this->totalMem);
-         tryRead("MemFree:", &this->freeMem);
-         tryRead("MemShared:", &this->sharedMem);
+         tryRead("MemFree:", &freeMem);
          break;
       case 'B':
          tryRead("Buffers:", &this->buffersMem);
@@ -1549,7 +1549,7 @@ static inline void LinuxProcessList_scanMemoryInfo(ProcessList* this) {
       #undef tryRead
    }
 
-   this->usedMem = this->totalMem - this->freeMem;
+   this->usedMem = this->totalMem - freeMem;
    this->cachedMem = this->cachedMem + sreclaimable - shmem;
    this->usedSwap = this->totalSwap - swapFree;
    fclose(file);

--- a/openbsd/OpenBSDProcessList.c
+++ b/openbsd/OpenBSDProcessList.c
@@ -103,7 +103,6 @@ static inline void OpenBSDProcessList_scanMemoryInfo(ProcessList* pl) {
    }
 
    pl->cachedMem = bcstats.numbufpages * CRT_pageSizeKB;
-   pl->freeMem = uvmexp.free * CRT_pageSizeKB;
    pl->usedMem = (uvmexp.npages - uvmexp.free - uvmexp.paging) * CRT_pageSizeKB;
 
    /*
@@ -114,7 +113,6 @@ static inline void OpenBSDProcessList_scanMemoryInfo(ProcessList* pl) {
    pl->totalMem /= 1024;
    sysctl(MIB_vm_stats_vm_v_wire_count, 4, &(pl->usedMem), &len, NULL, 0);
    pl->usedMem *= CRT_pageSizeKB;
-   pl->freeMem = pl->totalMem - pl->usedMem;
    sysctl(MIB_vm_stats_vm_v_cache_count, 4, &(pl->cachedMem), &len, NULL, 0);
    pl->cachedMem *= CRT_pageSizeKB;
 
@@ -129,7 +127,6 @@ static inline void OpenBSDProcessList_scanMemoryInfo(ProcessList* pl) {
    pl->totalSwap *= CRT_pageSizeKB;
    pl->usedSwap *= CRT_pageSizeKB;
 
-   pl->sharedMem = 0;  // currently unused
    pl->buffersMem = 0; // not exposed to userspace
    */
 }


### PR DESCRIPTION
The global ProcessList structure contains a couple of unused
fields.  'sharedMem' has never been used by any Meter, since
its not been anything other than zero in Linux /proc/meminfo
for many, many years.  The freeMem field is only used in the
usedMem calculation, so it can reside on the stack like some
other memory variables used within-calculations-only and not
exposed to the user via a Meter.