### PR TITLE
SELinuxMeter: silence comparison warning on 32-bit

### DIFF
--- a/linux/SELinuxMeter.c
+++ b/linux/SELinuxMeter.c
@@ -35,7 +35,7 @@ static bool hasSELinuxMount(void) {
       return false;
    }
 
-   if (sfbuf.f_type != SELINUX_MAGIC) {
+   if ((uint32_t)sfbuf.f_type != (uint32_t)SELINUX_MAGIC) {
       return false;
    }
 


### PR DESCRIPTION
```
linux/SELinuxMeter.c: In function ‘hasSELinuxMount’:
linux/SELinuxMeter.c:38:21: warning: comparison of integer expressions of different signedness: ‘__fsword_t’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
   38 |    if (sfbuf.f_type != SELINUX_MAGIC) {
      |                     ^~
```

Origin: https://github.com/SELinuxProject/selinux/blob/7df27b78e9eecbe65a57cdfefb9e51f547231b20/libselinux/src/init.c#L40