### PR TITLE
Harden makeCommandStr

### DIFF
--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -368,6 +368,13 @@ void LinuxProcess_makeCommandStr(Process* this) {
    char *str = strStart;
 
    int cmdlineBasenameOffset = lp->procCmdlineBasenameOffset;
+   int cmdlineBasenameEnd = lp->procCmdlineBasenameEnd;
+
+   if (!cmdline) {
+      cmdlineBasenameOffset = 0;
+      cmdlineBasenameEnd = 0;
+      cmdline = "(zombie)";
+   }
 
    if (!showMergedCommand || !procExe || !procComm) {    /* fall back to cmdline */
       if (showMergedCommand && !procExe && procComm && strlen(procComm)) {   /* Prefix column with comm */
@@ -385,11 +392,11 @@ void LinuxProcess_makeCommandStr(Process* this) {
       if (showProgramPath) {
          (void) stpcpyWithNewlineConversion(str, cmdline);
          mc->baseStart = cmdlineBasenameOffset;
-         mc->baseEnd = lp->procCmdlineBasenameEnd;
+         mc->baseEnd = cmdlineBasenameEnd;
       } else {
          (void) stpcpyWithNewlineConversion(str, cmdline + cmdlineBasenameOffset);
          mc->baseStart = 0;
-         mc->baseEnd = lp->procCmdlineBasenameEnd - cmdlineBasenameOffset;
+         mc->baseEnd = cmdlineBasenameEnd - cmdlineBasenameOffset;
       }
 
       if (mc->sep1) {

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -376,6 +376,9 @@ void LinuxProcess_makeCommandStr(Process* this) {
       cmdline = "(zombie)";
    }
 
+   assert(cmdlineBasenameOffset >= 0);
+   assert(cmdlineBasenameOffset <= strlen(cmdline));
+
    if (!showMergedCommand || !procExe || !procComm) {    /* fall back to cmdline */
       if (showMergedCommand && !procExe && procComm && strlen(procComm)) {   /* Prefix column with comm */
          if (strncmp(cmdline + cmdlineBasenameOffset, procComm, MINIMUM(TASK_COMM_LEN - 1, strlen(procComm))) != 0) {
@@ -410,6 +413,9 @@ void LinuxProcess_makeCommandStr(Process* this) {
    int exeLen = lp->procExeLen;
    int exeBasenameOffset = lp->procExeBasenameOffset;
    int exeBasenameLen = exeLen - exeBasenameOffset;
+
+   assert(exeBasenameOffset >= 0);
+   assert(exeBasenameOffset <= strlen(procExe));
 
    /* Start with copying exe */
    if (showProgramPath) {


### PR DESCRIPTION
This should resolve the NULL pointer dereference issues seen on Raspberry Pi as noted in #361.

The second patch also adds 4 additional in-depth checks to ensure we are always pointing inside the strings we process. These are not strictly necessary, but are defense-in-depth in case something else went wrong when reading these information.