### PR TITLE
Fix CPU percentage on M1 silicon Macs

### DIFF
--- a/darwin/DarwinProcessList.c
+++ b/darwin/DarwinProcessList.c
@@ -161,7 +161,7 @@ void ProcessList_delete(ProcessList* this) {
 
 static double ticksToNanoseconds(const double ticks) {
    const double nanos_per_sec = 1e9;
-   return ticks / (double) Platform_clockTicksPerSec * Platform_timebaseToNS * nanos_per_sec;
+   return (ticks / Platform_timebaseToNS) * (nanos_per_sec / (double) Platform_clockTicksPerSec);
 }
 
 void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {


### PR DESCRIPTION
Explanation in [this post](https://github.com/htop-dev/htop/issues/368#issuecomment-753439724), but TL;DR: CPU percentage was being divided by Platform_timebaseToNS instead of multiplied.

Resolves #368 