### PR TITLE
Install app icon in hicolor icon theme

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,8 +7,8 @@ EXTRA_DIST = $(dist_man_MANS) htop.desktop htop.png \
 install-sh autogen.sh missing
 applicationsdir = $(datadir)/applications
 applications_DATA = htop.desktop
-pixmapdir = $(datadir)/pixmaps
-pixmap_DATA = htop.png
+icon128dir = $(datadir)/icons/hicolor/128x128/apps
+icon128_DATA = htop.png
 
 AM_CFLAGS += -pedantic -std=c99 -D_XOPEN_SOURCE_EXTENDED -DSYSCONFDIR=\"$(sysconfdir)\" -I"$(top_srcdir)/$(my_htop_platform)"
 AM_LDFLAGS =


### PR DESCRIPTION
Switch the install location of the application icon from the legacy pixmaps location to the global hicolor icon theme (following the size of the icon).