### PR TITLE
Split RichString_(append|appendn|write) into wide and ascii

### DIFF
--- a/AffinityPanel.c
+++ b/AffinityPanel.c
@@ -59,25 +59,25 @@ static void MaskItem_delete(Object* cast) {
 static void MaskItem_display(const Object* cast, RichString* out) {
    const MaskItem* this = (const MaskItem*)cast;
    assert (this != NULL);
-   RichString_append(out, CRT_colors[CHECK_BOX], "[");
+   RichString_appendAscii(out, CRT_colors[CHECK_BOX], "[");
    if (this->value == 2) {
-      RichString_append(out, CRT_colors[CHECK_MARK], "x");
+      RichString_appendAscii(out, CRT_colors[CHECK_MARK], "x");
    } else if (this->value == 1) {
-      RichString_append(out, CRT_colors[CHECK_MARK], "o");
+      RichString_appendAscii(out, CRT_colors[CHECK_MARK], "o");
    } else {
-      RichString_append(out, CRT_colors[CHECK_MARK], " ");
+      RichString_appendAscii(out, CRT_colors[CHECK_MARK], " ");
    }
-   RichString_append(out, CRT_colors[CHECK_BOX], "]");
-   RichString_append(out, CRT_colors[CHECK_TEXT], " ");
+   RichString_appendAscii(out, CRT_colors[CHECK_BOX], "]");
+   RichString_appendAscii(out, CRT_colors[CHECK_TEXT], " ");
    if (this->indent) {
-      RichString_append(out, CRT_colors[PROCESS_TREE], this->indent);
-      RichString_append(out, CRT_colors[PROCESS_TREE],
-                        this->sub_tree == 2
-                        ? CRT_treeStr[TREE_STR_OPEN]
-                        : CRT_treeStr[TREE_STR_SHUT]);
-      RichString_append(out, CRT_colors[CHECK_TEXT], " ");
+      RichString_appendWide(out, CRT_colors[PROCESS_TREE], this->indent);
+      RichString_appendWide(out, CRT_colors[PROCESS_TREE],
+                            this->sub_tree == 2
+                            ? CRT_treeStr[TREE_STR_OPEN]
+                            : CRT_treeStr[TREE_STR_SHUT]);
+      RichString_appendAscii(out, CRT_colors[CHECK_TEXT], " ");
    }
-   RichString_append(out, CRT_colors[CHECK_TEXT], this->text);
+   RichString_appendWide(out, CRT_colors[CHECK_TEXT], this->text);
 }
 
 static const ObjectClass MaskItem_class = {

--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -104,49 +104,49 @@ static void CPUMeter_display(const Object* cast, RichString* out) {
    const Meter* this = (const Meter*)cast;
    RichString_prune(out);
    if (this->param > this->pl->cpuCount) {
-      RichString_append(out, CRT_colors[METER_TEXT], "absent");
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], "absent");
       return;
    }
    xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_NORMAL]);
-   RichString_append(out, CRT_colors[METER_TEXT], ":");
-   RichString_append(out, CRT_colors[CPU_NORMAL], buffer);
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], ":");
+   RichString_appendAscii(out, CRT_colors[CPU_NORMAL], buffer);
    if (this->pl->settings->detailedCPUTime) {
       xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_KERNEL]);
-      RichString_append(out, CRT_colors[METER_TEXT], "sy:");
-      RichString_append(out, CRT_colors[CPU_SYSTEM], buffer);
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], "sy:");
+      RichString_appendAscii(out, CRT_colors[CPU_SYSTEM], buffer);
       xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_NICE]);
-      RichString_append(out, CRT_colors[METER_TEXT], "ni:");
-      RichString_append(out, CRT_colors[CPU_NICE_TEXT], buffer);
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], "ni:");
+      RichString_appendAscii(out, CRT_colors[CPU_NICE_TEXT], buffer);
       xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_IRQ]);
-      RichString_append(out, CRT_colors[METER_TEXT], "hi:");
-      RichString_append(out, CRT_colors[CPU_IRQ], buffer);
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], "hi:");
+      RichString_appendAscii(out, CRT_colors[CPU_IRQ], buffer);
       xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_SOFTIRQ]);
-      RichString_append(out, CRT_colors[METER_TEXT], "si:");
-      RichString_append(out, CRT_colors[CPU_SOFTIRQ], buffer);
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], "si:");
+      RichString_appendAscii(out, CRT_colors[CPU_SOFTIRQ], buffer);
       if (!isnan(this->values[CPU_METER_STEAL])) {
          xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_STEAL]);
-         RichString_append(out, CRT_colors[METER_TEXT], "st:");
-         RichString_append(out, CRT_colors[CPU_STEAL], buffer);
+         RichString_appendAscii(out, CRT_colors[METER_TEXT], "st:");
+         RichString_appendAscii(out, CRT_colors[CPU_STEAL], buffer);
       }
       if (!isnan(this->values[CPU_METER_GUEST])) {
          xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_GUEST]);
-         RichString_append(out, CRT_colors[METER_TEXT], "gu:");
-         RichString_append(out, CRT_colors[CPU_GUEST], buffer);
+         RichString_appendAscii(out, CRT_colors[METER_TEXT], "gu:");
+         RichString_appendAscii(out, CRT_colors[CPU_GUEST], buffer);
       }
       xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_IOWAIT]);
-      RichString_append(out, CRT_colors[METER_TEXT], "wa:");
-      RichString_append(out, CRT_colors[CPU_IOWAIT], buffer);
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], "wa:");
+      RichString_appendAscii(out, CRT_colors[CPU_IOWAIT], buffer);
    } else {
       xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_KERNEL]);
-      RichString_append(out, CRT_colors[METER_TEXT], "sys:");
-      RichString_append(out, CRT_colors[CPU_SYSTEM], buffer);
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], "sys:");
+      RichString_appendAscii(out, CRT_colors[CPU_SYSTEM], buffer);
       xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_NICE]);
-      RichString_append(out, CRT_colors[METER_TEXT], "low:");
-      RichString_append(out, CRT_colors[CPU_NICE_TEXT], buffer);
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], "low:");
+      RichString_appendAscii(out, CRT_colors[CPU_NICE_TEXT], buffer);
       if (!isnan(this->values[CPU_METER_IRQ])) {
          xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_IRQ]);
-         RichString_append(out, CRT_colors[METER_TEXT], "vir:");
-         RichString_append(out, CRT_colors[CPU_GUEST], buffer);
+         RichString_appendAscii(out, CRT_colors[METER_TEXT], "vir:");
+         RichString_appendAscii(out, CRT_colors[CPU_GUEST], buffer);
       }
    }
 
@@ -161,8 +161,8 @@ static void CPUMeter_display(const Object* cast, RichString* out) {
       } else {
          xSnprintf(cpuTemperatureBuffer, sizeof(cpuTemperatureBuffer), "%5.1f%sC", cpuTemperature, CRT_degreeSign);
       }
-      RichString_append(out, CRT_colors[METER_TEXT], "temp:");
-      RichString_append(out, CRT_colors[METER_VALUE], cpuTemperatureBuffer);
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], "temp:");
+      RichString_appendWide(out, CRT_colors[METER_VALUE], cpuTemperatureBuffer);
    }
    #endif
 }

--- a/DiskIOMeter.c
+++ b/DiskIOMeter.c
@@ -88,7 +88,7 @@ static void DiskIOMeter_updateValues(Meter* this, char* buffer, size_t len) {
 
 static void DIskIOMeter_display(ATTR_UNUSED const Object* cast, RichString* out) {
    if (!hasData) {
-      RichString_write(out, CRT_colors[METER_VALUE_ERROR], "no data");
+      RichString_writeAscii(out, CRT_colors[METER_VALUE_ERROR], "no data");
       return;
    }
 
@@ -96,15 +96,15 @@ static void DIskIOMeter_display(ATTR_UNUSED const Object* cast, RichString* out)
 
    int color = cached_utilisation_diff > 40.0 ? METER_VALUE_NOTICE : METER_VALUE;
    xSnprintf(buffer, sizeof(buffer), "%.1f%%", cached_utilisation_diff);
-   RichString_write(out, CRT_colors[color], buffer);
+   RichString_writeAscii(out, CRT_colors[color], buffer);
 
-   RichString_append(out, CRT_colors[METER_TEXT], " read: ");
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " read: ");
    Meter_humanUnit(buffer, cached_read_diff, sizeof(buffer));
-   RichString_append(out, CRT_colors[METER_VALUE_IOREAD], buffer);
+   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOREAD], buffer);
 
-   RichString_append(out, CRT_colors[METER_TEXT], " write: ");
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " write: ");
    Meter_humanUnit(buffer, cached_write_diff, sizeof(buffer));
-   RichString_append(out, CRT_colors[METER_VALUE_IOWRITE], buffer);
+   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], buffer);
 }
 
 const MeterClass DiskIOMeter_class = {

--- a/ListItem.c
+++ b/ListItem.c
@@ -29,7 +29,7 @@ static void ListItem_display(const Object* cast, RichString* out) {
    assert (this != NULL);
 
    if (this->moving) {
-      RichString_write(out, CRT_colors[DEFAULT_COLOR],
+      RichString_writeWide(out, CRT_colors[DEFAULT_COLOR],
 #ifdef HAVE_LIBNCURSESW
                        CRT_utf8 ? "↕ " :
 #endif
@@ -37,7 +37,7 @@ static void ListItem_display(const Object* cast, RichString* out) {
    } else {
       RichString_prune(out);
    }
-   RichString_append(out, CRT_colors[DEFAULT_COLOR], this->value);
+   RichString_appendWide(out, CRT_colors[DEFAULT_COLOR], this->value);
 }
 
 ListItem* ListItem_new(const char* value, int key) {

--- a/LoadAverageMeter.c
+++ b/LoadAverageMeter.c
@@ -33,11 +33,11 @@ static void LoadAverageMeter_display(const Object* cast, RichString* out) {
    const Meter* this = (const Meter*)cast;
    char buffer[20];
    xSnprintf(buffer, sizeof(buffer), "%.2f ", this->values[0]);
-   RichString_write(out, CRT_colors[LOAD_AVERAGE_ONE], buffer);
+   RichString_writeAscii(out, CRT_colors[LOAD_AVERAGE_ONE], buffer);
    xSnprintf(buffer, sizeof(buffer), "%.2f ", this->values[1]);
-   RichString_append(out, CRT_colors[LOAD_AVERAGE_FIVE], buffer);
+   RichString_appendAscii(out, CRT_colors[LOAD_AVERAGE_FIVE], buffer);
    xSnprintf(buffer, sizeof(buffer), "%.2f ", this->values[2]);
-   RichString_append(out, CRT_colors[LOAD_AVERAGE_FIFTEEN], buffer);
+   RichString_appendAscii(out, CRT_colors[LOAD_AVERAGE_FIFTEEN], buffer);
 }
 
 static void LoadMeter_updateValues(Meter* this, char* buffer, size_t size) {
@@ -53,7 +53,7 @@ static void LoadMeter_display(const Object* cast, RichString* out) {
    const Meter* this = (const Meter*)cast;
    char buffer[20];
    xSnprintf(buffer, sizeof(buffer), "%.2f ", this->values[0]);
-   RichString_write(out, CRT_colors[LOAD], buffer);
+   RichString_writeAscii(out, CRT_colors[LOAD], buffer);
 }
 
 const MeterClass LoadAverageMeter_class = {

--- a/MemoryMeter.c
+++ b/MemoryMeter.c
@@ -34,18 +34,18 @@ static void MemoryMeter_updateValues(Meter* this, char* buffer, size_t size) {
 static void MemoryMeter_display(const Object* cast, RichString* out) {
    char buffer[50];
    const Meter* this = (const Meter*)cast;
-   RichString_write(out, CRT_colors[METER_TEXT], ":");
+   RichString_writeAscii(out, CRT_colors[METER_TEXT], ":");
    Meter_humanUnit(buffer, this->total, sizeof(buffer));
-   RichString_append(out, CRT_colors[METER_VALUE], buffer);
+   RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
    Meter_humanUnit(buffer, this->values[0], sizeof(buffer));
-   RichString_append(out, CRT_colors[METER_TEXT], " used:");
-   RichString_append(out, CRT_colors[MEMORY_USED], buffer);
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " used:");
+   RichString_appendAscii(out, CRT_colors[MEMORY_USED], buffer);
    Meter_humanUnit(buffer, this->values[1], sizeof(buffer));
-   RichString_append(out, CRT_colors[METER_TEXT], " buffers:");
-   RichString_append(out, CRT_colors[MEMORY_BUFFERS_TEXT], buffer);
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " buffers:");
+   RichString_appendAscii(out, CRT_colors[MEMORY_BUFFERS_TEXT], buffer);
    Meter_humanUnit(buffer, this->values[2], sizeof(buffer));
-   RichString_append(out, CRT_colors[METER_TEXT], " cache:");
-   RichString_append(out, CRT_colors[MEMORY_CACHE], buffer);
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " cache:");
+   RichString_appendAscii(out, CRT_colors[MEMORY_CACHE], buffer);
 }
 
 const MeterClass MemoryMeter_class = {

--- a/Meter.c
+++ b/Meter.c
@@ -100,7 +100,7 @@ static inline void Meter_displayBuffer(const Meter* this, const char* buffer, Ri
    if (Object_displayFn(this)) {
       Object_display(this, out);
    } else {
-      RichString_write(out, CRT_colors[Meter_attributes(this)[0]], buffer);
+      RichString_writeWide(out, CRT_colors[Meter_attributes(this)[0]], buffer);
    }
 }
 
@@ -201,7 +201,7 @@ static void BarMeterMode_draw(Meter* this, int x, int y, int w) {
 
    RichString_begin(bar);
    RichString_appendChr(&bar, ' ', padding);
-   RichString_append(&bar, 0, buffer);
+   RichString_appendWide(&bar, 0, buffer);
    assert(RichString_sizeVal(bar) >= w);
 
    int blockSizes[10];

--- a/NetworkIOMeter.c
+++ b/NetworkIOMeter.c
@@ -88,24 +88,24 @@ static void NetworkIOMeter_updateValues(ATTR_UNUSED Meter* this, char* buffer, s
 
 static void NetworkIOMeter_display(ATTR_UNUSED const Object* cast, RichString* out) {
    if (!hasData) {
-      RichString_write(out, CRT_colors[METER_VALUE_ERROR], "no data");
+      RichString_writeAscii(out, CRT_colors[METER_VALUE_ERROR], "no data");
       return;
    }
 
    char buffer[64];
 
-   RichString_write(out, CRT_colors[METER_TEXT], "rx: ");
+   RichString_writeAscii(out, CRT_colors[METER_TEXT], "rx: ");
    Meter_humanUnit(buffer, cached_rxb_diff, sizeof(buffer));
-   RichString_append(out, CRT_colors[METER_VALUE_IOREAD], buffer);
-   RichString_append(out, CRT_colors[METER_VALUE_IOREAD], "iB/s");
+   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOREAD], buffer);
+   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOREAD], "iB/s");
 
-   RichString_append(out, CRT_colors[METER_TEXT], " tx: ");
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " tx: ");
    Meter_humanUnit(buffer, cached_txb_diff, sizeof(buffer));
-   RichString_append(out, CRT_colors[METER_VALUE_IOWRITE], buffer);
-   RichString_append(out, CRT_colors[METER_VALUE_IOWRITE], "iB/s");
+   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], buffer);
+   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], "iB/s");
 
    xSnprintf(buffer, sizeof(buffer), " (%lu/%lu packets) ", cached_rxp_diff, cached_txp_diff);
-   RichString_append(out, CRT_colors[METER_TEXT], buffer);
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], buffer);
 }
 
 const MeterClass NetworkIOMeter_class = {

--- a/OptionItem.c
+++ b/OptionItem.c
@@ -29,14 +29,14 @@ static void CheckItem_display(const Object* cast, RichString* out) {
    const CheckItem* this = (const CheckItem*)cast;
    assert (this != NULL);
 
-   RichString_write(out, CRT_colors[CHECK_BOX], "[");
+   RichString_writeAscii(out, CRT_colors[CHECK_BOX], "[");
    if (CheckItem_get(this)) {
-      RichString_append(out, CRT_colors[CHECK_MARK], "x");
+      RichString_appendAscii(out, CRT_colors[CHECK_MARK], "x");
    } else {
-      RichString_append(out, CRT_colors[CHECK_MARK], " ");
+      RichString_appendAscii(out, CRT_colors[CHECK_MARK], " ");
    }
-   RichString_append(out, CRT_colors[CHECK_BOX], "]    ");
-   RichString_append(out, CRT_colors[CHECK_TEXT], this->super.text);
+   RichString_appendAscii(out, CRT_colors[CHECK_BOX], "]    ");
+   RichString_appendWide(out, CRT_colors[CHECK_TEXT], this->super.text);
 }
 
 static void NumberItem_display(const Object* cast, RichString* out) {
@@ -44,7 +44,7 @@ static void NumberItem_display(const Object* cast, RichString* out) {
    assert (this != NULL);
 
    char buffer[12];
-   RichString_write(out, CRT_colors[CHECK_BOX], "[");
+   RichString_writeAscii(out, CRT_colors[CHECK_BOX], "[");
    int written;
    if (this->scale < 0) {
       written = xSnprintf(buffer, sizeof(buffer), "%.*f", -this->scale, pow(10, this->scale) * NumberItem_get(this));
@@ -53,12 +53,12 @@ static void NumberItem_display(const Object* cast, RichString* out) {
    } else {
       written = xSnprintf(buffer, sizeof(buffer), "%d", NumberItem_get(this));
    }
-   RichString_append(out, CRT_colors[CHECK_MARK], buffer);
-   RichString_append(out, CRT_colors[CHECK_BOX], "]");
+   RichString_appendAscii(out, CRT_colors[CHECK_MARK], buffer);
+   RichString_appendAscii(out, CRT_colors[CHECK_BOX], "]");
    for (int i = written; i < 5; i++) {
-      RichString_append(out, CRT_colors[CHECK_BOX], " ");
+      RichString_appendAscii(out, CRT_colors[CHECK_BOX], " ");
    }
-   RichString_append(out, CRT_colors[CHECK_TEXT], this->super.text);
+   RichString_appendWide(out, CRT_colors[CHECK_TEXT], this->super.text);
 }
 
 const OptionItemClass OptionItem_class = {

--- a/Panel.c
+++ b/Panel.c
@@ -82,7 +82,7 @@ RichString* Panel_getHeader(Panel* this) {
 }
 
 inline void Panel_setHeader(Panel* this, const char* header) {
-   RichString_write(&(this->header), CRT_colors[PANEL_HEADER_FOCUS], header);
+   RichString_writeWide(&(this->header), CRT_colors[PANEL_HEADER_FOCUS], header);
    this->needsRedraw = true;
 }
 

--- a/Process.c
+++ b/Process.c
@@ -74,53 +74,53 @@ void Process_humanNumber(RichString* str, unsigned long long number, bool colori
    if (number < 1000) {
       //Plain number, no markings
       len = xSnprintf(buffer, sizeof(buffer), "%5llu ", number);
-      RichString_appendn(str, processColor, buffer, len);
+      RichString_appendnAscii(str, processColor, buffer, len);
    } else if (number < 100000) {
       //2 digit MB, 3 digit KB
       len = xSnprintf(buffer, sizeof(buffer), "%2llu", number/1000);
-      RichString_appendn(str, processMegabytesColor, buffer, len);
+      RichString_appendnAscii(str, processMegabytesColor, buffer, len);
       number %= 1000;
       len = xSnprintf(buffer, sizeof(buffer), "%03llu ", number);
-      RichString_appendn(str, processColor, buffer, len);
+      RichString_appendnAscii(str, processColor, buffer, len);
    } else if (number < 1000 * ONE_K) {
       //3 digit MB
       number /= ONE_K;
       len = xSnprintf(buffer, sizeof(buffer), "%4lluM ", number);
-      RichString_appendn(str, processMegabytesColor, buffer, len);
+      RichString_appendnAscii(str, processMegabytesColor, buffer, len);
    } else if (number < 10000 * ONE_K) {
       //1 digit GB, 3 digit MB
       number /= ONE_K;
       len = xSnprintf(buffer, sizeof(buffer), "%1llu", number/1000);
-      RichString_appendn(str, processGigabytesColor, buffer, len);
+      RichString_appendnAscii(str, processGigabytesColor, buffer, len);
       number %= 1000;
       len = xSnprintf(buffer, sizeof(buffer), "%03lluM ", number);
-      RichString_appendn(str, processMegabytesColor, buffer, len);
+      RichString_appendnAscii(str, processMegabytesColor, buffer, len);
    } else if (number < 100000 * ONE_K) {
       //2 digit GB, 1 digit MB
       number /= 100 * ONE_K;
       len = xSnprintf(buffer, sizeof(buffer), "%2llu", number/10);
-      RichString_appendn(str, processGigabytesColor, buffer, len);
+      RichString_appendnAscii(str, processGigabytesColor, buffer, len);
       number %= 10;
       len = xSnprintf(buffer, sizeof(buffer), ".%1llu", number);
-      RichString_appendn(str, processMegabytesColor, buffer, len);
-      RichString_append(str, processGigabytesColor, "G ");
+      RichString_appendnAscii(str, processMegabytesColor, buffer, len);
+      RichString_appendAscii(str, processGigabytesColor, "G ");
    } else if (number < 1000 * ONE_M) {
       //3 digit GB
       number /= ONE_M;
       len = xSnprintf(buffer, sizeof(buffer), "%4lluG ", number);
-      RichString_appendn(str, processGigabytesColor, buffer, len);
+      RichString_appendnAscii(str, processGigabytesColor, buffer, len);
    } else if (number < 10000ULL * ONE_M) {
       //1 digit TB, 3 digit GB
       number /= ONE_M;
       len = xSnprintf(buffer, sizeof(buffer), "%1llu", number/1000);
-      RichString_appendn(str, largeNumberColor, buffer, len);
+      RichString_appendnAscii(str, largeNumberColor, buffer, len);
       number %= 1000;
       len = xSnprintf(buffer, sizeof(buffer), "%03lluG ", number);
-      RichString_appendn(str, processGigabytesColor, buffer, len);
+      RichString_appendnAscii(str, processGigabytesColor, buffer, len);
    } else {
       //2 digit TB and above
       len = xSnprintf(buffer, sizeof(buffer), "%4.1lfT ", (double)number/ONE_G);
-      RichString_appendn(str, largeNumberColor, buffer, len);
+      RichString_appendnAscii(str, largeNumberColor, buffer, len);
    }
 }
 
@@ -139,26 +139,25 @@ void Process_colorNumber(RichString* str, unsigned long long number, bool colori
    }
 
    if (number == ULLONG_MAX) {
-      int len = xSnprintf(buffer, sizeof(buffer), "        N/A ");
-      RichString_appendn(str, CRT_colors[PROCESS_SHADOW], buffer, len);
+      RichString_appendAscii(str, CRT_colors[PROCESS_SHADOW], "        N/A ");
    } else if (number >= 100000LL * ONE_DECIMAL_T) {
       xSnprintf(buffer, sizeof(buffer), "%11llu ", number / ONE_DECIMAL_G);
-      RichString_appendn(str, largeNumberColor, buffer, 12);
+      RichString_appendnAscii(str, largeNumberColor, buffer, 12);
    } else if (number >= 100LL * ONE_DECIMAL_T) {
       xSnprintf(buffer, sizeof(buffer), "%11llu ", number / ONE_DECIMAL_M);
-      RichString_appendn(str, largeNumberColor, buffer, 8);
-      RichString_appendn(str, processMegabytesColor, buffer+8, 4);
+      RichString_appendnAscii(str, largeNumberColor, buffer, 8);
+      RichString_appendnAscii(str, processMegabytesColor, buffer+8, 4);
    } else if (number >= 10LL * ONE_DECIMAL_G) {
       xSnprintf(buffer, sizeof(buffer), "%11llu ", number / ONE_DECIMAL_K);
-      RichString_appendn(str, largeNumberColor, buffer, 5);
-      RichString_appendn(str, processMegabytesColor, buffer+5, 3);
-      RichString_appendn(str, processColor, buffer+8, 4);
+      RichString_appendnAscii(str, largeNumberColor, buffer, 5);
+      RichString_appendnAscii(str, processMegabytesColor, buffer+5, 3);
+      RichString_appendnAscii(str, processColor, buffer+8, 4);
    } else {
       xSnprintf(buffer, sizeof(buffer), "%11llu ", number);
-      RichString_appendn(str, largeNumberColor, buffer, 2);
-      RichString_appendn(str, processMegabytesColor, buffer+2, 3);
-      RichString_appendn(str, processColor, buffer+5, 3);
-      RichString_appendn(str, processShadowColor, buffer+8, 4);
+      RichString_appendnAscii(str, largeNumberColor, buffer, 2);
+      RichString_appendnAscii(str, processMegabytesColor, buffer+2, 3);
+      RichString_appendnAscii(str, processColor, buffer+5, 3);
+      RichString_appendnAscii(str, processShadowColor, buffer+8, 4);
    }
 }
 
@@ -172,16 +171,16 @@ void Process_printTime(RichString* str, unsigned long long totalHundredths) {
    char buffer[10];
    if (hours >= 100) {
       xSnprintf(buffer, sizeof(buffer), "%7lluh ", hours);
-      RichString_append(str, CRT_colors[LARGE_NUMBER], buffer);
+      RichString_appendAscii(str, CRT_colors[LARGE_NUMBER], buffer);
    } else {
       if (hours) {
          xSnprintf(buffer, sizeof(buffer), "%2lluh", hours);
-         RichString_append(str, CRT_colors[LARGE_NUMBER], buffer);
+         RichString_appendAscii(str, CRT_colors[LARGE_NUMBER], buffer);
          xSnprintf(buffer, sizeof(buffer), "%02d:%02d ", minutes, seconds);
       } else {
          xSnprintf(buffer, sizeof(buffer), "%2d:%02d.%02d ", minutes, seconds, hundredths);
       }
-      RichString_append(str, CRT_colors[DEFAULT_COLOR], buffer);
+      RichString_appendAscii(str, CRT_colors[DEFAULT_COLOR], buffer);
    }
 }
 
@@ -216,7 +215,7 @@ static inline void Process_writeCommand(const Process* this, int attr, int basea
       finish += start - 1;
    }
 
-   RichString_append(str, attr, comm);
+   RichString_appendWide(str, attr, comm);
 
    if (this->settings->highlightBaseName) {
       RichString_setAttrn(str, baseattr, start, finish);
@@ -234,23 +233,22 @@ void Process_outputRate(RichString* str, char* buffer, size_t n, double rate, in
    }
 
    if (isnan(rate)) {
-      int len = xSnprintf(buffer, n, "        N/A ");
-      RichString_appendn(str, CRT_colors[PROCESS_SHADOW], buffer, len);
+      RichString_appendAscii(str, CRT_colors[PROCESS_SHADOW], "        N/A ");
    } else if (rate < ONE_K) {
       int len = snprintf(buffer, n, "%7.2f B/s ", rate);
-      RichString_appendn(str, processColor, buffer, len);
+      RichString_appendnAscii(str, processColor, buffer, len);
    } else if (rate < ONE_M) {
       int len = snprintf(buffer, n, "%7.2f K/s ", rate / ONE_K);
-      RichString_appendn(str, processColor, buffer, len);
+      RichString_appendnAscii(str, processColor, buffer, len);
    } else if (rate < ONE_G) {
       int len = snprintf(buffer, n, "%7.2f M/s ", rate / ONE_M);
-      RichString_appendn(str, processMegabytesColor, buffer, len);
+      RichString_appendnAscii(str, processMegabytesColor, buffer, len);
    } else if (rate < ONE_T) {
       int len = snprintf(buffer, n, "%7.2f G/s ", rate / ONE_G);
-      RichString_appendn(str, largeNumberColor, buffer, len);
+      RichString_appendnAscii(str, largeNumberColor, buffer, len);
    } else {
       int len = snprintf(buffer, n, "%7.2f T/s ", rate / ONE_T);
-      RichString_appendn(str, largeNumberColor, buffer, len);
+      RichString_appendnAscii(str, largeNumberColor, buffer, len);
    }
 }
 
@@ -322,7 +320,7 @@ void Process_writeField(const Process* this, RichString* str, ProcessField field
          }
          const char* draw = CRT_treeStr[lastItem ? (this->settings->direction == 1 ? TREE_STR_BEND : TREE_STR_TEND) : TREE_STR_RTEE];
          xSnprintf(buf, n, "%s%s ", draw, this->showChildren ? CRT_treeStr[TREE_STR_SHUT] : CRT_treeStr[TREE_STR_OPEN] );
-         RichString_append(str, CRT_colors[PROCESS_TREE], buffer);
+         RichString_appendWide(str, CRT_colors[PROCESS_TREE], buffer);
          Process_writeCommand(this, attr, baseattr, str);
          return;
       }
@@ -386,7 +384,7 @@ void Process_writeField(const Process* this, RichString* str, ProcessField field
    default:
       xSnprintf(buffer, n, "- ");
    }
-   RichString_append(str, attr, buffer);
+   RichString_appendWide(str, attr, buffer);
 }
 
 void Process_display(const Object* cast, RichString* out) {

--- a/ProcessList.c
+++ b/ProcessList.c
@@ -92,9 +92,9 @@ void ProcessList_printHeader(ProcessList* this, RichString* header) {
 
       int color = (this->settings->sortKey == fields[i]) ?
          CRT_colors[PANEL_SELECTION_FOCUS] : CRT_colors[PANEL_HEADER_FOCUS];
-      RichString_append(header, color, field);
+      RichString_appendWide(header, color, field);
       if (COMM == fields[i] && this->settings->showMergedCommand) {
-         RichString_append(header, color, "(merged)");
+         RichString_appendAscii(header, color, "(merged)");
       }
    }
 }

--- a/RichString.c
+++ b/RichString.c
@@ -7,6 +7,7 @@ in the source distribution for its full text.
 
 #include "RichString.h"
 
+#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -47,7 +48,7 @@ static void RichString_setLen(RichString* this, int len) {
 
 #ifdef HAVE_LIBNCURSESW
 
-static inline void RichString_writeFrom(RichString* this, int attrs, const char* data_c, int from, int len) {
+static inline void RichString_writeFromWide(RichString* this, int attrs, const char* data_c, int from, int len) {
    wchar_t data[len + 1];
    len = mbstowcs(data, data_c, len);
    if (len < 0)
@@ -57,6 +58,14 @@ static inline void RichString_writeFrom(RichString* this, int attrs, const char*
    RichString_setLen(this, newLen);
    for (int i = from, j = 0; i < newLen; i++, j++) {
       this->chptr[i] = (CharType) { .attr = attrs & 0xffffff, .chars = { (iswprint(data[j]) ? data[j] : '?') } };
+   }
+}
+
+static inline void RichString_writeFromAscii(RichString* this, int attrs, const char* data, int from, int len) {
+   int newLen = from + len;
+   RichString_setLen(this, newLen);
+   for (int i = from, j = 0; i < newLen; i++, j++) {
+      this->chptr[i] = (CharType) { .attr = attrs & 0xffffff, .chars = { (isprint(data[j]) ? data[j] : '?') } };
    }
 }
 
@@ -82,13 +91,17 @@ int RichString_findChar(RichString* this, char c, int start) {
 
 #else /* HAVE_LIBNCURSESW */
 
-static inline void RichString_writeFrom(RichString* this, int attrs, const char* data_c, int from, int len) {
+static inline void RichString_writeFromWide(RichString* this, int attrs, const char* data_c, int from, int len) {
    int newLen = from + len;
    RichString_setLen(this, newLen);
    for (int i = from, j = 0; i < newLen; i++, j++) {
       this->chptr[i] = (((unsigned char)data_c[j]) >= 32 ? ((unsigned char)data_c[j]) : '?') | attrs;
    }
    this->chptr[newLen] = 0;
+}
+
+static inline void RichString_writeFromAscii(RichString* this, int attrs, const char* data_c, int from, int len) {
+   RichString_writeFromWide(this, attrs, data_c, from, len);
 }
 
 void RichString_setAttrn(RichString* this, int attrs, int start, int finish) {
@@ -132,14 +145,26 @@ void RichString_setAttr(RichString* this, int attrs) {
    RichString_setAttrn(this, attrs, 0, this->chlen - 1);
 }
 
-void RichString_append(RichString* this, int attrs, const char* data) {
-   RichString_writeFrom(this, attrs, data, this->chlen, strlen(data));
+void RichString_appendWide(RichString* this, int attrs, const char* data) {
+   RichString_writeFromWide(this, attrs, data, this->chlen, strlen(data));
 }
 
-void RichString_appendn(RichString* this, int attrs, const char* data, int len) {
-   RichString_writeFrom(this, attrs, data, this->chlen, len);
+void RichString_appendnWide(RichString* this, int attrs, const char* data, int len) {
+   RichString_writeFromWide(this, attrs, data, this->chlen, len);
 }
 
-void RichString_write(RichString* this, int attrs, const char* data) {
-   RichString_writeFrom(this, attrs, data, 0, strlen(data));
+void RichString_writeWide(RichString* this, int attrs, const char* data) {
+   RichString_writeFromWide(this, attrs, data, 0, strlen(data));
+}
+
+void RichString_appendAscii(RichString* this, int attrs, const char* data) {
+   RichString_writeFromAscii(this, attrs, data, this->chlen, strlen(data));
+}
+
+void RichString_appendnAscii(RichString* this, int attrs, const char* data, int len) {
+   RichString_writeFromAscii(this, attrs, data, this->chlen, len);
+}
+
+void RichString_writeAscii(RichString* this, int attrs, const char* data) {
+   RichString_writeFromAscii(this, attrs, data, 0, strlen(data));
 }

--- a/RichString.h
+++ b/RichString.h
@@ -52,10 +52,16 @@ void RichString_setAttr(RichString* this, int attrs);
 
 void RichString_appendChr(RichString* this, char c, int count);
 
-void RichString_append(RichString* this, int attrs, const char* data);
+void RichString_appendWide(RichString* this, int attrs, const char* data);
 
-void RichString_appendn(RichString* this, int attrs, const char* data, int len);
+void RichString_appendnWide(RichString* this, int attrs, const char* data, int len);
 
-void RichString_write(RichString* this, int attrs, const char* data);
+void RichString_writeWide(RichString* this, int attrs, const char* data);
+
+void RichString_appendAscii(RichString* this, int attrs, const char* data);
+
+void RichString_appendnAscii(RichString* this, int attrs, const char* data, int len);
+
+void RichString_writeAscii(RichString* this, int attrs, const char* data);
 
 #endif

--- a/SwapMeter.c
+++ b/SwapMeter.c
@@ -32,12 +32,12 @@ static void SwapMeter_updateValues(Meter* this, char* buffer, size_t size) {
 static void SwapMeter_display(const Object* cast, RichString* out) {
    char buffer[50];
    const Meter* this = (const Meter*)cast;
-   RichString_write(out, CRT_colors[METER_TEXT], ":");
+   RichString_writeAscii(out, CRT_colors[METER_TEXT], ":");
    Meter_humanUnit(buffer, this->total, sizeof(buffer));
-   RichString_append(out, CRT_colors[METER_VALUE], buffer);
+   RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
    Meter_humanUnit(buffer, this->values[0], sizeof(buffer));
-   RichString_append(out, CRT_colors[METER_TEXT], " used:");
-   RichString_append(out, CRT_colors[METER_VALUE], buffer);
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " used:");
+   RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
 }
 
 const MeterClass SwapMeter_class = {

--- a/TasksMeter.c
+++ b/TasksMeter.c
@@ -46,7 +46,7 @@ static void TasksMeter_display(const Object* cast, RichString* out) {
    int processes = (int) this->values[2];
 
    xSnprintf(buffer, sizeof(buffer), "%d", processes);
-   RichString_write(out, CRT_colors[METER_VALUE], buffer);
+   RichString_writeAscii(out, CRT_colors[METER_VALUE], buffer);
    int threadValueColor = CRT_colors[METER_VALUE];
    int threadCaptionColor = CRT_colors[METER_TEXT];
    if (settings->highlightThreads) {
@@ -54,21 +54,21 @@ static void TasksMeter_display(const Object* cast, RichString* out) {
       threadCaptionColor = CRT_colors[PROCESS_THREAD];
    }
    if (!settings->hideUserlandThreads) {
-      RichString_append(out, CRT_colors[METER_TEXT], ", ");
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], ", ");
       xSnprintf(buffer, sizeof(buffer), "%d", (int)this->values[1]);
-      RichString_append(out, threadValueColor, buffer);
-      RichString_append(out, threadCaptionColor, " thr");
+      RichString_appendAscii(out, threadValueColor, buffer);
+      RichString_appendAscii(out, threadCaptionColor, " thr");
    }
    if (!settings->hideKernelThreads) {
-      RichString_append(out, CRT_colors[METER_TEXT], ", ");
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], ", ");
       xSnprintf(buffer, sizeof(buffer), "%d", (int)this->values[0]);
-      RichString_append(out, threadValueColor, buffer);
-      RichString_append(out, threadCaptionColor, " kthr");
+      RichString_appendAscii(out, threadValueColor, buffer);
+      RichString_appendAscii(out, threadCaptionColor, " kthr");
    }
-   RichString_append(out, CRT_colors[METER_TEXT], "; ");
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], "; ");
    xSnprintf(buffer, sizeof(buffer), "%d", (int)this->values[3]);
-   RichString_append(out, CRT_colors[TASKS_RUNNING], buffer);
-   RichString_append(out, CRT_colors[METER_TEXT], " running");
+   RichString_appendAscii(out, CRT_colors[TASKS_RUNNING], buffer);
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " running");
 }
 
 const MeterClass TasksMeter_class = {

--- a/dragonflybsd/DragonFlyBSDProcess.c
+++ b/dragonflybsd/DragonFlyBSDProcess.c
@@ -105,7 +105,7 @@ void DragonFlyBSDProcess_writeField(const Process* this, RichString* str, Proces
       Process_writeField(this, str, field);
       return;
    }
-   RichString_append(str, attr, buffer);
+   RichString_appendWide(str, attr, buffer);
 }
 
 long DragonFlyBSDProcess_compare(const void* v1, const void* v2) {

--- a/freebsd/FreeBSDProcess.c
+++ b/freebsd/FreeBSDProcess.c
@@ -105,7 +105,7 @@ static void FreeBSDProcess_writeField(const Process* this, RichString* str, Proc
       Process_writeField(this, str, field);
       return;
    }
-   RichString_append(str, attr, buffer);
+   RichString_appendWide(str, attr, buffer);
 }
 
 static long FreeBSDProcess_compare(const void* v1, const void* v2) {

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -536,7 +536,7 @@ static void LinuxProcess_writeCommand(const Process* this, int attr, int baseAtt
    if(lp->procExeDeleted)
       baseAttr = CRT_colors[FAILED_READ];
 
-   RichString_append(str, attr, lp->mergedCommand.str);
+   RichString_appendWide(str, attr, lp->mergedCommand.str);
 
    if (lp->mergedCommand.commEnd) {
       if (!lp->mergedCommand.separateComm && commStart == baseStart && highlightBaseName) {
@@ -608,7 +608,7 @@ static void LinuxProcess_writeCommandField(const Process *this, RichString *str,
       n -= (buf - buffer);
       const char* draw = CRT_treeStr[lastItem ? (this->settings->direction == 1 ? TREE_STR_BEND : TREE_STR_TEND) : TREE_STR_RTEE];
       xSnprintf(buf, n, "%s%s ", draw, this->showChildren ? CRT_treeStr[TREE_STR_SHUT] : CRT_treeStr[TREE_STR_OPEN] );
-      RichString_append(str, CRT_colors[PROCESS_TREE], buffer);
+      RichString_appendWide(str, CRT_colors[PROCESS_TREE], buffer);
       LinuxProcess_writeCommand(this, attr, baseattr, str);
    }
 }
@@ -757,7 +757,7 @@ static void LinuxProcess_writeField(const Process* this, RichString* str, Proces
       Process_writeField(this, str, field);
       return;
    }
-   RichString_append(str, attr, buffer);
+   RichString_appendWide(str, attr, buffer);
 }
 
 static long LinuxProcess_compare(const void* v1, const void* v2) {

--- a/linux/PressureStallMeter.c
+++ b/linux/PressureStallMeter.c
@@ -50,11 +50,11 @@ static void PressureStallMeter_display(const Object* cast, RichString* out) {
    const Meter* this = (const Meter*)cast;
    char buffer[20];
    xSnprintf(buffer, sizeof(buffer), "%.2lf%% ", this->values[0]);
-   RichString_write(out, CRT_colors[PRESSURE_STALL_TEN], buffer);
+   RichString_writeAscii(out, CRT_colors[PRESSURE_STALL_TEN], buffer);
    xSnprintf(buffer, sizeof(buffer), "%.2lf%% ", this->values[1]);
-   RichString_append(out, CRT_colors[PRESSURE_STALL_SIXTY], buffer);
+   RichString_appendAscii(out, CRT_colors[PRESSURE_STALL_SIXTY], buffer);
    xSnprintf(buffer, sizeof(buffer), "%.2lf%% ", this->values[2]);
-   RichString_append(out, CRT_colors[PRESSURE_STALL_THREEHUNDRED], buffer);
+   RichString_appendAscii(out, CRT_colors[PRESSURE_STALL_THREEHUNDRED], buffer);
 }
 
 const MeterClass PressureStallCPUSomeMeter_class = {

--- a/linux/SystemdMeter.c
+++ b/linux/SystemdMeter.c
@@ -267,9 +267,9 @@ static void SystemdMeter_display(ATTR_UNUSED const Object* cast, RichString* out
    char buffer[16];
 
    int color = (systemState && 0 == strcmp(systemState, "running")) ? METER_VALUE_OK : METER_VALUE_ERROR;
-   RichString_write(out, CRT_colors[color], systemState ? systemState : "???");
+   RichString_writeAscii(out, CRT_colors[color], systemState ? systemState : "N/A");
 
-   RichString_append(out, CRT_colors[METER_TEXT], " (");
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " (");
 
    if (nFailedUnits == INVALID_VALUE) {
       buffer[0] = '?';
@@ -277,9 +277,9 @@ static void SystemdMeter_display(ATTR_UNUSED const Object* cast, RichString* out
    } else {
       xSnprintf(buffer, sizeof(buffer), "%u", nFailedUnits);
    }
-   RichString_append(out, zeroDigitColor(nFailedUnits), buffer);
+   RichString_appendAscii(out, zeroDigitColor(nFailedUnits), buffer);
 
-   RichString_append(out, CRT_colors[METER_TEXT], "/");
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], "/");
 
    if (nNames == INVALID_VALUE) {
       buffer[0] = '?';
@@ -287,9 +287,9 @@ static void SystemdMeter_display(ATTR_UNUSED const Object* cast, RichString* out
    } else {
       xSnprintf(buffer, sizeof(buffer), "%u", nNames);
    }
-   RichString_append(out, valueDigitColor(nNames), buffer);
+   RichString_appendAscii(out, valueDigitColor(nNames), buffer);
 
-   RichString_append(out, CRT_colors[METER_TEXT], " failed) (");
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " failed) (");
 
    if (nJobs == INVALID_VALUE) {
       buffer[0] = '?';
@@ -297,9 +297,9 @@ static void SystemdMeter_display(ATTR_UNUSED const Object* cast, RichString* out
    } else {
       xSnprintf(buffer, sizeof(buffer), "%u", nJobs);
    }
-   RichString_append(out, zeroDigitColor(nJobs), buffer);
+   RichString_appendAscii(out, zeroDigitColor(nJobs), buffer);
 
-   RichString_append(out, CRT_colors[METER_TEXT], "/");
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], "/");
 
    if (nInstalledJobs == INVALID_VALUE) {
       buffer[0] = '?';
@@ -307,9 +307,9 @@ static void SystemdMeter_display(ATTR_UNUSED const Object* cast, RichString* out
    } else {
       xSnprintf(buffer, sizeof(buffer), "%u", nInstalledJobs);
    }
-   RichString_append(out, valueDigitColor(nInstalledJobs), buffer);
+   RichString_appendAscii(out, valueDigitColor(nInstalledJobs), buffer);
 
-   RichString_append(out, CRT_colors[METER_TEXT], " jobs)");
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " jobs)");
 }
 
 static const int SystemdMeter_attributes[] = {

--- a/linux/ZramMeter.c
+++ b/linux/ZramMeter.c
@@ -37,17 +37,19 @@ static void ZramMeter_updateValues(Meter* this, char* buffer, size_t size) {
 static void ZramMeter_display(const Object* cast, RichString* out) {
    char buffer[50];
    const Meter* this = (const Meter*)cast;
-   RichString_write(out, CRT_colors[METER_TEXT], ":");
-   Meter_humanUnit(buffer, this->total, sizeof(buffer));
 
-   RichString_append(out, CRT_colors[METER_VALUE], buffer);
+   RichString_writeAscii(out, CRT_colors[METER_TEXT], ":");
+
+   Meter_humanUnit(buffer, this->total, sizeof(buffer));
+   RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
+
    Meter_humanUnit(buffer, this->values[0], sizeof(buffer));
-   RichString_append(out, CRT_colors[METER_TEXT], " used:");
-   RichString_append(out, CRT_colors[METER_VALUE], buffer);
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " used:");
+   RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
 
    Meter_humanUnit(buffer, this->values[1], sizeof(buffer));
-   RichString_append(out, CRT_colors[METER_TEXT], " uncompressed:");
-   RichString_append(out, CRT_colors[METER_VALUE], buffer);
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " uncompressed:");
+   RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
 }
 
 const MeterClass ZramMeter_class = {

--- a/openbsd/OpenBSDProcess.c
+++ b/openbsd/OpenBSDProcess.c
@@ -209,7 +209,7 @@ static void OpenBSDProcess_writeField(const Process* this, RichString* str, Proc
       Process_writeField(this, str, field);
       return;
    }
-   RichString_append(str, attr, buffer);
+   RichString_appendWide(str, attr, buffer);
 }
 
 static long OpenBSDProcess_compare(const void* v1, const void* v2) {

--- a/solaris/SolarisProcess.c
+++ b/solaris/SolarisProcess.c
@@ -114,7 +114,7 @@ void SolarisProcess_writeField(const Process* this, RichString* str, ProcessFiel
       Process_writeField(this, str, field);
       return;
    }
-   RichString_append(str, attr, buffer);
+   RichString_appendWide(str, attr, buffer);
 }
 
 long SolarisProcess_compare(const void* v1, const void* v2) {

--- a/zfs/ZfsArcMeter.c
+++ b/zfs/ZfsArcMeter.c
@@ -51,28 +51,28 @@ static void ZfsArcMeter_display(const Object* cast, RichString* out) {
    if (this->values[5] > 0) {
       char buffer[50];
       Meter_humanUnit(buffer, this->total, sizeof(buffer));
-      RichString_append(out, CRT_colors[METER_VALUE], buffer);
+      RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
       Meter_humanUnit(buffer, this->values[5], sizeof(buffer));
-      RichString_append(out, CRT_colors[METER_TEXT], " Used:");
-      RichString_append(out, CRT_colors[METER_VALUE], buffer);
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], " Used:");
+      RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
       Meter_humanUnit(buffer, this->values[0], sizeof(buffer));
-      RichString_append(out, CRT_colors[METER_TEXT], " MFU:");
-      RichString_append(out, CRT_colors[ZFS_MFU], buffer);
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], " MFU:");
+      RichString_appendAscii(out, CRT_colors[ZFS_MFU], buffer);
       Meter_humanUnit(buffer, this->values[1], sizeof(buffer));
-      RichString_append(out, CRT_colors[METER_TEXT], " MRU:");
-      RichString_append(out, CRT_colors[ZFS_MRU], buffer);
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], " MRU:");
+      RichString_appendAscii(out, CRT_colors[ZFS_MRU], buffer);
       Meter_humanUnit(buffer, this->values[2], sizeof(buffer));
-      RichString_append(out, CRT_colors[METER_TEXT], " Anon:");
-      RichString_append(out, CRT_colors[ZFS_ANON], buffer);
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], " Anon:");
+      RichString_appendAscii(out, CRT_colors[ZFS_ANON], buffer);
       Meter_humanUnit(buffer, this->values[3], sizeof(buffer));
-      RichString_append(out, CRT_colors[METER_TEXT], " Hdr:");
-      RichString_append(out, CRT_colors[ZFS_HEADER], buffer);
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], " Hdr:");
+      RichString_appendAscii(out, CRT_colors[ZFS_HEADER], buffer);
       Meter_humanUnit(buffer, this->values[4], sizeof(buffer));
-      RichString_append(out, CRT_colors[METER_TEXT], " Oth:");
-      RichString_append(out, CRT_colors[ZFS_OTHER], buffer);
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], " Oth:");
+      RichString_appendAscii(out, CRT_colors[ZFS_OTHER], buffer);
    } else {
-      RichString_write(out, CRT_colors[METER_TEXT], " ");
-      RichString_append(out, CRT_colors[FAILED_SEARCH], "Unavailable");
+      RichString_writeAscii(out, CRT_colors[METER_TEXT], " ");
+      RichString_appendAscii(out, CRT_colors[FAILED_SEARCH], "Unavailable");
    }
 }
 

--- a/zfs/ZfsCompressedArcMeter.c
+++ b/zfs/ZfsCompressedArcMeter.c
@@ -48,17 +48,17 @@ static void ZfsCompressedArcMeter_display(const Object* cast, RichString* out) {
    if (this->values[0] > 0) {
       char buffer[50];
       Meter_humanUnit(buffer, this->total, sizeof(buffer));
-      RichString_append(out, CRT_colors[METER_VALUE], buffer);
-      RichString_append(out, CRT_colors[METER_TEXT], " Uncompressed, ");
+      RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], " Uncompressed, ");
       Meter_humanUnit(buffer, this->values[0], sizeof(buffer));
-      RichString_append(out, CRT_colors[METER_VALUE], buffer);
-      RichString_append(out, CRT_colors[METER_TEXT], " Compressed, ");
+      RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], " Compressed, ");
       ZfsCompressedArcMeter_printRatioString(this, buffer, sizeof(buffer));
-      RichString_append(out, CRT_colors[METER_VALUE], buffer);
-      RichString_append(out, CRT_colors[METER_TEXT], " Ratio");
+      RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], " Ratio");
    } else {
-      RichString_write(out, CRT_colors[METER_TEXT], " ");
-      RichString_append(out, CRT_colors[FAILED_SEARCH], "Compression Unavailable");
+      RichString_writeAscii(out, CRT_colors[METER_TEXT], " ");
+      RichString_appendAscii(out, CRT_colors[FAILED_SEARCH], "Compression Unavailable");
    }
 }
 


### PR DESCRIPTION
RichString_writeFrom takes a top spot during performance analysis due to the
calls to mbstowcs() and iswprint().

Most of the time we know in advance that we are only going to print regular
ASCII characters.