### PR TITLE
Unhardcode tick-to-ms conversion

### DIFF
--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -27,6 +27,8 @@ extern int Platform_numberOfFields;
 
 extern double Platform_timebaseToNS;
 
+extern long Platform_clockTicksPerSec;
+
 extern const SignalItem Platform_signals[];
 
 extern const unsigned int Platform_numberOfSignals;


### PR DESCRIPTION
Division by 100000.0  worked because `sysconf(_SC_CLK_TCK)` happened to be 100.

By unhardcoding:

1) It becomes more clear what this `10000.0` figure comes from.
2) It protects against bugs in the case `sysconf(_SC_CLK_TCK)` ever changes.