### PR TITLE
Fix building against a CentOS 6 kernel

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -142,7 +142,7 @@ linux_platform_headers = \
 	zfs/ZfsCompressedArcMeter.h
 
 if HTOP_LINUX
-AM_LDFLAGS += -rdynamic
+AM_LDFLAGS += -rdynamic -lrt
 myhtopplatsources = \
 	linux/IOPriorityPanel.c \
 	linux/LibSensors.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -142,7 +142,7 @@ linux_platform_headers = \
 	zfs/ZfsCompressedArcMeter.h
 
 if HTOP_LINUX
-AM_LDFLAGS += -rdynamic -lrt
+AM_LDFLAGS += -rdynamic
 myhtopplatsources = \
 	linux/IOPriorityPanel.c \
 	linux/LibSensors.c \

--- a/configure.ac
+++ b/configure.ac
@@ -100,6 +100,7 @@ AC_CHECK_FUNCS([\
 ])
 
 AC_SEARCH_LIBS([dlopen], [dl dld])
+AC_SEARCH_LIBS([clock_gettime], [rt])
 
 save_cflags="${CFLAGS}"
 CFLAGS="${CFLAGS} -std=c99"

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -57,6 +57,7 @@ in the source distribution for its full text.
 #endif
 
 // CentOS 6's kernel doesn't provide a definition of O_PATH
+// based on definition taken from uapi/asm-generic/fcnth.h in Linux kernel tree
 #ifndef O_PATH
 # define O_PATH 010000000
 #endif

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -56,6 +56,11 @@ in the source distribution for its full text.
 #include "LibSensors.h"
 #endif
 
+// CentOS 6's kernel doesn't provide a definition of O_PATH
+#ifndef O_PATH
+# define O_PATH 010000000
+#endif
+
 
 static FILE* fopenat(openat_arg_t openatArg, const char* pathname, const char* mode) {
    assert(String_eq(mode, "r")); /* only currently supported mode */


### PR DESCRIPTION
This PR contains two minor fixes that were needed in conda-forge for htop 3.0.3 to be buildable against the CentOS 6 kernel headers.