### PR TITLE
Add read-only option

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -248,11 +248,17 @@ static Htop_Reaction actionIncSearch(State* st) {
 }
 
 static Htop_Reaction actionHigherPriority(State* st) {
+   if (Settings_lockdown())
+      return HTOP_OK;
+
    bool changed = changePriority((MainPanel*)st->panel, -1);
    return changed ? HTOP_REFRESH : HTOP_OK;
 }
 
 static Htop_Reaction actionLowerPriority(State* st) {
+   if (Settings_lockdown())
+      return HTOP_OK;
+
    bool changed = changePriority((MainPanel*)st->panel, 1);
    return changed ? HTOP_REFRESH : HTOP_OK;
 }
@@ -286,6 +292,9 @@ static Htop_Reaction actionQuit(ATTR_UNUSED State* st) {
 }
 
 static Htop_Reaction actionSetAffinity(State* st) {
+   if (Settings_lockdown())
+      return HTOP_OK;
+
    if (st->pl->cpuCount == 1)
       return HTOP_OK;
 
@@ -319,6 +328,9 @@ static Htop_Reaction actionSetAffinity(State* st) {
 }
 
 static Htop_Reaction actionKill(State* st) {
+   if (Settings_lockdown())
+      return HTOP_OK;
+
    Panel* signalsPanel = SignalsPanel_new();
    const ListItem* sgn = (ListItem*) Action_pickFromVector(st, signalsPanel, 15, true);
    if (sgn) {
@@ -369,6 +381,9 @@ static Htop_Reaction actionSetup(State* st) {
 }
 
 static Htop_Reaction actionLsof(State* st) {
+   if (Settings_lockdown())
+      return HTOP_OK;
+
    const Process* p = (Process*) Panel_getSelected(st->panel);
    if (!p)
       return HTOP_OK;
@@ -393,6 +408,9 @@ static Htop_Reaction actionShowLocks(State* st) {
 }
 
 static Htop_Reaction actionStrace(State* st) {
+   if (Settings_lockdown())
+      return HTOP_OK;
+
    const Process* p = (Process*) Panel_getSelected(st->panel);
    if (!p)
       return HTOP_OK;

--- a/Process.c
+++ b/Process.c
@@ -460,6 +460,9 @@ bool Process_isTomb(const Process* this) {
 }
 
 bool Process_setPriority(Process* this, int priority) {
+   if (Settings_lockdown())
+      return false;
+
    CRT_dropPrivileges();
    int old_prio = getpriority(PRIO_PROCESS, this->pid);
    int err = setpriority(PRIO_PROCESS, this->pid, priority);

--- a/Settings.c
+++ b/Settings.c
@@ -457,3 +457,13 @@ void Settings_setSortKey(Settings* this, ProcessField sortKey) {
       this->treeDirection = 1;
    }
 }
+
+static bool lockdown = false;
+
+void Settings_enableLockdown(void) {
+   lockdown = true;
+}
+
+bool Settings_lockdown(void) {
+   return lockdown;
+}

--- a/Settings.h
+++ b/Settings.h
@@ -94,4 +94,8 @@ void Settings_invertSortOrder(Settings* this);
 
 void Settings_setSortKey(Settings* this, ProcessField sortKey);
 
+void Settings_enableLockdown(void);
+
+bool Settings_lockdown(void);
+
 #endif

--- a/htop.c
+++ b/htop.c
@@ -67,6 +67,7 @@ static void printHelpFlag(void) {
          "                                strict - drop all capabilities except those needed for core functionality\n"
 #endif
          "-H --highlight-changes[=DELAY]  Highlight new and old processes\n"
+         "   --lockdown                   Disable all system and process changing features\n"
          "-M --no-mouse                   Disable the mouse\n"
          "-p --pid=PID[,PID,PID...]       Show only the given PIDs\n"
          "-s --sort-key=COLUMN            Sort by COLUMN in list view (try --sort-key=help for a list)\n"
@@ -95,6 +96,7 @@ typedef struct CommandLineSettings_ {
    bool allowUnicode;
    bool highlightChanges;
    int highlightDelaySecs;
+   bool lockdown;
 #ifdef HAVE_LIBCAP
    enum CapMode capabilitiesMode;
 #endif
@@ -114,6 +116,7 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
       .allowUnicode = true,
       .highlightChanges = false,
       .highlightDelaySecs = -1,
+      .lockdown = false,
 #ifdef HAVE_LIBCAP
       .capabilitiesMode = CAP_MODE_BASIC,
 #endif
@@ -134,6 +137,7 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
       {"pid",        required_argument,   0, 'p'},
       {"filter",     required_argument,   0, 'F'},
       {"highlight-changes", optional_argument, 0, 'H'},
+      {"lockdown",   no_argument,         0, 129},
 #ifdef HAVE_LIBCAP
       {"drop-capabilities", optional_argument, 0, 128},
 #endif
@@ -254,6 +258,9 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
             flags.highlightChanges = true;
             break;
          }
+         case 129:
+            flags.lockdown = true;
+            break;
 #ifdef HAVE_LIBCAP
          case 128: {
             const char* mode = optarg;
@@ -400,6 +407,9 @@ int main(int argc, char** argv) {
       setlocale(LC_CTYPE, "");
 
    CommandLineSettings flags = parseArguments(argc, argv);
+
+   if (flags.lockdown)
+      Settings_enableLockdown();
 
 #ifdef HAVE_LIBCAP
    if (dropCapabilities(flags.capabilitiesMode) < 0)

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -129,6 +129,9 @@ void Platform_done(void) {
 }
 
 static Htop_Reaction Platform_actionSetIOPriority(State* st) {
+   if (Settings_lockdown())
+      return HTOP_OK;
+
    Panel* panel = st->panel;
 
    const LinuxProcess* p = (const LinuxProcess*) Panel_getSelected(panel);

--- a/linux/SystemdMeter.c
+++ b/linux/SystemdMeter.c
@@ -161,6 +161,9 @@ dlfailure:
 }
 
 static void updateViaExec(void) {
+   if (Settings_lockdown())
+      return;
+
    int fdpair[2];
    if (pipe(fdpair) < 0)
       return;


### PR DESCRIPTION
Add command line option to disable all system and process changing
features.

Improves: #483

Misses graphical indications of unavailable/disables features.