### PR TITLE
Define PATH_MAX for GNU/hurd

### DIFF
--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -42,6 +42,7 @@ in the source distribution for its full text.
 #include "LinuxProcess.h"
 #include "Macros.h"
 #include "Object.h"
+#include "Platform.h" // needed for GNU/hurd to get PATH_MAX
 #include "Process.h"
 #include "Settings.h"
 #include "XUtils.h"

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -14,7 +14,6 @@ in the source distribution for its full text.
 #include <dirent.h>
 #include <fcntl.h>
 #include <inttypes.h>
-#include <limits.h>
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -7,6 +7,7 @@ Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include <limits.h>
 #include <stdbool.h>
 #include <sys/types.h>
 
@@ -17,6 +18,12 @@ in the source distribution for its full text.
 #include "Process.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
+
+/* GNU/Hurd does not have PATH_MAX in limits.h */
+#ifndef PATH_MAX
+   #define PATH_MAX 4096
+#endif
+
 
 extern const ProcessField Platform_defaultFields[];
 


### PR DESCRIPTION
Otherwise fails with
"> linux/LinuxProcessList.c:889:20: error: ‘PATH_MAX’ undeclared (first use in this function)"