### PR TITLE
Fix dlopen issue for libsensors5 in Debian Buster, Bullseye

### DIFF
--- a/linux/LibSensors.c
+++ b/linux/LibSensors.c
@@ -21,9 +21,13 @@ static void* dlopenHandle = NULL;
 
 int LibSensors_init(FILE* input) {
    if (!dlopenHandle) {
-      dlopenHandle = dlopen("libsensors.so", RTLD_LAZY);
-      if (!dlopenHandle)
-         goto dlfailure;
+      dlopenHandle = dlopen("libsensors.so.", RTLD_LAZY);
+      if (!dlopenHandle) {
+      /* Debian contains no unversioned .so in libsensors5, only in the -dev package, so work around that: */
+         dlopenHandle = dlopen("libsensors.so.5", RTLD_LAZY);
+         if (!dlopenHandle)
+            goto dlfailure;
+      }
 
       /* Clear any errors */
       dlerror();


### PR DESCRIPTION
libsensors.so is provided only by the -dev package, so search for
libsensors.so.5 (installed from the libsensors5 package) explicitly

see: dpkg-query -S libsensors.so