### PR TITLE
Object: return int on comparison

### DIFF
--- a/ListItem.c
+++ b/ListItem.c
@@ -57,7 +57,7 @@ void ListItem_append(ListItem* this, const char* text) {
    this->value[newLen] = '\0';
 }
 
-static long ListItem_compare(const void* cast1, const void* cast2) {
+static int ListItem_compare(const void* cast1, const void* cast2) {
    const ListItem* obj1 = (const ListItem*) cast1;
    const ListItem* obj2 = (const ListItem*) cast2;
    return strcmp(obj1->value, obj2->value);

--- a/Object.h
+++ b/Object.h
@@ -24,7 +24,7 @@ struct Object_;
 typedef struct Object_ Object;
 
 typedef void(*Object_Display)(const Object*, RichString*);
-typedef long(*Object_Compare)(const void*, const void*);
+typedef int(*Object_Compare)(const void*, const void*);
 typedef void(*Object_Delete)(Object*);
 
 #define Object_getClass(obj_)         ((const Object*)(obj_))->klass

--- a/Process.c
+++ b/Process.c
@@ -476,14 +476,14 @@ bool Process_sendSignal(Process* this, Arg sgn) {
    return ok;
 }
 
-long Process_pidCompare(const void* v1, const void* v2) {
+int Process_pidCompare(const void* v1, const void* v2) {
    const Process* p1 = (const Process*)v1;
    const Process* p2 = (const Process*)v2;
 
    return SPACESHIP_NUMBER(p1->pid, p2->pid);
 }
 
-long Process_compare(const void* v1, const void* v2) {
+int Process_compare(const void* v1, const void* v2) {
    const Process *p1, *p2;
    const Settings *settings = ((const Process*)v1)->settings;
 
@@ -497,7 +497,7 @@ long Process_compare(const void* v1, const void* v2) {
 
    ProcessField key = Settings_getActiveSortKey(settings);
 
-   long result = Process_compareByKey(p1, p2, key);
+   int result = Process_compareByKey(p1, p2, key);
 
    // Implement tie-breaker (needed to make tree mode more stable)
    if (!result)
@@ -506,7 +506,7 @@ long Process_compare(const void* v1, const void* v2) {
    return result;
 }
 
-long Process_compareByKey_Base(const Process* p1, const Process* p2, ProcessField key) {
+int Process_compareByKey_Base(const Process* p1, const Process* p2, ProcessField key) {
    int r;
 
    switch (key) {

--- a/Process.h
+++ b/Process.h
@@ -122,7 +122,7 @@ typedef struct ProcessFieldData_ {
 
 // Implemented in platform-specific code:
 void Process_writeField(const Process* this, RichString* str, ProcessField field);
-long Process_compare(const void* v1, const void* v2);
+int Process_compare(const void* v1, const void* v2);
 void Process_delete(Object* cast);
 bool Process_isThread(const Process* this);
 extern const ProcessFieldData Process_fields[LAST_PROCESSFIELD];
@@ -131,7 +131,7 @@ extern int Process_pidDigits;
 
 typedef Process*(*Process_New)(const struct Settings_*);
 typedef void (*Process_WriteField)(const Process*, RichString*, ProcessField);
-typedef long (*Process_CompareByKey)(const Process*, const Process*, ProcessField);
+typedef int (*Process_CompareByKey)(const Process*, const Process*, ProcessField);
 typedef const char* (*Process_GetCommandStr)(const Process*);
 
 typedef struct ProcessClass_ {
@@ -199,8 +199,8 @@ bool Process_changePriorityBy(Process* this, Arg delta);
 
 bool Process_sendSignal(Process* this, Arg sgn);
 
-long Process_pidCompare(const void* v1, const void* v2);
+int Process_pidCompare(const void* v1, const void* v2);
 
-long Process_compareByKey_Base(const Process* p1, const Process* p2, ProcessField key);
+int Process_compareByKey_Base(const Process* p1, const Process* p2, ProcessField key);
 
 #endif

--- a/ProcessList.c
+++ b/ProcessList.c
@@ -348,14 +348,14 @@ static void ProcessList_buildTreeBranch(ProcessList* this, pid_t pid, int level,
    Vector_delete(children);
 }
 
-static long ProcessList_treeProcessCompare(const void* v1, const void* v2) {
+static int ProcessList_treeProcessCompare(const void* v1, const void* v2) {
    const Process *p1 = (const Process*)v1;
    const Process *p2 = (const Process*)v2;
 
    return SPACESHIP_NUMBER(p1->tree_left, p2->tree_left);
 }
 
-static long ProcessList_treeProcessCompareByPID(const void* v1, const void* v2) {
+static int ProcessList_treeProcessCompareByPID(const void* v1, const void* v2) {
    const Process *p1 = (const Process*)v1;
    const Process *p2 = (const Process*)v2;
 

--- a/darwin/DarwinProcess.c
+++ b/darwin/DarwinProcess.c
@@ -82,7 +82,7 @@ static void DarwinProcess_writeField(const Process* this, RichString* str, Proce
    RichString_appendWide(str, attr, buffer);
 }
 
-static long DarwinProcess_compareByKey(const Process* v1, const Process* v2, ProcessField key) {
+static int DarwinProcess_compareByKey(const Process* v1, const Process* v2, ProcessField key) {
    const DarwinProcess* p1 = (const DarwinProcess*)v1;
    const DarwinProcess* p2 = (const DarwinProcess*)v2;
 

--- a/dragonflybsd/DragonFlyBSDProcess.c
+++ b/dragonflybsd/DragonFlyBSDProcess.c
@@ -86,7 +86,7 @@ static void DragonFlyBSDProcess_writeField(const Process* this, RichString* str,
    RichString_appendWide(str, attr, buffer);
 }
 
-static long DragonFlyBSDProcess_compareByKey(const Process* v1, const Process* v2, ProcessField key) {
+static int DragonFlyBSDProcess_compareByKey(const Process* v1, const Process* v2, ProcessField key) {
    const DragonFlyBSDProcess* p1 = (const DragonFlyBSDProcess*)v1;
    const DragonFlyBSDProcess* p2 = (const DragonFlyBSDProcess*)v2;
 

--- a/freebsd/FreeBSDProcess.c
+++ b/freebsd/FreeBSDProcess.c
@@ -96,7 +96,7 @@ static void FreeBSDProcess_writeField(const Process* this, RichString* str, Proc
    RichString_appendWide(str, attr, buffer);
 }
 
-static long FreeBSDProcess_compareByKey(const Process* v1, const Process* v2, ProcessField key) {
+static int FreeBSDProcess_compareByKey(const Process* v1, const Process* v2, ProcessField key) {
    const FreeBSDProcess* p1 = (const FreeBSDProcess*)v1;
    const FreeBSDProcess* p2 = (const FreeBSDProcess*)v2;
 

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -748,7 +748,7 @@ static void LinuxProcess_writeField(const Process* this, RichString* str, Proces
    RichString_appendWide(str, attr, buffer);
 }
 
-static long LinuxProcess_compareByKey(const Process* v1, const Process* v2, ProcessField key) {
+static int LinuxProcess_compareByKey(const Process* v1, const Process* v2, ProcessField key) {
    const LinuxProcess* p1 = (const LinuxProcess*)v1;
    const LinuxProcess* p2 = (const LinuxProcess*)v2;
 

--- a/openbsd/OpenBSDProcess.c
+++ b/openbsd/OpenBSDProcess.c
@@ -202,7 +202,7 @@ static void OpenBSDProcess_writeField(const Process* this, RichString* str, Proc
    RichString_appendWide(str, attr, buffer);
 }
 
-static long OpenBSDProcess_compareByKey(const Process* v1, const Process* v2, ProcessField key) {
+static int OpenBSDProcess_compareByKey(const Process* v1, const Process* v2, ProcessField key) {
    const OpenBSDProcess* p1 = (const OpenBSDProcess*)v1;
    const OpenBSDProcess* p2 = (const OpenBSDProcess*)v2;
 

--- a/solaris/SolarisProcess.c
+++ b/solaris/SolarisProcess.c
@@ -101,7 +101,7 @@ void SolarisProcess_writeField(const Process* this, RichString* str, ProcessFiel
    RichString_appendWide(str, attr, buffer);
 }
 
-long SolarisProcess_compareByKey(const Process* v1, const Process* v2, ProcessField key) {
+int SolarisProcess_compareByKey(const Process* v1, const Process* v2, ProcessField key) {
    const SolarisProcess* p1 = (const SolarisProcess*)v1;
    const SolarisProcess* p2 = (const SolarisProcess*)v2;
 


### PR DESCRIPTION
Comparisons do, due to the new introduced shaceship-comparisons,
only return -1, 0, 1 or the result of strcmp().