### PR TITLE
Linux: overhaul memory partition

### DIFF
--- a/MemoryMeter.c
+++ b/MemoryMeter.c
@@ -7,6 +7,8 @@ in the source distribution for its full text.
 
 #include "MemoryMeter.h"
 
+#include <math.h>
+
 #include "CRT.h"
 #include "Object.h"
 #include "Platform.h"
@@ -21,9 +23,15 @@ static const int MemoryMeter_attributes[] = {
 
 static void MemoryMeter_updateValues(Meter* this, char* buffer, size_t size) {
    int written;
+
+   /* available memory is not supported on all platforms */
+   this->values[3] = NAN;
    Platform_setMemoryValues(this);
 
-   written = Meter_humanUnit(buffer, this->values[0], size);
+   /* Do not print available memory in bar mode */
+   this->curItems = 3;
+
+   written = Meter_humanUnit(buffer, isnan(this->values[3]) ? this->values[0] : this->total - this->values[3], size);
    METER_BUFFER_CHECK(buffer, size, written);
 
    METER_BUFFER_APPEND_CHR(buffer, size, '/');
@@ -34,18 +42,29 @@ static void MemoryMeter_updateValues(Meter* this, char* buffer, size_t size) {
 static void MemoryMeter_display(const Object* cast, RichString* out) {
    char buffer[50];
    const Meter* this = (const Meter*)cast;
+
    RichString_writeAscii(out, CRT_colors[METER_TEXT], ":");
    Meter_humanUnit(buffer, this->total, sizeof(buffer));
    RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
+
    Meter_humanUnit(buffer, this->values[0], sizeof(buffer));
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " used:");
    RichString_appendAscii(out, CRT_colors[MEMORY_USED], buffer);
+
    Meter_humanUnit(buffer, this->values[1], sizeof(buffer));
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " buffers:");
    RichString_appendAscii(out, CRT_colors[MEMORY_BUFFERS_TEXT], buffer);
+
    Meter_humanUnit(buffer, this->values[2], sizeof(buffer));
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " cache:");
    RichString_appendAscii(out, CRT_colors[MEMORY_CACHE], buffer);
+
+   /* available memory is not supported on all platforms */
+   if (!isnan(this->values[3])) {
+      Meter_humanUnit(buffer, this->values[3], sizeof(buffer));
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], " available:");
+      RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
+   }
 }
 
 const MeterClass MemoryMeter_class = {
@@ -56,7 +75,7 @@ const MeterClass MemoryMeter_class = {
    },
    .updateValues = MemoryMeter_updateValues,
    .defaultMode = BAR_METERMODE,
-   .maxItems = 3,
+   .maxItems = 4,
    .total = 100.0,
    .attributes = MemoryMeter_attributes,
    .name = "Memory",

--- a/ProcessList.h
+++ b/ProcessList.h
@@ -34,6 +34,9 @@ in the source distribution for its full text.
 #define MAX_READ 2048
 #endif
 
+typedef unsigned long long int memory_t;
+#define MEMORY_MAX ULLONG_MAX
+
 typedef struct ProcessList_ {
    const Settings* settings;
 
@@ -61,14 +64,15 @@ typedef struct ProcessList_ {
    int userlandThreads;
    int kernelThreads;
 
-   unsigned long long int totalMem;
-   unsigned long long int usedMem;
-   unsigned long long int buffersMem;
-   unsigned long long int cachedMem;
+   memory_t totalMem;
+   memory_t usedMem;
+   memory_t buffersMem;
+   memory_t cachedMem;
+   memory_t availableMem;
 
-   unsigned long long int totalSwap;
-   unsigned long long int usedSwap;
-   unsigned long long int cachedSwap;
+   memory_t totalSwap;
+   memory_t usedSwap;
+   memory_t cachedSwap;
 
    int cpuCount;
 

--- a/linux/HugePageMeter.c
+++ b/linux/HugePageMeter.c
@@ -35,7 +35,7 @@ static void HugePageMeter_updateValues(Meter* this, char* buffer, size_t size) {
    assert(ARRAYSIZE(HugePageMeter_labels) == HTOP_HUGEPAGE_COUNT);
 
    int written;
-   unsigned long long int usedTotal = 0;
+   memory_t usedTotal = 0;
    unsigned nextUsed = 0;
 
    const LinuxProcessList* lpl = (const LinuxProcessList*) this->pl;
@@ -47,8 +47,8 @@ static void HugePageMeter_updateValues(Meter* this, char* buffer, size_t size) {
       HugePageMeter_active_labels[i] = NULL;
    }
    for (unsigned i = 0; i < HTOP_HUGEPAGE_COUNT; i++) {
-      unsigned long long int value = lpl->usedHugePageMem[i];
-      if (value != ULLONG_MAX) {
+      memory_t value = lpl->usedHugePageMem[i];
+      if (value != MEMORY_MAX) {
          this->values[nextUsed] = value;
          usedTotal += value;
          HugePageMeter_active_labels[nextUsed] = HugePageMeter_labels[i];

--- a/linux/LinuxProcessList.h
+++ b/linux/LinuxProcessList.h
@@ -74,8 +74,10 @@ typedef struct LinuxProcessList_ {
    int netlink_family;
    #endif
 
-   unsigned long long int totalHugePageMem;
-   unsigned long long int usedHugePageMem[HTOP_HUGEPAGE_COUNT];
+   memory_t totalHugePageMem;
+   memory_t usedHugePageMem[HTOP_HUGEPAGE_COUNT];
+
+   memory_t availableMem;
 
    ZfsArcStats zfs;
    ZramStats zram;

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -283,14 +283,11 @@ void Platform_setMemoryValues(Meter* this) {
    const ProcessList* pl = this->pl;
    const LinuxProcessList* lpl = (const LinuxProcessList*) pl;
 
-   long int usedMem = pl->usedMem;
-   long int buffersMem = pl->buffersMem;
-   long int cachedMem = pl->cachedMem;
-   usedMem -= buffersMem + cachedMem + lpl->totalHugePageMem;
-   this->total = pl->totalMem - lpl->totalHugePageMem;
-   this->values[0] = usedMem;
-   this->values[1] = buffersMem;
-   this->values[2] = cachedMem;
+   this->total     = pl->totalMem;
+   this->values[0] = pl->usedMem;
+   this->values[1] = pl->buffersMem;
+   this->values[2] = pl->cachedMem;
+   this->values[3] = pl->availableMem;
 
    if (lpl->zfs.enabled != 0) {
       this->values[0] -= lpl->zfs.size;

--- a/linux/ZramStats.h
+++ b/linux/ZramStats.h
@@ -2,9 +2,9 @@
 #define HEADER_ZramStats
 
 typedef struct ZramStats_ {
-   unsigned long long int totalZram;
-   unsigned long long int usedZramComp;
-   unsigned long long int usedZramOrig;
+   memory_t totalZram;
+   memory_t usedZramComp;
+   memory_t usedZramOrig;
 } ZramStats;
 
 #endif


### PR DESCRIPTION
![Screenshot_20210122_200221](https://user-images.githubusercontent.com/6131885/105533884-0113a000-5ced-11eb-8e57-a2702e71a70a.png)

![Screenshot_1](https://user-images.githubusercontent.com/6131885/105537474-42f31500-5cf2-11eb-951a-4396067f3f49.jpeg)

Use similar calculation than procps.
Show AvailableMemory in text mode.
Use total minus available memory as lower number in bar mode (if available).

Alternative to #385