### PR TITLE
Drop redundant sys/dirent.h include

### DIFF
--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -14,7 +14,6 @@ in the source distribution for its full text.
 #include <stdlib.h>
 #include <string.h>
 #include <sys/_iovec.h>
-#include <sys/dirent.h>
 #include <sys/errno.h>
 #include <sys/param.h> // needs to be included before <sys/jail.h> for MAXPATHLEN
 #include <sys/jail.h>

--- a/iwyu/htop.imp
+++ b/iwyu/htop.imp
@@ -8,6 +8,8 @@
 
     { include: ["<bits/getopt_core.h>", "private", "<unistd.h>", "public"] },
 
+    { include: ["<sys/dirent.h>", "private", "<dirent.h>", "public"] },
+
     { include: ["<sys/signal.h>", "private", "<signal.h>", "public"] },
 
     { include: ["<sys/_stdarg.h>", "private", "<stdarg.h>", "public"] },


### PR DESCRIPTION
sys/dirent.h is included by dirent.h in FreeBSD, and does not exist in Debian GNU/kFreeBSD