### PR TITLE
Cull the definitions of pageSize and pageSizeKB from CRT.c

### DIFF
--- a/CRT.c
+++ b/CRT.c
@@ -608,9 +608,6 @@ const char* CRT_termType;
 
 int CRT_colorScheme = 0;
 
-long CRT_pageSize = -1;
-long CRT_pageSizeKB = -1;
-
 ATTR_NORETURN
 static void CRT_handleSIGTERM(int sgn) {
    (void) sgn;
@@ -745,11 +742,6 @@ void CRT_init(const int* delay, int colorScheme, bool allowUnicode) {
 #else
    mousemask(BUTTON1_RELEASED, NULL);
 #endif
-
-   CRT_pageSize = sysconf(_SC_PAGESIZE);
-   if (CRT_pageSize == -1)
-      CRT_fatalError("Fatal error: Can not get PAGE_SIZE by sysconf(_SC_PAGESIZE)");
-   CRT_pageSizeKB = CRT_pageSize / 1024;
 
    CRT_degreeSign = initDegreeSign();
 }

--- a/CRT.h
+++ b/CRT.h
@@ -156,9 +156,6 @@ extern const char* CRT_termType;
 
 extern int CRT_colorScheme;
 
-extern long CRT_pageSize;
-extern long CRT_pageSizeKB;
-
 #ifdef HAVE_SETUID_ENABLED
 
 void CRT_dropPrivileges(void);

--- a/Process.c
+++ b/Process.c
@@ -328,8 +328,8 @@ void Process_writeField(const Process* this, RichString* str, ProcessField field
    }
    case MAJFLT: Process_colorNumber(str, this->majflt, coloring); return;
    case MINFLT: Process_colorNumber(str, this->minflt, coloring); return;
-   case M_RESIDENT: Process_humanNumber(str, this->m_resident * CRT_pageSizeKB, coloring); return;
-   case M_VIRT: Process_humanNumber(str, this->m_virt * CRT_pageSizeKB, coloring); return;
+   case M_RESIDENT: Process_humanNumber(str, this->m_resident, coloring); return;
+   case M_VIRT: Process_humanNumber(str, this->m_virt, coloring); return;
    case NICE: {
       xSnprintf(buffer, n, "%3ld ", this->nice);
       attr = this->nice < 0 ? CRT_colors[PROCESS_HIGH_PRIORITY]

--- a/darwin/DarwinProcess.c
+++ b/darwin/DarwinProcess.c
@@ -258,8 +258,8 @@ void DarwinProcess_setFromLibprocPidinfo(DarwinProcess* proc, DarwinProcessList*
 
       proc->super.time = (pti.pti_total_system + pti.pti_total_user) / 10000000;
       proc->super.nlwp = pti.pti_threadnum;
-      proc->super.m_virt = pti.pti_virtual_size / CRT_pageSize;
-      proc->super.m_resident = pti.pti_resident_size / CRT_pageSize;
+      proc->super.m_virt = pti.pti_virtual_size / ONE_K;
+      proc->super.m_resident = pti.pti_resident_size / ONE_K;
       proc->super.majflt = pti.pti_faults;
       proc->super.percent_mem = (double)pti.pti_resident_size * 100.0
                               / (double)dpl->host_info.max_mem;

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -25,6 +25,8 @@ in the source distribution for its full text.
 
 /* semi-global */
 long long btime;
+int pageSize;
+int pageSizeKB;
 
 /* Used to identify kernel threads in Comm and Exe columns */
 static const char *const kthreadID = "KTHREAD";
@@ -632,19 +634,19 @@ static void LinuxProcess_writeField(const Process* this, RichString* str, Proces
    }
    case CMINFLT: Process_colorNumber(str, lp->cminflt, coloring); return;
    case CMAJFLT: Process_colorNumber(str, lp->cmajflt, coloring); return;
-   case M_DRS: Process_humanNumber(str, lp->m_drs * CRT_pageSizeKB, coloring); return;
-   case M_DT: Process_humanNumber(str, lp->m_dt * CRT_pageSizeKB, coloring); return;
+   case M_DRS: Process_humanNumber(str, lp->m_drs * pageSizeKB, coloring); return;
+   case M_DT: Process_humanNumber(str, lp->m_dt * pageSizeKB, coloring); return;
    case M_LRS:
       if (lp->m_lrs) {
-         Process_humanNumber(str, lp->m_lrs * CRT_pageSizeKB, coloring);
+         Process_humanNumber(str, lp->m_lrs * pageSizeKB, coloring);
          return;
       }
 
       attr = CRT_colors[PROCESS_SHADOW];
       xSnprintf(buffer, n, "  N/A ");
       break;
-   case M_TRS: Process_humanNumber(str, lp->m_trs * CRT_pageSizeKB, coloring); return;
-   case M_SHARE: Process_humanNumber(str, lp->m_share * CRT_pageSizeKB, coloring); return;
+   case M_TRS: Process_humanNumber(str, lp->m_trs * pageSizeKB, coloring); return;
+   case M_SHARE: Process_humanNumber(str, lp->m_share * pageSizeKB, coloring); return;
    case M_PSS: Process_humanNumber(str, lp->m_pss, coloring); return;
    case M_SWAP: Process_humanNumber(str, lp->m_swap, coloring); return;
    case M_PSSWP: Process_humanNumber(str, lp->m_psswp, coloring); return;

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -193,6 +193,10 @@ static inline bool Process_isUserlandThread(const Process* this) {
 
 extern long long btime;
 
+extern int pageSize;
+
+extern int pageSizeKB;
+
 extern ProcessFieldData Process_fields[];
 
 extern ProcessPidColumn Process_pidColumns[];


### PR DESCRIPTION
By storing the per-process m_resident and m_virt values in the form
htop wants to display them in (KB, not pages), we no longer need to
have definitions of pageSize and pageSizeKB in the common CRT code.

These variables were never really CRT (i.e. display) related in the
first place.  It turns out the darwin platform code doesn't need to
use these at all (the process values are extracted from the kernel
in bytes not pages) and the other platforms can each use their own
local pagesize variables, in more appropriate locations.

Some platforms were actually already doing this, so this change is
removing duplication of logic and variables there.