### PR TITLE
fix argument type following prototype change in "Invert Process_compa…

### DIFF
--- a/solaris/SolarisProcess.c
+++ b/solaris/SolarisProcess.c
@@ -101,7 +101,7 @@ void SolarisProcess_writeField(const Process* this, RichString* str, ProcessFiel
    RichString_appendWide(str, attr, buffer);
 }
 
-long SolarisProcess_compareByKey(const void* v1, const void* v2, ProcessField key) {
+long SolarisProcess_compareByKey(const Process* v1, const Process* v2, ProcessField key) {
    const SolarisProcess* p1 = (const SolarisProcess*)v1;
    const SolarisProcess* p2 = (const SolarisProcess*)v2;
 


### PR DESCRIPTION
…re resolution so that superclass matches run first"

function prototype has been changed recently:
https://github.com/htop-dev/htop/commit/3d1703f16faf5bd3c73976909e1b6e03061a7f72#diff-b44874a4f5ef90eadea51feae4fe62ec855f1280d4e4e20106ecc719fc1dd6ddL59-R59