### PR TITLE
Linux: accept clock CPU frequency

### DIFF
--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -1793,7 +1793,9 @@ static void scanCPUFreqencyFromCPUinfo(LinuxProcessList* this) {
          continue;
       } else if (
          (sscanf(buffer, "cpu MHz : %lf", &frequency) == 1) ||
-         (sscanf(buffer, "cpu MHz: %lf", &frequency) == 1)
+         (sscanf(buffer, "cpu MHz: %lf", &frequency) == 1) ||
+         (sscanf(buffer, "clock : %lfMHz", &frequency) == 1) ||
+         (sscanf(buffer, "clock: %lfMHz", &frequency) == 1)
       ) {
          if (cpuid < 0 || cpuid > (cpus - 1)) {
             continue;


### PR DESCRIPTION
```
processor   : 0
cpu         : POWER8 (architected), altivec supported
clock       : 4024.000000MHz
revision    : 2.0 (pvr 004d 0200)
```

Closes: #424