### PR TITLE
InfoScreen: fix uncontrolled format string

### DIFF
--- a/InfoScreen.c
+++ b/InfoScreen.c
@@ -54,7 +54,7 @@ void InfoScreen_drawTitled(InfoScreen* this, const char* fmt, ...) {
 
    attrset(CRT_colors[METER_TEXT]);
    mvhline(0, 0, ' ', COLS);
-   mvwprintw(stdscr, 0, 0, title);
+   mvaddstr(0, 0, title);
    attrset(CRT_colors[DEFAULT_COLOR]);
    Panel_draw(this->display, true, true, true, false);
 


### PR DESCRIPTION
mvwprintw takes a format string as its fourth argument, and title is
user-controlled. This results in e.g. crashing when trying to trace a
process with a format specifier in its command line.