### PR TITLE
InfoScreen: fix mouse selection and add mouse wheel scrolling

### DIFF
--- a/InfoScreen.c
+++ b/InfoScreen.c
@@ -109,11 +109,19 @@ void InfoScreen_run(InfoScreen* this) {
          MEVENT mevent;
          int ok = getmouse(&mevent);
          if (ok == OK) {
-            if (mevent.y >= panel->y && mevent.y < LINES - 1) {
-               Panel_setSelected(panel, mevent.y - panel->y + panel->scrollV - 1);
-               ch = 0;
-            } else if (mevent.y == LINES - 1) {
-               ch = IncSet_synthesizeEvent(this->inc, mevent.x);
+            if (mevent.bstate & BUTTON1_RELEASED) {
+               if (mevent.y >= panel->y && mevent.y < LINES - 1) {
+                  Panel_setSelected(panel, mevent.y - panel->y + panel->scrollV - 1);
+                  ch = 0;
+               } else if (mevent.y == LINES - 1) {
+                  ch = IncSet_synthesizeEvent(this->inc, mevent.x);
+               }
+            #if NCURSES_MOUSE_VERSION > 1
+            } else if (mevent.bstate & BUTTON4_PRESSED) {
+               ch = KEY_WHEELUP;
+            } else if (mevent.bstate & BUTTON5_PRESSED) {
+               ch = KEY_WHEELDOWN;
+            #endif
             }
          }
       }

--- a/InfoScreen.c
+++ b/InfoScreen.c
@@ -110,7 +110,7 @@ void InfoScreen_run(InfoScreen* this) {
          int ok = getmouse(&mevent);
          if (ok == OK) {
             if (mevent.y >= panel->y && mevent.y < LINES - 1) {
-               Panel_setSelected(panel, mevent.y - panel->y + panel->scrollV);
+               Panel_setSelected(panel, mevent.y - panel->y + panel->scrollV - 1);
                ch = 0;
             } else if (mevent.y == LINES - 1) {
                ch = IncSet_synthesizeEvent(this->inc, mevent.x);

--- a/InfoScreen.c
+++ b/InfoScreen.c
@@ -116,13 +116,14 @@ void InfoScreen_run(InfoScreen* this) {
                } else if (mevent.y == LINES - 1) {
                   ch = IncSet_synthesizeEvent(this->inc, mevent.x);
                }
+            }
             #if NCURSES_MOUSE_VERSION > 1
-            } else if (mevent.bstate & BUTTON4_PRESSED) {
+            else if (mevent.bstate & BUTTON4_PRESSED) {
                ch = KEY_WHEELUP;
             } else if (mevent.bstate & BUTTON5_PRESSED) {
                ch = KEY_WHEELDOWN;
-            #endif
             }
+            #endif
          }
       }
 

--- a/TraceScreen.c
+++ b/TraceScreen.c
@@ -42,7 +42,7 @@ TraceScreen* TraceScreen_new(const Process* process) {
    this->tracing = true;
    FunctionBar* fuBar = FunctionBar_new(TraceScreenFunctions, TraceScreenKeys, TraceScreenEvents);
    CRT_disableDelay();
-   return (TraceScreen*) InfoScreen_init(&this->super, process, fuBar, LINES - 2, "");
+   return (TraceScreen*) InfoScreen_init(&this->super, process, fuBar, LINES - 2, " ");
 }
 
 void TraceScreen_delete(Object* cast) {


### PR DESCRIPTION
Line number is incorrectly calculated when selecting with mouse in InfoScreen. It also lacks the mouse scrolling, and scroll is handled as a click.