### PR TITLE
Print G in gigabyte color

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -101,8 +101,9 @@ void Process_humanNumber(RichString* str, unsigned long long number, bool colori
       len = xSnprintf(buffer, sizeof(buffer), "%2llu", number/10);
       RichString_appendn(str, processGigabytesColor, buffer, len);
       number %= 10;
-      len = xSnprintf(buffer, sizeof(buffer), ".%1lluG ", number);
+      len = xSnprintf(buffer, sizeof(buffer), ".%1llu", number);
       RichString_appendn(str, processMegabytesColor, buffer, len);
+      RichString_append(str, processGigabytesColor, "G ");
    } else if (number < 1000 * ONE_M) {
       //3 digit GB
       number /= ONE_M;


### PR DESCRIPTION
When printing a size like 27.2G print the G like the 27 in the gigabyte color.