### PR TITLE
CI: enable format attributes in ncurses headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: CI
 
 on: [ push, pull_request ]
 
+env:
+  # Enable format attributes in ncurses headers
+  # Enable fortified memory/string handling
+  CPPFLAGS: -DGCC_PRINTF -DGCC_SCANF -D_FORTIFY_SOURCE=2
+
 jobs:
   build-ubuntu-latest-minimal-gcc:
     runs-on: ubuntu-latest
@@ -47,6 +52,10 @@ jobs:
 
   build-ubuntu-latest-full-featured-gcc:
     runs-on: ubuntu-latest
+    # Enable LTO, might trigger additional warnings on advanced inlining
+    env:
+      CFLAGS: -O3 -g -flto
+      LDFLAGS: -O3 -g -flto
     steps:
     - uses: actions/checkout@v2
     - name: Install Dependencies

--- a/CRT.c
+++ b/CRT.c
@@ -818,9 +818,13 @@ void CRT_handleSIGSEGV(int signal) {
       "- Your OS and kernel version (uname -a)\n"
       "- Your distribution and release (lsb_release -a)\n"
       "- Likely steps to reproduce (How did it happened?)\n"
+   );
+
 #ifdef HAVE_EXECINFO_H
-      "- Backtrace of the issue (see below)\n"
+   fprintf(stderr, "- Backtrace of the issue (see below)\n");
 #endif
+
+   fprintf(stderr,
       "\n"
    );
 
@@ -855,11 +859,15 @@ void CRT_handleSIGSEGV(int signal) {
       "you should provide a disassembly of your binary.\n"
       "This can usually be done by running the following command:\n"
       "\n"
+   );
+
 #ifdef HTOP_DARWIN
-      "   otool -tvV `which htop` > ~/htop.otool\n"
+   fprintf(stderr, "   otool -tvV `which htop` > ~/htop.otool\n");
 #else
-      "   objdump -d -S -w `which htop` > ~/htop.objdump\n"
+   fprintf(stderr, "   objdump -d -S -w `which htop` > ~/htop.objdump\n");
 #endif
+
+   fprintf(stderr,
       "\n"
       "Please include the generated file in your report.\n"
       "\n"


### PR DESCRIPTION
Avoid format string issues like bfcb8ca by helping compilers spot such
bogus usages.

Also use LTO and O3 in the full-featured gcc job, which might trigger
additional warnings on advanced inlining, like 3695cbd and ad3acfc