### PR TITLE
configure overhaul

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: ./configure --enable-werror --enable-linux-affinity --disable-unicode --without-sensors
+      run: ./configure --enable-werror --enable-linux-affinity --disable-unicode --disable-sensors
     - name: Enable compatibility modes
       run: |
         sed -i 's/#define HAVE_FSTATAT 1/#undef HAVE_FSTATAT/g' config.h
@@ -26,7 +26,7 @@ jobs:
     - name: Build
       run: make -k
     - name: Distcheck
-      run: make distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-werror --enable-linux-affinity --disable-unicode --without-sensors"
+      run: make distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-werror --enable-linux-affinity --disable-unicode --disable-sensors"
 
   build-ubuntu-latest-minimal-clang:
     runs-on: ubuntu-latest
@@ -44,11 +44,11 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: ./configure --enable-werror --enable-linux-affinity --disable-unicode --without-sensors
+      run: ./configure --enable-werror --enable-linux-affinity --disable-unicode --disable-sensors
     - name: Build
       run: make -k
     - name: Distcheck
-      run: make distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-werror --enable-linux-affinity --disable-unicode --without-sensors"
+      run: make distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-werror --enable-linux-affinity --disable-unicode --disable-sensors"
 
   build-ubuntu-latest-full-featured-gcc:
     runs-on: ubuntu-latest
@@ -63,11 +63,11 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: ./configure --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --with-sensors --with-capabilities
+      run: ./configure --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors --enable-capabilities
     - name: Build
       run: make -k
     - name: Distcheck
-      run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --with-sensors --with-capabilities'
+      run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors --enable-capabilities'
 
   build-ubuntu-latest-full-featured-clang:
     runs-on: ubuntu-latest
@@ -85,11 +85,11 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: ./configure --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --with-sensors --with-capabilities
+      run: ./configure --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors --enable-capabilities
     - name: Build
       run: make -k
     - name: Distcheck
-      run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --with-sensors --with-capabilities'
+      run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors --enable-capabilities'
 
   build-ubuntu-latest-clang-analyzer:
     runs-on: ubuntu-latest
@@ -107,7 +107,7 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: scan-build-11 -analyze-headers --status-bugs ./configure --enable-debug --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --with-sensors --with-capabilities
+      run: scan-build-11 -analyze-headers --status-bugs ./configure --enable-debug --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors --enable-capabilities
     - name: Build
       run: scan-build-11 -analyze-headers --status-bugs make -j"$(nproc)"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,25 @@ jobs:
     - name: Distcheck
       run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --enable-sensors --enable-capabilities'
 
+  build-ubuntu-latest-gcc-static:
+    runs-on: ubuntu-latest
+    # Enable LTO, might trigger additional warnings on advanced inlining
+    env:
+      CFLAGS: -O3 -g -flto
+      LDFLAGS: -O3 -g -flto
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Dependencies
+      run: sudo apt-get install libncursesw5-dev libtinfo-dev libgpm-dev libsensors4-dev libcap-dev
+    - name: Bootstrap
+      run: ./autogen.sh
+    - name: Configure
+      run: ./configure --enable-static --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --disable-hwloc --enable-setuid --disable-delayacct --enable-sensors --enable-capabilities
+    - name: Build
+      run: make -k
+    - name: Distcheck
+      run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-static --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --disable-hwloc --enable-setuid --disable-delayacct --enable-sensors --enable-capabilities'
+
   build-ubuntu-latest-clang-analyzer:
     runs-on: ubuntu-latest
     env:

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,8 +3,16 @@ AUTOMAKE_OPTIONS = subdir-objects
 bin_PROGRAMS = htop
 
 dist_man_MANS = htop.1
-EXTRA_DIST = $(dist_man_MANS) htop.desktop htop.png htop.svg \
-install-sh autogen.sh missing
+EXTRA_DIST = \
+	$(dist_man_MANS) \
+	autogen.sh \
+	htop.desktop \
+	htop.png \
+	htop.svg \
+	build-aux/compile \
+	build-aux/depcomp \
+	build-aux/install-sh \
+	build-aux/missing
 applicationsdir = $(datadir)/applications
 applications_DATA = htop.desktop
 pixmapdir = $(datadir)/pixmaps

--- a/README
+++ b/README
@@ -44,6 +44,59 @@ install the header files for `ncurses` (libncursesw*-dev) and other required dev
 
 By default `make install` will install into `/usr/local`, for changing the path use `./configure --prefix=/some/path`.
 
+### Build Options
+
+`htop` has several build-time options to enable/disable additional features.
+
+#### Generic
+
+  * `--enable-unicode`:
+    enable Unicode support
+    dependency: *libncursesw*
+    default: *yes*
+  * `--enable-hwloc`:
+    enable hwloc support for CPU affinity; disables Linux affinity
+    dependency: *libhwloc*
+    default: *no*
+  * `--enable-setuid`:
+    enable setuid support for privilege dropping
+    default: *no*
+  * `--enable-debug`:
+    Enable asserts and internal sanity checks; implies a performance penalty
+    default: *no*
+
+#### Linux
+
+  * `--enable-sensors`:
+    enable libsensors(3) support for reading temperature data
+    dependencies: *libsensors-dev*(build-time), at runtime *libsensors* is loaded via `dlopen(3)` if available
+    default: *check*
+  * `--enable-capabilities`:
+    enable Linux capabilities support
+    dependency: *libcap*
+    default: *check*
+  * `--with-proc`:
+    location of a Linux-compatible proc filesystem
+    default: */proc*
+  * `--enable-openvz`:
+    enable OpenVZ support
+    default: *no*
+  * `--enable-vserver`:
+    enable VServer support
+    default: *no*
+  * `--enable-ancient-vserver`:
+    enable ancient VServer support (implies `--enable-vserver`)
+    default: *no*
+   * `--enable-linux-affinity`:
+    enable Linux `sched_setaffinity(2)` and `sched_getaffinity(2)` for affinity support; conflicts with hwloc
+    default: *check*
+  * `--enable-delayacct`:
+    enable Linux delay accounting support
+    dependencies: *pkg-config*(build-time), *libnl-3* and *libnl-genl-3*
+    default: *check*
+
+## Usage
+
 See the manual page (`man htop`) or the on-line help ('F1' or 'h' inside `htop`) for a list of supported key commands.
 
 ## Support

--- a/README
+++ b/README
@@ -61,6 +61,9 @@ By default `make install` will install into `/usr/local`, for changing the path 
   * `--enable-setuid`:
     enable setuid support for privilege dropping
     default: *no*
+  *`--enable-static`:
+    build a static htop binary; hwloc and delay accounting are not supported
+    default: *no*
   * `--enable-debug`:
     Enable asserts and internal sanity checks; implies a performance penalty
     default: *no*

--- a/configure.ac
+++ b/configure.ac
@@ -84,7 +84,7 @@ AC_CHECK_HEADERS([ \
     sys/param.h \
     sys/time.h \
     unistd.h
-   ], [], [missing_headers="$missing_headers $ac_header"])
+   ], [], [AC_MSG_ERROR([can not find required generic header files])])
 
 AC_HEADER_MAJOR
 dnl glibc 2.25 deprecates 'major' and 'minor' in <sys/types.h> and requires to
@@ -125,29 +125,29 @@ AC_TYPE_UINT64_T
 # Checks for generic library functions.
 # ----------------------------------------------------------------------
 
-AC_CHECK_LIB([m], [ceil], [], [missing_libraries="$missing_libraries libm"])
+AC_CHECK_LIB([m], [ceil], [], [AC_MSG_ERROR([can not find required function ceil()])])
 
 if test "$my_htop_platform" = dragonflybsd; then
-   AC_SEARCH_LIBS([kvm_open], [kvm], [], [missing_libraries="$missing_libraries libkvm"])
+   AC_SEARCH_LIBS([kvm_open], [kvm], [], [AC_MSG_ERROR([can not find required function kvm_open()])])
 fi
 
 if test "$my_htop_platform" = freebsd; then
-   AC_SEARCH_LIBS([kvm_open], [kvm], [], [missing_libraries="$missing_libraries libkvm"])
-   AC_SEARCH_LIBS([devstat_checkversion], [devstat], [], [missing_libraries="$missing_libraries libdevstat"])
+   AC_SEARCH_LIBS([kvm_open], [kvm], [], [AC_MSG_ERROR([can not find required function kvm_open()])])
+   AC_SEARCH_LIBS([devstat_checkversion], [devstat], [], [AC_MSG_ERROR([can not find required function devstat_checkversion()])])
 fi
 
 if test "$my_htop_platform" = linux; then
-   AC_SEARCH_LIBS([dlopen], [dl dld], [], [missing_libraries="$missing_libraries libdl/libdld"])
+   AC_SEARCH_LIBS([dlopen], [dl dld], [], [AC_MSG_ERROR([can not find required function dlopen()])])
 fi
 
 if test "$my_htop_platform" = openbsd; then
-   AC_SEARCH_LIBS([kvm_open], [kvm], [], [missing_libraries="$missing_libraries libkvm"])
+   AC_SEARCH_LIBS([kvm_open], [kvm], [], [AC_MSG_ERROR([can not find required function kvm_open()])])
 fi
 
 if test "$my_htop_platform" = solaris; then
-   AC_SEARCH_LIBS([kstat_open], [kstat], [], [missing_libraries="$missing_libraries libkstat"])
-   AC_SEARCH_LIBS([Pgrab_error], [proc], [], [missing_libraries="$missing_libraries libproc"])
-   AC_SEARCH_LIBS([free], [malloc], [], [missing_libraries="$missing_libraries libmalloc"])
+   AC_SEARCH_LIBS([kstat_open], [kstat], [], [AC_MSG_ERROR([can not find required function kstat_open()])])
+   AC_SEARCH_LIBS([Pgrab_error], [proc], [], [AC_MSG_ERROR([can not find required function Pgrab_error()])])
+   AC_SEARCH_LIBS([free], [malloc], [], [AC_MSG_ERROR([can not find required function free()])])
 fi
 
 # Optional Section
@@ -230,30 +230,31 @@ if test "x$enable_unicode" = xyes; then
        HTOP_CHECK_LIB([ncursesw6], [addnwstr], [HAVE_LIBNCURSESW],
         HTOP_CHECK_LIB([ncursesw], [addnwstr], [HAVE_LIBNCURSESW],
          HTOP_CHECK_LIB([ncurses], [addnwstr], [HAVE_LIBNCURSESW],
-      missing_libraries="$missing_libraries libncursesw"
-      AC_MSG_ERROR([You may want to use --disable-unicode or install libncursesw.])
+          AC_MSG_ERROR([can not find required library libncursesw; you may want to use --disable-unicode])
    )))))))
 
-   AC_CHECK_HEADERS([ncursesw/curses.h],[:],
-      [AC_CHECK_HEADERS([ncurses/ncurses.h],[:],
-         [AC_CHECK_HEADERS([ncurses/curses.h],[:],
-            [AC_CHECK_HEADERS([ncurses.h],[:],[missing_headers="$missing_headers $ac_header"])])])])
+   AC_CHECK_HEADERS([ncursesw/curses.h], [],
+      [AC_CHECK_HEADERS([ncurses/ncurses.h], [],
+         [AC_CHECK_HEADERS([ncurses/curses.h], [],
+            [AC_CHECK_HEADERS([ncurses.h], [],
+               [AC_MSG_ERROR([can not find required ncurses header file])])])])])
 
    # check if additional linker flags are needed for keypad(3)
    # (at this point we already link against a working ncurses library with wide character support)
    AC_SEARCH_LIBS([keypad], [tinfow tinfo])
 else
-   HTOP_CHECK_SCRIPT([ncurses6], [refresh], [HAVE_LIBNCURSES], "ncurses6-config",
-    HTOP_CHECK_SCRIPT([ncurses], [refresh], [HAVE_LIBNCURSES], "ncurses5-config",
+   HTOP_CHECK_SCRIPT([ncurses6], [refresh], [HAVE_LIBNCURSES], [ncurses6-config],
+    HTOP_CHECK_SCRIPT([ncurses], [refresh], [HAVE_LIBNCURSES], [ncurses5-config],
      HTOP_CHECK_LIB([ncurses6],  [refresh], [HAVE_LIBNCURSES],
       HTOP_CHECK_LIB([ncurses],  [refresh], [HAVE_LIBNCURSES],
-      missing_libraries="$missing_libraries libncurses"
+       AC_MSG_ERROR([can not find required library libncurses])
    ))))
 
-   AC_CHECK_HEADERS([curses.h],[:],
-      [AC_CHECK_HEADERS([ncurses/curses.h],[:],
-         [AC_CHECK_HEADERS([ncurses/ncurses.h],[:],
-            [AC_CHECK_HEADERS([ncurses.h],[:],[missing_headers="$missing_headers $ac_header"])])])])
+   AC_CHECK_HEADERS([curses.h], [],
+      [AC_CHECK_HEADERS([ncurses/curses.h], [],
+         [AC_CHECK_HEADERS([ncurses/ncurses.h], [],
+            [AC_CHECK_HEADERS([ncurses.h] ,[],
+               [AC_MSG_ERROR([can not find required ncurses header file])])])])])
 
    # check if additional linker flags are needed for keypad(3)
    # (at this point we already link against a working ncurses library)
@@ -270,8 +271,8 @@ case "$enable_hwloc" in
    no)
       ;;
    yes)
-      AC_CHECK_LIB([hwloc], [hwloc_get_proc_cpubind], [], [missing_libraries="$missing_libraries libhwloc"])
-      AC_CHECK_HEADERS([hwloc.h], [], [missing_headers="$missing_headers $ac_header"])
+      AC_CHECK_LIB([hwloc], [hwloc_get_proc_cpubind], [], [AC_MSG_ERROR([can not find required library libhwloc])])
+      AC_CHECK_HEADERS([hwloc.h], [], [AC_MSG_ERROR([can not find require header file hwloc.h])])
       ;;
    *)
       AC_MSG_ERROR([bad value '$enable_hwloc' for --enable-hwloc])
@@ -386,8 +387,8 @@ case "$enable_capabilities" in
       AC_CHECK_HEADERS([sys/capability.h], [], [enable_capabilities=no])
       ;;
    yes)
-      AC_CHECK_LIB([cap], [cap_init], [], [missing_libraries="$missing_libraries libcap"])
-      AC_CHECK_HEADERS([sys/capability.h], [], [missing_headers="$missing_headers $ac_header"])
+      AC_CHECK_LIB([cap], [cap_init], [], [AC_MSG_ERROR([can not find required library libcap])])
+      AC_CHECK_HEADERS([sys/capability.h], [], [AC_MSG_ERROR([can not find required header file sys/capability.h])])
       ;;
    *)
       AC_MSG_ERROR([bad value '$enable_capabilities' for --enable-capabilities])
@@ -422,8 +423,8 @@ case "$enable_delayacct" in
    yes)
       m4_ifdef([PKG_PROG_PKG_CONFIG], [
          PKG_PROG_PKG_CONFIG()
-         PKG_CHECK_MODULES(LIBNL3, libnl-3.0, [], [missing_libraries="$missing_libraries libnl-3"])
-         PKG_CHECK_MODULES(LIBNL3GENL, libnl-genl-3.0, [], [missing_libraries="$missing_libraries libnl-genl-3"])
+         PKG_CHECK_MODULES(LIBNL3, libnl-3.0, [], [AC_MSG_ERROR([can not find required library libnl3])])
+         PKG_CHECK_MODULES(LIBNL3GENL, libnl-genl-3.0, [], [AC_MSG_ERROR([can not find required library libnl3genl])])
          CFLAGS="$CFLAGS $LIBNL3_CFLAGS $LIBNL3GENL_CFLAGS"
          LIBS="$LIBS $LIBNL3_LIBS $LIBNL3GENL_LIBS"
          AC_DEFINE([HAVE_DELAYACCT], [1], [Define if delay accounting support should be enabled.])
@@ -452,7 +453,7 @@ case "$enable_sensors" in
       AC_CHECK_HEADERS([sensors/sensors.h], [], [enable_sensors=no])
       ;;
    yes)
-      AC_CHECK_HEADERS([sensors/sensors.h], [], [missing_headers="$missing_headers $ac_header"])
+      AC_CHECK_HEADERS([sensors/sensors.h], [], [AC_MSG_ERROR([can not find required header file ensors/sensors.h])])
       ;;
    *)
       AC_MSG_ERROR([bad value '$enable_sensors' for --enable-sensors])
@@ -524,20 +525,6 @@ fi
 
 AC_SUBST([AM_CFLAGS])
 AC_SUBST([AM_CPPFLAGS])
-
-# ----------------------------------------------------------------------
-
-
-# ----------------------------------------------------------------------
-# Bail out on errors.
-# ----------------------------------------------------------------------
-
-if test ! -z "$missing_libraries"; then
-   AC_MSG_ERROR([missing libraries: $missing_libraries])
-fi
-if test ! -z "$missing_headers"; then
-   AC_MSG_ERROR([missing headers: $missing_headers])
-fi
 
 # ----------------------------------------------------------------------
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,12 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_PREREQ(2.65)
-AC_INIT([htop],[3.0.6-dev],[htop@groups.io])
+# ----------------------------------------------------------------------
+# Autoconf initialization.
+# ----------------------------------------------------------------------
+
+AC_PREREQ([2.65])
+AC_INIT([htop], [3.0.6-dev], [htop@groups.io])
 
 AC_CONFIG_SRCDIR([htop.c])
 AC_CONFIG_AUX_DIR([.])
@@ -13,97 +17,56 @@ AC_CANONICAL_TARGET
 
 AM_INIT_AUTOMAKE([1.11])
 
-# Checks for programs.
 # ----------------------------------------------------------------------
-AC_PROG_CC
-AM_PROG_CC_C_O
+
+
+# ----------------------------------------------------------------------
+# Checks for platform.
+# ----------------------------------------------------------------------
+
+case "$target_os" in
+linux*|gnu*)
+   my_htop_platform=linux
+   AC_DEFINE([HTOP_LINUX], [], [Building for Linux.])
+   ;;
+freebsd*|kfreebsd*)
+   my_htop_platform=freebsd
+   AC_DEFINE([HTOP_FREEBSD], [], [Building for FreeBSD.])
+   ;;
+openbsd*)
+   my_htop_platform=openbsd
+   AC_DEFINE([HTOP_OPENBSD], [], [Building for OpenBSD.])
+   ;;
+dragonfly*)
+   my_htop_platform=dragonflybsd
+   AC_DEFINE([HTOP_DRAGONFLYBSD], [], [Building for DragonFlyBSD.])
+   ;;
+darwin*)
+   my_htop_platform=darwin
+   AC_DEFINE([HTOP_DARWIN], [], [Building for Darwin.])
+   ;;
+solaris*)
+   my_htop_platform=solaris
+   AC_DEFINE([HTOP_SOLARIS], [], [Building for Solaris.])
+   ;;
+*)
+   my_htop_platform=unsupported
+   AC_DEFINE([HTOP_UNSUPPORTED], [], [Building for an unsupported platform.])
+   ;;
+esac
 
 # Required by hwloc scripts
 AC_USE_SYSTEM_EXTENSIONS
 
-# Checks for platform.
 # ----------------------------------------------------------------------
-case "$target_os" in
-linux*|gnu*)
-   my_htop_platform=linux
-   AC_DEFINE([HTOP_LINUX], [], [Building for Linux])
-   ;;
-freebsd*|kfreebsd*)
-   my_htop_platform=freebsd
-   AC_DEFINE([HTOP_FREEBSD], [], [Building for FreeBSD])
-   ;;
-openbsd*)
-   my_htop_platform=openbsd
-   AC_DEFINE([HTOP_OPENBSD], [], [Building for OpenBSD])
-   ;;
-dragonfly*)
-   my_htop_platform=dragonflybsd
-   AC_DEFINE([HTOP_DRAGONFLYBSD], [], [Building for DragonFlyBSD])
-   ;;
-darwin*)
-   my_htop_platform=darwin
-   AC_DEFINE([HTOP_DARWIN], [], [Building for Darwin])
-   ;;
-solaris*)
-   my_htop_platform=solaris
-   AC_DEFINE([HTOP_SOLARIS], [], [Building for Solaris])
-   ;;
-*)
-   my_htop_platform=unsupported
-   AC_DEFINE([HTOP_UNSUPPORTED], [], [Building for an unsupported platform])
-   ;;
-esac
 
-# Checks for libraries.
+
 # ----------------------------------------------------------------------
-AC_CHECK_LIB([m], [ceil], [], [missing_libraries="$missing_libraries libm"])
-
-# Checks for header files.
+# Checks for compiler.
 # ----------------------------------------------------------------------
-AC_HEADER_DIRENT
-AC_HEADER_STDC
-AC_CHECK_HEADERS([stdlib.h string.h strings.h sys/param.h sys/time.h unistd.h],[:],[
-  missing_headers="$missing_headers $ac_header"
-])
-AC_CHECK_HEADERS([execinfo.h],[:],[:])
 
-AC_HEADER_MAJOR
-dnl glibc 2.25 deprecates 'major' and 'minor' in <sys/types.h> and requires to
-dnl include <sys/sysmacros.h>. However the logic in AC_HEADER_MAJOR has not yet
-dnl been updated in Autoconf 2.69, so use a workaround:
-m4_version_prereq([2.70], [],
-[if test "x$ac_cv_header_sys_mkdev_h" != xyes; then
-   AC_CHECK_HEADER(sys/sysmacros.h, [AC_DEFINE(MAJOR_IN_SYSMACROS, 1,
-      [Define to 1 if `major', `minor', and `makedev' are declared in <sys/sysmacros.h>.])])
-fi])
-
-# Checks for typedefs, structures, and compiler characteristics.
-# ----------------------------------------------------------------------
-AC_HEADER_STDBOOL
-AC_C_CONST
-AC_TYPE_PID_T
-AC_TYPE_UID_T
-AC_TYPE_UINT8_T
-AC_TYPE_UINT16_T
-AC_TYPE_UINT32_T
-AC_TYPE_UINT64_T
-
-# Checks for library functions and compiler features.
-# ----------------------------------------------------------------------
-AC_FUNC_CLOSEDIR_VOID
-AC_FUNC_STAT
-
-AC_SEARCH_LIBS([dlopen], [dl dld])
-AC_SEARCH_LIBS([clock_gettime], [rt])
-
-AC_CHECK_FUNCS([\
-   clock_gettime\
-   faccessat\
-   fstatat\
-   host_get_clock_service\
-   openat\
-   readlinkat\
-])
+AC_PROG_CC
+AM_PROG_CC_C_O
 
 save_cflags="${CFLAGS}"
 CFLAGS="${CFLAGS} -std=c99"
@@ -114,52 +77,119 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
    [AC_MSG_ERROR([htop is written in C99. A newer compiler is required.])])
 CFLAGS="$save_cflags"
 
+# ----------------------------------------------------------------------
+
+
+# ----------------------------------------------------------------------
+# Checks for generic header files.
+# ----------------------------------------------------------------------
+
+AC_HEADER_DIRENT
+AC_HEADER_STDC
+AC_CHECK_HEADERS([ \
+    stdlib.h \
+    string.h \
+    strings.h \
+    sys/param.h \
+    sys/time.h \
+    unistd.h
+   ], [], [missing_headers="$missing_headers $ac_header"])
+
+AC_HEADER_MAJOR
+dnl glibc 2.25 deprecates 'major' and 'minor' in <sys/types.h> and requires to
+dnl include <sys/sysmacros.h>. However the logic in AC_HEADER_MAJOR has not yet
+dnl been updated in Autoconf 2.69, so use a workaround:
+m4_version_prereq([2.70], [],
+[if test "x$ac_cv_header_sys_mkdev_h" != xyes; then
+   AC_CHECK_HEADER([sys/sysmacros.h], [AC_DEFINE([MAJOR_IN_SYSMACROS], [1],
+      [Define to 1 if `major', `minor', and `makedev' are declared in <sys/sysmacros.h>.])])
+fi])
+
+# Optional Section
+
+AC_CHECK_HEADERS([execinfo.h])
+
+if test "$my_htop_platform" = darwin; then
+   AC_CHECK_HEADERS([mach/mach_time.h])
+fi
+
+# ----------------------------------------------------------------------
+
+
+# ----------------------------------------------------------------------
+# Checks for typedefs, structures, and compiler characteristics.
+# ----------------------------------------------------------------------
+
+AC_HEADER_STDBOOL
+AC_C_CONST
+AC_TYPE_PID_T
+AC_TYPE_UID_T
+AC_TYPE_UINT8_T
+AC_TYPE_UINT16_T
+AC_TYPE_UINT32_T
+AC_TYPE_UINT64_T
+
+# ----------------------------------------------------------------------
+
+
+# ----------------------------------------------------------------------
+# Checks for generic library functions.
+# ----------------------------------------------------------------------
+
+AC_FUNC_CLOSEDIR_VOID
+AC_FUNC_STAT
+
+AC_CHECK_LIB([m], [ceil], [], [missing_libraries="$missing_libraries libm"])
+
+if test "$my_htop_platform" = dragonflybsd; then
+   AC_SEARCH_LIBS([kvm_open], [kvm], [], [missing_libraries="$missing_libraries libkvm"])
+fi
+
+if test "$my_htop_platform" = freebsd; then
+   AC_SEARCH_LIBS([kvm_open], [kvm], [], [missing_libraries="$missing_libraries libkvm"])
+   AC_SEARCH_LIBS([devstat_checkversion], [devstat], [], [missing_libraries="$missing_libraries libdevstat"])
+fi
+
+if test "$my_htop_platform" = linux; then
+   AC_SEARCH_LIBS([dlopen], [dl dld], [], [missing_libraries="$missing_libraries libdl/libdld"])
+fi
+
+if test "$my_htop_platform" = openbsd; then
+   AC_SEARCH_LIBS([kvm_open], [kvm], [], [missing_libraries="$missing_libraries libkvm"])
+fi
+
+if test "$my_htop_platform" = solaris; then
+   AC_SEARCH_LIBS([kstat_open], [kstat], [], [missing_libraries="$missing_libraries libkstat"])
+   AC_SEARCH_LIBS([Pgrab_error], [proc], [], [missing_libraries="$missing_libraries libproc"])
+   AC_SEARCH_LIBS([free], [malloc], [], [missing_libraries="$missing_libraries libmalloc"])
+fi
+
+# Optional Section
+
+AC_SEARCH_LIBS([clock_gettime], [rt])
+
+AC_CHECK_FUNCS([ \
+    clock_gettime \
+    faccessat \
+    fstatat \
+    host_get_clock_service \
+    openat \
+    readlinkat \
+   ])
+
 # Add -lexecinfo if needed
 AC_SEARCH_LIBS([backtrace], [execinfo])
 
-# Add -ldevstat if needed
-AC_SEARCH_LIBS([devstat_checkversion], [devstat])
+if test "$my_htop_platform" = darwin; then
+   AC_CHECK_FUNCS([mach_timebase_info])
+fi
 
-# Checks for features and flags.
 # ----------------------------------------------------------------------
 
-AC_ARG_WITH([proc],
-            [AS_HELP_STRING([--with-proc=DIR],
-                            [location of a Linux-compatible proc filesystem @<:@default=/proc@:>@])],
-            [],
-            [with_proc=/proc])
-if test -z "$with_proc"; then
-   AC_MSG_ERROR([bad empty value for --with-proc option])
-fi
-AC_DEFINE_UNQUOTED([PROCDIR], ["$with_proc"], [Path of proc filesystem.])
 
-AC_ARG_ENABLE([openvz],
-              [AS_HELP_STRING([--enable-openvz],
-                              [enable OpenVZ support @<:@default=no@:>@])],
-              [],
-              [enable_openvz=no])
-if test "x$enable_openvz" = xyes; then
-   AC_DEFINE([HAVE_OPENVZ], [1], [Define if openvz support enabled.])
-fi
-
-AC_ARG_ENABLE([vserver],
-              [AS_HELP_STRING([--enable-vserver],
-                              [enable VServer support @<:@default=no@:>@])],
-              [],
-              [enable_vserver=no])
-if test "x$enable_vserver" = xyes; then
-    AC_DEFINE([HAVE_VSERVER], [1], [Define if vserver support enabled.])
-fi
-
-AC_ARG_ENABLE([ancient_vserver],
-              [AS_HELP_STRING([--enable-ancient-vserver],
-                              [enable ancient VServer support (implies --enable-vserver) @<:@default=no@:>@])],
-              [],
-              [enable_ancient_vserver=no])
-if test "x$enable_ancient_vserver" = xyes; then
-    AC_DEFINE([HAVE_VSERVER], [1], [Define if vserver support enabled.])
-    AC_DEFINE([HAVE_ANCIENT_VSERVER], [1], [Define if ancient vserver support enabled.])
-fi
+# ----------------------------------------------------------------------
+# Checks for cross-platform features and flags.
+# ----------------------------------------------------------------------
 
 # HTOP_CHECK_SCRIPT(LIBNAME, FUNCTION, DEFINE, CONFIG_SCRIPT, ELSE_PART)
 m4_define([HTOP_CHECK_SCRIPT],
@@ -200,23 +230,6 @@ m4_define([HTOP_CHECK_LIB],
       LIBS="-l[$1] $LIBS "
    ], [$4])
 ])
-
-dnl https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
-AC_DEFUN([AX_CHECK_COMPILE_FLAG],
-[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
-AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
-AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
-   ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
-   _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
-   AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
-      [AS_VAR_SET(CACHEVAR,[yes])],
-      [AS_VAR_SET(CACHEVAR,[no])])
-   _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
-AS_VAR_IF(CACHEVAR,yes,
-   [m4_default([$2], :)],
-   [m4_default([$3], :)])
-AS_VAR_POPDEF([CACHEVAR])dnl
-])dnl AX_CHECK_COMPILE_FLAGS
 
 AC_ARG_ENABLE([unicode],
               [AS_HELP_STRING([--enable-unicode],
@@ -261,28 +274,6 @@ else
    AC_SEARCH_LIBS([keypad], [tinfo])
 fi
 
-if test "$my_htop_platform" = "darwin"; then
-   AC_CHECK_HEADERS([mach/mach_time.h])
-   AC_CHECK_FUNCS([mach_timebase_info])
-fi
-
-if test "$my_htop_platform" = "dragonflybsd"; then
-   AC_CHECK_LIB([kvm], [kvm_open], [], [missing_libraries="$missing_libraries libkvm"])
-fi
-
-if test "$my_htop_platform" = "freebsd"; then
-   AC_CHECK_LIB([kvm], [kvm_open], [], [missing_libraries="$missing_libraries libkvm"])
-fi
-
-if test "$my_htop_platform" = "openbsd"; then
-   AC_CHECK_LIB([kvm], [kvm_open], [], [missing_libraries="$missing_libraries libkvm"])
-fi
-
-if test "$my_htop_platform" = "solaris"; then
-   AC_CHECK_LIB([kstat], [kstat_open], [], [missing_libraries="$missing_libraries libkstat"])
-   AC_CHECK_LIB([proc], [Pgrab_error], [], [missing_libraries="$missing_libraries libproc"])
-   AC_CHECK_LIB([malloc], [free], [], [missing_libraries="$missing_libraries libmalloc"])
-fi
 
 AC_ARG_ENABLE([hwloc],
               [AS_HELP_STRING([--enable-hwloc],
@@ -300,6 +291,65 @@ case "$enable_hwloc" in
       AC_MSG_ERROR([bad value '$enable_hwloc' for --enable-hwloc])
       ;;
 esac
+
+
+AC_ARG_ENABLE([setuid],
+              [AS_HELP_STRING([--enable-setuid],
+                              [enable setuid support for privilege dropping @<:@default=no@:>@])],
+              [],
+              [enable_setuid=no])
+if test "x$enable_setuid" = xyes; then
+   AC_DEFINE([HAVE_SETUID_ENABLED], [1], [Define if setuid support should be enabled.])
+fi
+
+# ----------------------------------------------------------------------
+
+
+# ----------------------------------------------------------------------
+# Checks for Linux features and flags.
+# ----------------------------------------------------------------------
+
+AC_ARG_WITH([proc],
+            [AS_HELP_STRING([--with-proc=DIR],
+                            [location of a Linux-compatible proc filesystem @<:@default=/proc@:>@])],
+            [],
+            [with_proc=/proc])
+if test -z "$with_proc"; then
+   AC_MSG_ERROR([bad empty value for --with-proc option])
+fi
+AC_DEFINE_UNQUOTED([PROCDIR], ["$with_proc"], [Path of proc filesystem.])
+
+
+AC_ARG_ENABLE([openvz],
+              [AS_HELP_STRING([--enable-openvz],
+                              [enable OpenVZ support @<:@default=no@:>@])],
+              [],
+              [enable_openvz=no])
+if test "x$enable_openvz" = xyes; then
+   AC_DEFINE([HAVE_OPENVZ], [1], [Define if openvz support enabled.])
+fi
+
+
+AC_ARG_ENABLE([vserver],
+              [AS_HELP_STRING([--enable-vserver],
+                              [enable VServer support @<:@default=no@:>@])],
+              [],
+              [enable_vserver=no])
+if test "x$enable_vserver" = xyes; then
+    AC_DEFINE([HAVE_VSERVER], [1], [Define if VServer support enabled.])
+fi
+
+
+AC_ARG_ENABLE([ancient_vserver],
+              [AS_HELP_STRING([--enable-ancient-vserver],
+                              [enable ancient VServer support (implies --enable-vserver) @<:@default=no@:>@])],
+              [],
+              [enable_ancient_vserver=no])
+if test "x$enable_ancient_vserver" = xyes; then
+    AC_DEFINE([HAVE_VSERVER], [1], [Define if VServer support enabled.])
+    AC_DEFINE([HAVE_ANCIENT_VSERVER], [1], [Define if ancient vserver support enabled.])
+fi
+
 
 AC_ARG_ENABLE([linux_affinity],
               [AS_HELP_STRING([--enable-linux-affinity],
@@ -335,14 +385,6 @@ if test "x$enable_linux_affinity" = xyes; then
    AC_DEFINE([HAVE_LINUX_AFFINITY], [1], [Define if Linux sched_setaffinity and sched_getaffinity are to be used.])
 fi
 
-AC_ARG_ENABLE([setuid],
-              [AS_HELP_STRING([--enable-setuid],
-                              [enable setuid support for privilege dropping @<:@default=no@:>@])],
-              [],
-              [enable_setuid=no])
-if test "x$enable_setuid" = xyes; then
-   AC_DEFINE([HAVE_SETUID_ENABLED], [1], [Define if setuid support should be enabled.])
-fi
 
 AC_ARG_ENABLE([capabilities],
               [AS_HELP_STRING([--enable-capabilities],
@@ -365,6 +407,7 @@ case "$enable_capabilities" in
       AC_MSG_ERROR([bad value '$enable_capabilities' for --enable-capabilities])
       ;;
 esac
+
 
 AC_ARG_ENABLE([delayacct],
               [AS_HELP_STRING([--enable-delayacct],
@@ -409,6 +452,7 @@ case "$enable_delayacct" in
       ;;
 esac
 
+
 AC_ARG_ENABLE([sensors],
               [AS_HELP_STRING([--enable-sensors],
                               [enable libsensors support for reading temperature data; requires only libsensors headers at compile time, at runtime libsensors is loaded via dlopen @<:@default=check@:>@])],
@@ -429,6 +473,12 @@ case "$enable_sensors" in
       ;;
 esac
 
+# ----------------------------------------------------------------------
+
+
+# ----------------------------------------------------------------------
+# Checks for compiler warnings.
+# ----------------------------------------------------------------------
 
 AM_CFLAGS="\
  -Wall\
@@ -447,6 +497,23 @@ AM_CFLAGS="\
  -Wundef\
  -Wunused\
  -Wwrite-strings"
+
+dnl https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
+   ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+   _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+   AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+      [AS_VAR_SET(CACHEVAR,[yes])],
+      [AS_VAR_SET(CACHEVAR,[no])])
+   _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+   [m4_default([$2], :)],
+   [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS
 
 AX_CHECK_COMPILE_FLAG([-Wnull-dereference], [AM_CFLAGS="$AM_CFLAGS -Wnull-dereference"], , [-Werror])
 
@@ -468,12 +535,17 @@ if test "x$enable_debug" != xyes; then
    AM_CPPFLAGS="$AM_CPPFLAGS -DNDEBUG"
 fi
 
+
 AC_SUBST([AM_CFLAGS])
 AC_SUBST([AM_CPPFLAGS])
 
+# ----------------------------------------------------------------------
 
+
+# ----------------------------------------------------------------------
 # Bail out on errors.
 # ----------------------------------------------------------------------
+
 if test ! -z "$missing_libraries"; then
    AC_MSG_ERROR([missing libraries: $missing_libraries])
 fi
@@ -481,10 +553,15 @@ if test ! -z "$missing_headers"; then
    AC_MSG_ERROR([missing headers: $missing_headers])
 fi
 
-AC_DEFINE_UNQUOTED(COPYRIGHT, "(C) 2004-2019 Hisham Muhammad. (C) 2020-2021 htop dev team.", [Copyright message.])
+# ----------------------------------------------------------------------
 
+
+# ----------------------------------------------------------------------
 # We're done, let's go!
 # ----------------------------------------------------------------------
+
+AC_DEFINE_UNQUOTED([COPYRIGHT], ["(C) 2004-2019 Hisham Muhammad. (C) 2020-2021 htop dev team."], [Copyright message.])
+
 AM_CONDITIONAL([HTOP_LINUX], [test "$my_htop_platform" = linux])
 AM_CONDITIONAL([HTOP_FREEBSD], [test "$my_htop_platform" = freebsd])
 AM_CONDITIONAL([HTOP_DRAGONFLYBSD], [test "$my_htop_platform" = dragonflybsd])
@@ -496,7 +573,7 @@ AC_SUBST(my_htop_platform)
 AC_CONFIG_FILES([Makefile htop.1])
 AC_OUTPUT
 
-if test "$my_htop_platform" = "unsupported"; then
+if test "$my_htop_platform" = unsupported; then
    echo ""
    echo "****************************************************************"
    echo "WARNING! This platform is not currently supported by htop."

--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,31 @@ AS_IF([test "x$ac_cv_prog_cc_c99" = xno], [AC_MSG_ERROR([htop is written in C99.
 
 
 # ----------------------------------------------------------------------
+# Checks for static build.
+# ----------------------------------------------------------------------
+
+AC_ARG_ENABLE([static],
+              [AS_HELP_STRING([--enable-static],
+                              [build a static htop binary @<:@default=no@:>@])],
+              [],
+              [enable_static=no])
+case "$enable_static" in
+   no)
+      ;;
+   yes)
+      AC_DEFINE([BUILD_STATIC], [1], [Define if building static binary.])
+      CFLAGS="$CFLAGS -static"
+      LDFLAGS="$LDFLAGS -static"
+      ;;
+   *)
+      AC_MSG_ERROR([bad value '$enable_static' for --enable-static option])
+      ;;
+esac
+
+# ----------------------------------------------------------------------
+
+
+# ----------------------------------------------------------------------
 # Checks for generic header files.
 # ----------------------------------------------------------------------
 
@@ -137,7 +162,9 @@ if test "$my_htop_platform" = freebsd; then
 fi
 
 if test "$my_htop_platform" = linux; then
-   AC_SEARCH_LIBS([dlopen], [dl dld], [], [AC_MSG_ERROR([can not find required function dlopen()])])
+   if test "$enable_static" != yes; then
+      AC_SEARCH_LIBS([dlopen], [dl dld], [], [AC_MSG_ERROR([can not find required function dlopen()])])
+   fi
 fi
 
 if test "$my_htop_platform" = openbsd; then
@@ -170,6 +197,10 @@ if test "$my_htop_platform" = darwin; then
    AC_CHECK_FUNCS([mach_timebase_info])
 fi
 
+if test "$my_htop_platform" = linux && test "x$enable_static" = xyes; then
+   AC_CHECK_LIB([systemd], [sd_bus_open_system])
+fi
+
 # ----------------------------------------------------------------------
 
 
@@ -189,10 +220,8 @@ m4_define([HTOP_CHECK_SCRIPT],
       htop_config_script_cflags=$([$4] --cflags 2> /dev/null)
    fi
    htop_script_success=no
-   htop_save_LDFLAGS="$LDFLAGS"
    htop_save_CFLAGS="$CFLAGS"
    if test ! "x$htop_config_script_libs" = x; then
-      LDFLAGS="$htop_config_script_libs $LDFLAGS"
       CFLAGS="$htop_config_script_cflags $CFLAGS"
       AC_CHECK_LIB([$1], [$2], [
          AC_DEFINE([$3], 1, [The library is present.])
@@ -200,8 +229,9 @@ m4_define([HTOP_CHECK_SCRIPT],
          htop_script_success=yes
       ], [
          CFLAGS="$htop_save_CFLAGS"
+      ], [
+         $htop_config_script_libs
       ])
-      LDFLAGS="$htop_save_LDFLAGS"
    fi
    if test "x$htop_script_success" = xno; then
       [$5]
@@ -212,7 +242,7 @@ m4_define([HTOP_CHECK_SCRIPT],
 m4_define([HTOP_CHECK_LIB],
 [
    AC_CHECK_LIB([$1], [$2], [
-      AC_DEFINE([$3], 1, [The library is present.])
+      AC_DEFINE([$3], [1], [The library is present.])
       LIBS="-l[$1] $LIBS "
    ], [$4])
 ])
@@ -223,13 +253,13 @@ AC_ARG_ENABLE([unicode],
               [],
               [enable_unicode=yes])
 if test "x$enable_unicode" = xyes; then
-   HTOP_CHECK_SCRIPT([ncursesw6], [addnwstr], [HAVE_LIBNCURSESW], "ncursesw6-config",
-    HTOP_CHECK_SCRIPT([ncursesw], [addnwstr], [HAVE_LIBNCURSESW], "ncursesw6-config",
-     HTOP_CHECK_SCRIPT([ncursesw], [addnwstr], [HAVE_LIBNCURSESW], "ncursesw5-config",
-      HTOP_CHECK_SCRIPT([ncurses], [addnwstr], [HAVE_LIBNCURSESW], "ncurses5-config",
-       HTOP_CHECK_LIB([ncursesw6], [addnwstr], [HAVE_LIBNCURSESW],
-        HTOP_CHECK_LIB([ncursesw], [addnwstr], [HAVE_LIBNCURSESW],
-         HTOP_CHECK_LIB([ncurses], [addnwstr], [HAVE_LIBNCURSESW],
+   HTOP_CHECK_SCRIPT([ncursesw6], [waddnwstr], [HAVE_LIBNCURSESW], "ncursesw6-config",
+    HTOP_CHECK_SCRIPT([ncursesw], [waddnwstr], [HAVE_LIBNCURSESW], "ncursesw6-config",
+     HTOP_CHECK_SCRIPT([ncursesw], [waddnwstr], [HAVE_LIBNCURSESW], "ncursesw5-config",
+      HTOP_CHECK_SCRIPT([ncurses], [waddnwstr], [HAVE_LIBNCURSESW], "ncurses5-config",
+       HTOP_CHECK_LIB([ncursesw6], [waddnwstr], [HAVE_LIBNCURSESW],
+        HTOP_CHECK_LIB([ncursesw], [waddnwstr], [HAVE_LIBNCURSESW],
+         HTOP_CHECK_LIB([ncurses], [waddnwstr], [HAVE_LIBNCURSESW],
           AC_MSG_ERROR([can not find required library libncursesw; you may want to use --disable-unicode])
    )))))))
 
@@ -243,10 +273,10 @@ if test "x$enable_unicode" = xyes; then
    # (at this point we already link against a working ncurses library with wide character support)
    AC_SEARCH_LIBS([keypad], [tinfow tinfo])
 else
-   HTOP_CHECK_SCRIPT([ncurses6], [refresh], [HAVE_LIBNCURSES], [ncurses6-config],
-    HTOP_CHECK_SCRIPT([ncurses], [refresh], [HAVE_LIBNCURSES], [ncurses5-config],
-     HTOP_CHECK_LIB([ncurses6],  [refresh], [HAVE_LIBNCURSES],
-      HTOP_CHECK_LIB([ncurses],  [refresh], [HAVE_LIBNCURSES],
+   HTOP_CHECK_SCRIPT([ncurses6], [wnoutrefresh], [HAVE_LIBNCURSES], [ncurses6-config],
+    HTOP_CHECK_SCRIPT([ncurses], [wnoutrefresh], [HAVE_LIBNCURSES], [ncurses5-config],
+     HTOP_CHECK_LIB([ncurses6],  [wnoutrefresh], [HAVE_LIBNCURSES],
+      HTOP_CHECK_LIB([ncurses],  [wnoutrefresh], [HAVE_LIBNCURSES],
        AC_MSG_ERROR([can not find required library libncurses])
    ))))
 
@@ -259,6 +289,9 @@ else
    # check if additional linker flags are needed for keypad(3)
    # (at this point we already link against a working ncurses library)
    AC_SEARCH_LIBS([keypad], [tinfo])
+fi
+if test "$enable_static" = yes; then
+   AC_SEARCH_LIBS([Gpm_GetEvent], [gpm])
 fi
 
 
@@ -405,20 +438,24 @@ case "$enable_delayacct" in
    no)
       ;;
    check)
-      m4_ifdef([PKG_PROG_PKG_CONFIG], [
-         enable_delayacct=yes
-         PKG_PROG_PKG_CONFIG()
-         PKG_CHECK_MODULES(LIBNL3, libnl-3.0, [], [enable_delayacct=no])
-         PKG_CHECK_MODULES(LIBNL3GENL, libnl-genl-3.0, [], [enable_delayacct=no])
-         if test "$enable_delayacct" = yes; then
-            CFLAGS="$CFLAGS $LIBNL3_CFLAGS $LIBNL3GENL_CFLAGS"
-            LIBS="$LIBS $LIBNL3_LIBS $LIBNL3GENL_LIBS"
-            AC_DEFINE([HAVE_DELAYACCT], [1], [Define if delay accounting support should be enabled.])
-         fi
-      ], [
+      if test "$enable_static" = yes; then
          enable_delayacct=no
-         AC_MSG_NOTICE([Linux delay accounting support can not be enabled, cause pkg-config is required for checking its availability])
-      ])
+      else
+         m4_ifdef([PKG_PROG_PKG_CONFIG], [
+            enable_delayacct=yes
+            PKG_PROG_PKG_CONFIG()
+            PKG_CHECK_MODULES(LIBNL3, libnl-3.0, [], [enable_delayacct=no])
+            PKG_CHECK_MODULES(LIBNL3GENL, libnl-genl-3.0, [], [enable_delayacct=no])
+            if test "$enable_delayacct" = yes; then
+               CFLAGS="$CFLAGS $LIBNL3_CFLAGS $LIBNL3GENL_CFLAGS"
+               LIBS="$LIBS $LIBNL3_LIBS $LIBNL3GENL_LIBS"
+               AC_DEFINE([HAVE_DELAYACCT], [1], [Define if delay accounting support should be enabled.])
+            fi
+         ], [
+            enable_delayacct=no
+            AC_MSG_NOTICE([Linux delay accounting support can not be enabled, cause pkg-config is required for checking its availability])
+         ])
+      fi
       ;;
    yes)
       m4_ifdef([PKG_PROG_PKG_CONFIG], [
@@ -450,10 +487,16 @@ case "$enable_sensors" in
       ;;
    check)
       enable_sensors=yes
+      if test "$enable_static" = yes; then
+         AC_CHECK_LIB([sensors], [sensors_init], [], [enable_sensors=no])
+      fi
       AC_CHECK_HEADERS([sensors/sensors.h], [], [enable_sensors=no])
       ;;
    yes)
-      AC_CHECK_HEADERS([sensors/sensors.h], [], [AC_MSG_ERROR([can not find required header file ensors/sensors.h])])
+      if test "$enable_static" = yes; then
+         AC_CHECK_LIB([sensors], [sensors_init], [], [AC_MSG_ERROR([can not find required library libsensors])])
+      fi
+      AC_CHECK_HEADERS([sensors/sensors.h], [], [AC_MSG_ERROR([can not find required header file sensors/sensors.h])])
       ;;
    *)
       AC_MSG_ERROR([bad value '$enable_sensors' for --enable-sensors])
@@ -576,4 +619,5 @@ AC_MSG_RESULT([
   hwloc:                     $enable_hwloc
   setuid:                    $enable_setuid
   debug:                     $enable_debug
+  static:                    $enable_static
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -122,29 +122,43 @@ AC_SEARCH_LIBS([devstat_checkversion], [devstat])
 
 # Checks for features and flags.
 # ----------------------------------------------------------------------
-PROCDIR=/proc
 
-AC_ARG_WITH(proc, [AS_HELP_STRING([--with-proc=DIR], [Location of a Linux-compatible proc filesystem (default=/proc).])],
-  if test -n "$withval"; then
-    AC_DEFINE_UNQUOTED(PROCDIR, "$withval", [Path of proc filesystem])
-    PROCDIR="$withval"
-  fi,
-  AC_DEFINE(PROCDIR, "/proc", [Path of proc filesystem]))
+AC_ARG_WITH([proc],
+            [AS_HELP_STRING([--with-proc=DIR],
+                            [location of a Linux-compatible proc filesystem @<:@default=/proc@:>@])],
+            [],
+            [with_proc=/proc])
+if test -z "$with_proc"; then
+   AC_MSG_ERROR([bad empty value for --with-proc option])
+fi
+AC_DEFINE_UNQUOTED([PROCDIR], ["$with_proc"], [Path of proc filesystem.])
 
-AC_ARG_ENABLE(openvz, [AS_HELP_STRING([--enable-openvz], [enable OpenVZ support])], ,enable_openvz="no")
+AC_ARG_ENABLE([openvz],
+              [AS_HELP_STRING([--enable-openvz],
+                              [enable OpenVZ support @<:@default=no@:>@])],
+              [],
+              [enable_openvz=no])
 if test "x$enable_openvz" = xyes; then
-   AC_DEFINE(HAVE_OPENVZ, 1, [Define if openvz support enabled.])
+   AC_DEFINE([HAVE_OPENVZ], [1], [Define if openvz support enabled.])
 fi
 
-AC_ARG_ENABLE(vserver, [AS_HELP_STRING([--enable-vserver], [enable VServer support])], ,enable_vserver="no")
+AC_ARG_ENABLE([vserver],
+              [AS_HELP_STRING([--enable-vserver],
+                              [enable VServer support @<:@default=no@:>@])],
+              [],
+              [enable_vserver=no])
 if test "x$enable_vserver" = xyes; then
-    AC_DEFINE(HAVE_VSERVER, 1, [Define if vserver support enabled.])
+    AC_DEFINE([HAVE_VSERVER], [1], [Define if vserver support enabled.])
 fi
 
-AC_ARG_ENABLE(ancient_vserver, [AS_HELP_STRING([--enable-ancient-vserver], [enable ancient VServer support (implies --enable-vserver)])], ,enable_ancient_vserver="no")
+AC_ARG_ENABLE([ancient_vserver],
+              [AS_HELP_STRING([--enable-ancient-vserver],
+                              [enable ancient VServer support (implies --enable-vserver) @<:@default=no@:>@])],
+              [],
+              [enable_ancient_vserver=no])
 if test "x$enable_ancient_vserver" = xyes; then
-    AC_DEFINE(HAVE_VSERVER, 1, [Define if vserver support enabled.])
-    AC_DEFINE(HAVE_ANCIENT_VSERVER, 1, [Define if ancient vserver support enabled.])
+    AC_DEFINE([HAVE_VSERVER], [1], [Define if vserver support enabled.])
+    AC_DEFINE([HAVE_ANCIENT_VSERVER], [1], [Define if ancient vserver support enabled.])
 fi
 
 # HTOP_CHECK_SCRIPT(LIBNAME, FUNCTION, DEFINE, CONFIG_SCRIPT, ELSE_PART)
@@ -204,7 +218,11 @@ AS_VAR_IF(CACHEVAR,yes,
 AS_VAR_POPDEF([CACHEVAR])dnl
 ])dnl AX_CHECK_COMPILE_FLAGS
 
-AC_ARG_ENABLE(unicode, [AS_HELP_STRING([--enable-unicode], [enable Unicode support])], ,enable_unicode="yes")
+AC_ARG_ENABLE([unicode],
+              [AS_HELP_STRING([--enable-unicode],
+                              [enable Unicode support @<:@default=yes@:>@])],
+              [],
+              [enable_unicode=yes])
 if test "x$enable_unicode" = xyes; then
    HTOP_CHECK_SCRIPT([ncursesw6], [addnwstr], [HAVE_LIBNCURSESW], "ncursesw6-config",
     HTOP_CHECK_SCRIPT([ncursesw], [addnwstr], [HAVE_LIBNCURSESW], "ncursesw6-config",
@@ -266,13 +284,28 @@ if test "$my_htop_platform" = "solaris"; then
    AC_CHECK_LIB([malloc], [free], [], [missing_libraries="$missing_libraries libmalloc"])
 fi
 
-AC_ARG_ENABLE(hwloc, [AS_HELP_STRING([--enable-hwloc], [enable hwloc support for CPU affinity, disables Linux affinity])],, enable_hwloc="no")
-if test "x$enable_hwloc" = xyes; then
-   AC_CHECK_LIB([hwloc], [hwloc_get_proc_cpubind], [], [missing_libraries="$missing_libraries libhwloc"])
-   AC_CHECK_HEADERS([hwloc.h],[:], [missing_headers="$missing_headers $ac_header"])
-fi
+AC_ARG_ENABLE([hwloc],
+              [AS_HELP_STRING([--enable-hwloc],
+              [enable hwloc support for CPU affinity; disables Linux affinity; requires libhwloc @<:@default=no@:>@])],
+              [],
+              [enable_hwloc=no])
+case "$enable_hwloc" in
+   no)
+      ;;
+   yes)
+      AC_CHECK_LIB([hwloc], [hwloc_get_proc_cpubind], [], [missing_libraries="$missing_libraries libhwloc"])
+      AC_CHECK_HEADERS([hwloc.h], [], [missing_headers="$missing_headers $ac_header"])
+      ;;
+   *)
+      AC_MSG_ERROR([bad value '$enable_hwloc' for --enable-hwloc])
+      ;;
+esac
 
-AC_ARG_ENABLE(linux_affinity, [AS_HELP_STRING([--enable-linux-affinity], [enable Linux sched_setaffinity and sched_getaffinity for affinity support, conflicts with hwloc])], ,enable_linux_affinity="check")
+AC_ARG_ENABLE([linux_affinity],
+              [AS_HELP_STRING([--enable-linux-affinity],
+                              [enable Linux sched_setaffinity and sched_getaffinity for affinity support, conflicts with hwloc @<:@default=check@:>@])],
+              [],
+              [enable_linux_affinity=check])
 if test "x$enable_linux_affinity" = xcheck; then
    if test "x$enable_hwloc" = xyes; then
       enable_linux_affinity=no
@@ -296,48 +329,106 @@ if test "x$enable_linux_affinity" = xcheck; then
    fi
 fi
 if test "x$enable_linux_affinity" = xyes; then
-   AC_DEFINE(HAVE_LINUX_AFFINITY, 1, [Define if Linux sched_setaffinity and sched_getaffinity are to be used.])
+   if test "x$enable_hwloc" = xyes; then
+      AC_MSG_ERROR([--enable-hwloc and --enable-linux-affinity are mutual exclusive. Specify at most one of them.])
+   fi
+   AC_DEFINE([HAVE_LINUX_AFFINITY], [1], [Define if Linux sched_setaffinity and sched_getaffinity are to be used.])
 fi
 
-if test "x$enable_linux_affinity" = xyes -a "x$enable_hwloc" = xyes; then
-   AC_MSG_ERROR([--enable-hwloc and --enable-linux-affinity are mutual exclusive. Specify at most one of them.])
-fi
-
-AC_ARG_ENABLE(setuid, [AS_HELP_STRING([--enable-setuid], [enable setuid support for platforms that need it])],, enable_setuid="no")
+AC_ARG_ENABLE([setuid],
+              [AS_HELP_STRING([--enable-setuid],
+                              [enable setuid support for privilege dropping @<:@default=no@:>@])],
+              [],
+              [enable_setuid=no])
 if test "x$enable_setuid" = xyes; then
-   AC_DEFINE(HAVE_SETUID_ENABLED, 1, [Define if setuid support should be enabled.])
+   AC_DEFINE([HAVE_SETUID_ENABLED], [1], [Define if setuid support should be enabled.])
 fi
 
-AC_ARG_WITH(capabilities, [AS_HELP_STRING([--with-capabilities], [Enable option to drop Linux capabilities via libcap])],, with_capabilities="no")
-if test "x$with_capabilities" = xyes
-then
-  AC_CHECK_LIB([cap], [cap_init], [], [missing_libraries="$missing_libraries libcap"])
-  AC_CHECK_HEADERS([sys/capability.h], [:], [missing_headers="$missing_headers $ac_header"])
-fi
+AC_ARG_ENABLE([capabilities],
+              [AS_HELP_STRING([--enable-capabilities],
+                              [enable Linux capabilities support; requires libcap @<:@default=check@:>@])],
+              [],
+              [enable_capabilities=check])
+case "$enable_capabilities" in
+   no)
+      ;;
+   check)
+      enable_capabilities=yes
+      AC_CHECK_LIB([cap], [cap_init], [], [enable_capabilities=no])
+      AC_CHECK_HEADERS([sys/capability.h], [], [enable_capabilities=no])
+      ;;
+   yes)
+      AC_CHECK_LIB([cap], [cap_init], [], [missing_libraries="$missing_libraries libcap"])
+      AC_CHECK_HEADERS([sys/capability.h], [], [missing_headers="$missing_headers $ac_header"])
+      ;;
+   *)
+      AC_MSG_ERROR([bad value '$enable_capabilities' for --enable-capabilities])
+      ;;
+esac
 
-AC_ARG_ENABLE(delayacct, [AS_HELP_STRING([--enable-delayacct], [enable Linux delay accounting])],, enable_delayacct="no")
-if test "x$enable_delayacct" = xyes; then
-   m4_ifdef([PKG_PROG_PKG_CONFIG], [
-      PKG_PROG_PKG_CONFIG()
-      PKG_CHECK_MODULES(LIBNL3, libnl-3.0, [], [missing_libraries="$missing_libraries libnl-3"])
-      PKG_CHECK_MODULES(LIBNL3GENL, libnl-genl-3.0, [], [missing_libraries="$missing_libraries libnl-genl-3"])
-      CFLAGS="$CFLAGS $LIBNL3_CFLAGS $LIBNL3GENL_CFLAGS"
-      LIBS="$LIBS $LIBNL3_LIBS $LIBNL3GENL_LIBS"
-      AC_DEFINE(HAVE_DELAYACCT, 1, [Define if delay accounting support should be enabled.])
-   ], [
-      pkg_m4_absent=1
-      m4_warning([configure is generated without pkg.m4. 'make dist' target will be disabled.])
-      AC_MSG_ERROR([htop on Linux requires pkg-config for checking delayacct requirements. Please install pkg-config and run ./autogen.sh to rebuild the configure script.])
-   ])
-fi
+AC_ARG_ENABLE([delayacct],
+              [AS_HELP_STRING([--enable-delayacct],
+                              [enable Linux delay accounting support; requires pkg-config, libnl-3 and libnl-genl-3 @<:@default=check@:>@])],
+              [],
+              [enable_delayacct=check])
+case "$enable_delayacct" in
+   no)
+      ;;
+   check)
+      m4_ifdef([PKG_PROG_PKG_CONFIG], [
+         enable_delayacct=yes
+         PKG_PROG_PKG_CONFIG()
+         PKG_CHECK_MODULES(LIBNL3, libnl-3.0, [], [enable_delayacct=no])
+         PKG_CHECK_MODULES(LIBNL3GENL, libnl-genl-3.0, [], [enable_delayacct=no])
+         if test "$enable_delayacct" = yes; then
+            CFLAGS="$CFLAGS $LIBNL3_CFLAGS $LIBNL3GENL_CFLAGS"
+            LIBS="$LIBS $LIBNL3_LIBS $LIBNL3GENL_LIBS"
+            AC_DEFINE([HAVE_DELAYACCT], [1], [Define if delay accounting support should be enabled.])
+         fi
+      ], [
+         enable_delayacct=no
+         AC_MSG_NOTICE([Linux delay accounting support can not be enabled, cause pkg-config is required for checking its availability])
+      ])
+      ;;
+   yes)
+      m4_ifdef([PKG_PROG_PKG_CONFIG], [
+         PKG_PROG_PKG_CONFIG()
+         PKG_CHECK_MODULES(LIBNL3, libnl-3.0, [], [missing_libraries="$missing_libraries libnl-3"])
+         PKG_CHECK_MODULES(LIBNL3GENL, libnl-genl-3.0, [], [missing_libraries="$missing_libraries libnl-genl-3"])
+         CFLAGS="$CFLAGS $LIBNL3_CFLAGS $LIBNL3GENL_CFLAGS"
+         LIBS="$LIBS $LIBNL3_LIBS $LIBNL3GENL_LIBS"
+         AC_DEFINE([HAVE_DELAYACCT], [1], [Define if delay accounting support should be enabled.])
+      ], [
+         pkg_m4_absent=1
+         m4_warning([configure is generated without pkg.m4. 'make dist' target will be disabled.])
+         AC_MSG_ERROR([htop on Linux requires pkg-config for checking delayacct requirements. Please install pkg-config and run ./autogen.sh to rebuild the configure script.])
+      ])
+      ;;
+   *)
+      AC_MSG_ERROR([bad value '$enable_delayacct' for --enable-delayacct])
+      ;;
+esac
 
-AC_ARG_WITH(sensors, [AS_HELP_STRING([--with-sensors], [Compile with libsensors support for reading temperature data. Only requires libsensors headers at compile time, at runtime libsensors is loaded via dlopen.])],, with_sensors="check")
-if test "x$with_sensors" = xyes; then
-   AC_CHECK_HEADERS([sensors/sensors.h], [], [missing_headers="$missing_headers $ac_header"])
-elif test "x$with_sensors" = xcheck; then
-   with_sensors=yes
-   AC_CHECK_HEADERS([sensors/sensors.h], [], [with_sensors=no])
-fi
+AC_ARG_ENABLE([sensors],
+              [AS_HELP_STRING([--enable-sensors],
+                              [enable libsensors support for reading temperature data; requires only libsensors headers at compile time, at runtime libsensors is loaded via dlopen @<:@default=check@:>@])],
+              [],
+              [enable_sensors=check])
+case "$enable_sensors" in
+   no)
+      ;;
+   check)
+      enable_sensors=yes
+      AC_CHECK_HEADERS([sensors/sensors.h], [], [enable_sensors=no])
+      ;;
+   yes)
+      AC_CHECK_HEADERS([sensors/sensors.h], [], [missing_headers="$missing_headers $ac_header"])
+      ;;
+   *)
+      AC_MSG_ERROR([bad value '$enable_sensors' for --enable-sensors])
+      ;;
+esac
+
 
 AM_CFLAGS="\
  -Wall\
@@ -359,15 +450,27 @@ AM_CFLAGS="\
 
 AX_CHECK_COMPILE_FLAG([-Wnull-dereference], [AM_CFLAGS="$AM_CFLAGS -Wnull-dereference"], , [-Werror])
 
-AC_ARG_ENABLE([werror], [AS_HELP_STRING([--enable-werror], [Treat warnings as errors (default: warnings are not errors)])], [enable_werror="$enableval"], [enable_werror=no])
-AS_IF([test "x$enable_werror" = "xyes"], [AM_CFLAGS="$AM_CFLAGS -Werror"])
+AC_ARG_ENABLE([werror],
+              [AS_HELP_STRING([--enable-werror],
+                              [Treat warnings as errors @<:@default=no@:>@])],
+              [],
+              [enable_werror=no])
+if test "x$enable_werror" = xyes; then
+   AM_CFLAGS="$AM_CFLAGS -Werror"
+fi
+
+AC_ARG_ENABLE([debug],
+              [AS_HELP_STRING([--enable-debug],
+                              [Enable asserts and internal sanity checks @<:@default=no@:>@])],
+              [],
+              [enable_debug=no])
+if test "x$enable_debug" != xyes; then
+   AM_CPPFLAGS="$AM_CPPFLAGS -DNDEBUG"
+fi
 
 AC_SUBST([AM_CFLAGS])
-
-AC_ARG_ENABLE([debug], [AS_HELP_STRING([--enable-debug], [Enable asserts (default: asserts are disabled)])], [enable_debug="$enableval"], [enable_debug=no])
-AS_IF([test "x$enable_debug" = "xyes"], , [AM_CPPFLAGS="$AM_CPPFLAGS -DNDEBUG"])
-
 AC_SUBST([AM_CPPFLAGS])
+
 
 # Bail out on errors.
 # ----------------------------------------------------------------------
@@ -410,14 +513,14 @@ AC_MSG_RESULT([
   ${PACKAGE_NAME} ${VERSION}
 
   platform:                  $my_htop_platform
-  (Linux) proc directory:    $PROCDIR
+  (Linux) proc directory:    $with_proc
   (Linux) openvz:            $enable_openvz
   (Linux) vserver:           $enable_vserver
   (Linux) ancient vserver:   $enable_ancient_vserver
   (Linux) affinity:          $enable_linux_affinity
   (Linux) delay accounting:  $enable_delayacct
-  (Linux) sensors:           $with_sensors
-  (Linux) capabilities:      $with_capabilities
+  (Linux) sensors:           $enable_sensors
+  (Linux) capabilities:      $enable_capabilities
   unicode:                   $enable_unicode
   hwloc:                     $enable_hwloc
   setuid:                    $enable_setuid

--- a/configure.ac
+++ b/configure.ac
@@ -5,17 +5,15 @@
 # Autoconf initialization.
 # ----------------------------------------------------------------------
 
-AC_PREREQ([2.65])
-AC_INIT([htop], [3.0.6-dev], [htop@groups.io])
+AC_PREREQ([2.69])
+AC_INIT([htop], [3.0.6-dev], [htop@groups.io], [], [https://htop.dev/])
 
 AC_CONFIG_SRCDIR([htop.c])
-AC_CONFIG_AUX_DIR([.])
+AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])
 
-# Required by hwloc scripts
 AC_CANONICAL_TARGET
-
-AM_INIT_AUTOMAKE([1.11])
+AM_INIT_AUTOMAKE([-Wall std-options subdir-objects])
 
 # ----------------------------------------------------------------------
 
@@ -55,7 +53,7 @@ solaris*)
    ;;
 esac
 
-# Required by hwloc scripts
+# Enable extensions, required by hwloc scripts
 AC_USE_SYSTEM_EXTENSIONS
 
 # ----------------------------------------------------------------------
@@ -67,15 +65,8 @@ AC_USE_SYSTEM_EXTENSIONS
 
 AC_PROG_CC
 AM_PROG_CC_C_O
-
-save_cflags="${CFLAGS}"
-CFLAGS="${CFLAGS} -std=c99"
-AC_MSG_CHECKING([whether cc -std=c99 option works])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-   [AC_INCLUDES_DEFAULT], [[char *a; a = strdup("foo"); int i = 0; i++; // C99]])],
-   [AC_MSG_RESULT([yes])],
-   [AC_MSG_ERROR([htop is written in C99. A newer compiler is required.])])
-CFLAGS="$save_cflags"
+AC_PROG_CC_C99
+AS_IF([test "x$ac_cv_prog_cc_c99" = xno], [AC_MSG_ERROR([htop is written in C99. A newer compiler is required.])])
 
 # ----------------------------------------------------------------------
 
@@ -120,8 +111,6 @@ fi
 # Checks for typedefs, structures, and compiler characteristics.
 # ----------------------------------------------------------------------
 
-AC_HEADER_STDBOOL
-AC_C_CONST
 AC_TYPE_PID_T
 AC_TYPE_UID_T
 AC_TYPE_UINT8_T
@@ -135,9 +124,6 @@ AC_TYPE_UINT64_T
 # ----------------------------------------------------------------------
 # Checks for generic library functions.
 # ----------------------------------------------------------------------
-
-AC_FUNC_CLOSEDIR_VOID
-AC_FUNC_STAT
 
 AC_CHECK_LIB([m], [ceil], [], [missing_libraries="$missing_libraries libm"])
 
@@ -500,7 +486,7 @@ AM_CFLAGS="\
 
 dnl https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
 AC_DEFUN([AX_CHECK_COMPILE_FLAG],
-[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+[
 AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
 AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
    ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
@@ -569,6 +555,7 @@ AM_CONDITIONAL([HTOP_OPENBSD], [test "$my_htop_platform" = openbsd])
 AM_CONDITIONAL([HTOP_DARWIN], [test "$my_htop_platform" = darwin])
 AM_CONDITIONAL([HTOP_SOLARIS], [test "$my_htop_platform" = solaris])
 AM_CONDITIONAL([HTOP_UNSUPPORTED], [test "$my_htop_platform" = unsupported])
+
 AC_SUBST(my_htop_platform)
 AC_CONFIG_FILES([Makefile htop.1])
 AC_OUTPUT

--- a/linux/LibSensors.c
+++ b/linux/LibSensors.c
@@ -10,6 +10,19 @@
 #include "XUtils.h"
 
 
+#ifdef BUILD_STATIC
+
+#define sym_sensors_init sensors_init
+#define sym_sensors_cleanup sensors_cleanup
+#define sym_sensors_get_detected_chips sensors_get_detected_chips
+#define sym_sensors_snprintf_chip_name sensors_snprintf_chip_name
+#define sym_sensors_get_features sensors_get_features
+#define sym_sensors_get_subfeature sensors_get_subfeature
+#define sym_sensors_get_value sensors_get_value
+#define sym_sensors_get_label sensors_get_label
+
+#else
+
 static int (*sym_sensors_init)(FILE*);
 static void (*sym_sensors_cleanup)(void);
 static const sensors_chip_name* (*sym_sensors_get_detected_chips)(const sensors_chip_name*, int*);
@@ -21,7 +34,15 @@ static char* (*sym_sensors_get_label)(const sensors_chip_name*, const sensors_fe
 
 static void* dlopenHandle = NULL;
 
+#endif /* BUILD_STATIC */
+
 int LibSensors_init(FILE* input) {
+#ifdef BUILD_STATIC
+
+   return sym_sensors_init(input);
+
+#else
+
    if (!dlopenHandle) {
       /* Find the unversioned libsensors.so (symlink) and prefer that, but Debian has .so.5 and Fedora .so.4 without
          matching symlinks (unless people install the -dev packages) */
@@ -56,29 +77,42 @@ int LibSensors_init(FILE* input) {
 
    return sym_sensors_init(input);
 
+
 dlfailure:
    if (dlopenHandle) {
       dlclose(dlopenHandle);
       dlopenHandle = NULL;
    }
    return -1;
+
+#endif /* BUILD_STATIC */
 }
 
 void LibSensors_cleanup(void) {
+#ifdef BUILD_STATIC
+
+   sym_sensors_cleanup();
+
+#else
+
    if (dlopenHandle) {
       sym_sensors_cleanup();
 
       dlclose(dlopenHandle);
       dlopenHandle = NULL;
    }
+
+#endif /* BUILD_STATIC */
 }
 
 void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int cpuCount) {
    for (unsigned int i = 0; i <= cpuCount; i++)
       cpus[i].temperature = NAN;
 
+#ifndef BUILD_STATIC
    if (!dlopenHandle)
       return;
+#endif /* !BUILD_STATIC */
 
    unsigned int coreTempCount = 0;
 

--- a/linux/SystemdMeter.c
+++ b/linux/SystemdMeter.c
@@ -21,8 +21,19 @@ in the source distribution for its full text.
 #include "RichString.h"
 #include "XUtils.h"
 
+#if defined(BUILD_STATIC) && defined(HAVE_LIBSYSTEMD)
+#include <systemd/sd-bus.h>
+#endif
 
-#define INVALID_VALUE ((unsigned int)-1)
+
+#ifdef BUILD_STATIC
+
+#define sym_sd_bus_open_system sd_bus_open_system
+#define sym_sd_bus_get_property_string sd_bus_get_property_string
+#define sym_sd_bus_get_property_trivial sd_bus_get_property_trivial
+#define sym_sd_bus_unref sd_bus_unref
+
+#else
 
 typedef void sd_bus;
 typedef void sd_bus_error;
@@ -30,19 +41,35 @@ static int (*sym_sd_bus_open_system)(sd_bus**);
 static int (*sym_sd_bus_get_property_string)(sd_bus*, const char*, const char*, const char*, const char*, sd_bus_error*, char**);
 static int (*sym_sd_bus_get_property_trivial)(sd_bus*, const char*, const char*, const char*, const char*, sd_bus_error*, char, void*);
 static sd_bus* (*sym_sd_bus_unref)(sd_bus*);
+static void* dlopenHandle = NULL;
+
+#endif /* BUILD_STATIC */
+
+#if !defined(BUILD_STATIC) || defined(HAVE_LIBSYSTEMD)
+static sd_bus* bus = NULL;
+#endif /* !BUILD_STATIC || HAVE_LIBSYSTEMD */
+
+
+#define INVALID_VALUE ((unsigned int)-1)
 
 static char* systemState = NULL;
 static unsigned int nFailedUnits = INVALID_VALUE;
 static unsigned int nInstalledJobs = INVALID_VALUE;
 static unsigned int nNames = INVALID_VALUE;
 static unsigned int nJobs = INVALID_VALUE;
-static void* dlopenHandle = NULL;
-static sd_bus* bus = NULL;
 
 static void SystemdMeter_done(ATTR_UNUSED Meter* this) {
    free(systemState);
    systemState = NULL;
 
+#ifdef BUILD_STATIC
+# ifdef HAVE_LIBSYSTEMD
+   if (bus) {
+      sym_sd_bus_unref(bus);
+   }
+   bus = NULL;
+# endif /* HAVE_LIBSYSTEMD */
+#else /* BUILD_STATIC */
    if (bus && dlopenHandle) {
       sym_sd_bus_unref(bus);
    }
@@ -52,9 +79,12 @@ static void SystemdMeter_done(ATTR_UNUSED Meter* this) {
       dlclose(dlopenHandle);
       dlopenHandle = NULL;
    }
+#endif /* BUILD_STATIC */
 }
 
+#if !defined(BUILD_STATIC) || defined(HAVE_LIBSYSTEMD)
 static int updateViaLib(void) {
+#ifndef BUILD_STATIC
    if (!dlopenHandle) {
       dlopenHandle = dlopen("libsystemd.so.0", RTLD_LAZY);
       if (!dlopenHandle)
@@ -76,6 +106,7 @@ static int updateViaLib(void) {
 
       #undef resolve
    }
+#endif /* !BUILD_STATIC */
 
    int r;
 
@@ -152,13 +183,16 @@ busfailure:
    bus = NULL;
    return -2;
 
+#ifndef BUILD_STATIC
 dlfailure:
    if (dlopenHandle) {
       dlclose(dlopenHandle);
       dlopenHandle = NULL;
    }
    return -1;
+#endif /* !BUILD_STATIC */
 }
+#endif /* !BUILD_STATIC || HAVE_LIBSYSTEMD */
 
 static void updateViaExec(void) {
    int fdpair[2];
@@ -233,8 +267,12 @@ static void SystemdMeter_updateValues(ATTR_UNUSED Meter* this, char* buffer, siz
    systemState = NULL;
    nFailedUnits = nInstalledJobs = nNames = nJobs = INVALID_VALUE;
 
+#if !defined(BUILD_STATIC) || defined(HAVE_LIBSYSTEMD)
    if (updateViaLib() < 0)
       updateViaExec();
+#else
+   updateViaExec();
+#endif /* !BUILD_STATIC || HAVE_LIBSYSTEMD */
 
    xSnprintf(buffer, size, "%s", systemState ? systemState : "???");
 }


### PR DESCRIPTION
* overhaul option handling
  - switch Linux capabilities default from "no" to "check"
  - document default settings
  - use more readable formatting
* reformat for improved reabability
* misc modernizations
  - require autoconf version 2.69
    was released in 2012 and one still can configure and build on older
    systems (just not generate the configure script)
  - use modern C99 compiler check
  - drop obsolete checks: AC_C_CONST, AC_FUNC_CLOSEDIR_VOID, AC_FUNC_STAT
  - drop AC_HEADER_STDBOOL in favor of C99 compatibility
* fail immediately on missing requirement
* add option to build a static htop binary (adopted from #412)