### PR TITLE
Drop usage of formatted error messages from <err.h>

### DIFF
--- a/darwin/DarwinProcessList.c
+++ b/darwin/DarwinProcessList.c
@@ -7,7 +7,6 @@ in the source distribution for its full text.
 
 #include "DarwinProcessList.h"
 
-#include <err.h>
 #include <errno.h>
 #include <libproc.h>
 #include <stdbool.h>

--- a/dragonflybsd/DragonFlyBSDProcessList.c
+++ b/dragonflybsd/DragonFlyBSDProcessList.c
@@ -15,7 +15,6 @@ in the source distribution for its full text.
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #include <sys/user.h>
-#include <err.h>
 #include <fcntl.h>
 #include <limits.h>
 #include <string.h>
@@ -112,7 +111,7 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidMatchList, ui
 
    dfpl->kd = kvm_openfiles(NULL, "/dev/null", NULL, 0, errbuf);
    if (dfpl->kd == NULL) {
-      errx(1, "kvm_open: %s", errbuf);
+      CRT_fatalError("kvm_openfiles() failed");
    }
 
    return pl;
@@ -294,25 +293,20 @@ static inline void DragonFlyBSDProcessList_scanJails(DragonFlyBSDProcessList* df
    char* nextpos;
 
    if (sysctlbyname("jail.list", NULL, &len, NULL, 0) == -1) {
-      fprintf(stderr, "initial sysctlbyname / jail.list failed\n");
-      exit(3);
+      CRT_fatalError("initial sysctlbyname / jail.list failed");
    }
 retry:
    if (len == 0)
       return;
 
    jls = xMalloc(len);
-   if (jls == NULL) {
-      fprintf(stderr, "xMalloc failed\n");
-      exit(4);
-   }
+
    if (sysctlbyname("jail.list", jls, &len, NULL, 0) == -1) {
       if (errno == ENOMEM) {
          free(jls);
          goto retry;
       }
-      fprintf(stderr, "sysctlbyname / jail.list failed\n");
-      exit(5);
+      CRT_fatalError("sysctlbyname / jail.list failed");
    }
 
    if (dfpl->jails) {

--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -9,7 +9,6 @@ in the source distribution for its full text.
 
 #include <assert.h>
 #include <dirent.h>
-#include <err.h>
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
@@ -145,7 +144,7 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidMatchList, ui
 
    fpl->kd = kvm_openfiles(NULL, "/dev/null", NULL, 0, errbuf);
    if (fpl->kd == NULL) {
-      errx(1, "kvm_open: %s", errbuf);
+      CRT_fatalError("kvm_openfiles() failed");
    }
 
    fpl->ttys = Hashtable_new(20, true);

--- a/openbsd/OpenBSDProcessList.c
+++ b/openbsd/OpenBSDProcessList.c
@@ -8,7 +8,6 @@ in the source distribution for its full text.
 
 #include "OpenBSDProcessList.h"
 
-#include <err.h>
 #include <kvm.h>
 #include <limits.h>
 #include <stdlib.h>
@@ -57,11 +56,11 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidMatchList, ui
 
    size = sizeof(fscale);
    if (sysctl(fmib, 2, &fscale, &size, NULL, 0) < 0) {
-      err(1, "fscale sysctl call failed");
+      CRT_fatalError("fscale sysctl call failed");
    }
 
    if ((pageSize = sysconf(_SC_PAGESIZE)) == -1)
-      err(1, "pagesize sysconf call failed");
+      CRT_fatalError("pagesize sysconf call failed");
    pageSizeKB = pageSize / ONE_K;
 
    for (int i = 0; i <= pl->cpuCount; i++) {
@@ -72,7 +71,7 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidMatchList, ui
 
    opl->kd = kvm_openfiles(NULL, NULL, NULL, KVM_NO_FILES, errbuf);
    if (opl->kd == NULL) {
-      errx(1, "kvm_open: %s", errbuf);
+      CRT_fatalError("kvm_openfiles() failed");
    }
 
    return pl;
@@ -97,7 +96,7 @@ static void OpenBSDProcessList_scanMemoryInfo(ProcessList* pl) {
    size_t size_uvmexp = sizeof(uvmexp);
 
    if (sysctl(uvmexp_mib, 2, &uvmexp, &size_uvmexp, NULL, 0) < 0) {
-      err(1, "uvmexp sysctl call failed");
+      CRT_fatalError("uvmexp sysctl call failed");
    }
 
    pl->totalMem = uvmexp.npages * pageSizeKB;
@@ -109,7 +108,7 @@ static void OpenBSDProcessList_scanMemoryInfo(ProcessList* pl) {
    size_t size_bcstats = sizeof(bcstats);
 
    if (sysctl(bcache_mib, 3, &bcstats, &size_bcstats, NULL, 0) < 0) {
-      err(1, "cannot get vfs.bcachestat");
+      CRT_fatalError("cannot get vfs.bcachestat");
    }
 
    pl->cachedMem = bcstats.numbufpages * pageSizeKB;

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -14,7 +14,6 @@ in the source distribution for its full text.
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/user.h>
-#include <err.h>
 #include <limits.h>
 #include <string.h>
 #include <procfs.h>


### PR DESCRIPTION
They do not clean up the ncurses environment, leaving the terminal in a
broken state.

Also drop bare usage of exit(3).