### PR TITLE
GitHub CI: Add job for building on s390x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,37 @@ jobs:
     - name: Distcheck
       run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --with-sensors --with-capabilities'
 
+  build-ubuntu-arch-matrix-full-featured-gcc:
+    runs-on: ubuntu-20.04
+    name: Build on ${{ matrix.distro }} ${{ matrix.arch }}
+    strategy:
+      matrix:
+        include:
+          - arch: s390x
+            distro: ubuntu20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: uraimo/run-on-arch-action@v2.0.8
+      name: Configure and Build
+      id: arch-matrix-gcc
+      with:
+        arch: ${{ matrix.arch }}
+        distro: ${{ matrix.distro }}
+        githubToken: ${{ github.token }}
+        shell: /bin/bash
+        install: |
+          apt-get -q -y update
+          apt-get install -q -y libncursesw5-dev libhwloc-dev libnl-3-dev libnl-genl-3-dev libsensors4-dev libcap-dev make pkg-config
+        env: |
+          CPPFLAGS: -DGCC_PRINTF -DGCC_SCANF -D_FORTIFY_SOURCE=2
+          CFLAGS: -O3 -g -flto
+          LDFLAGS: -O3 -g -flto
+        run: |
+          ./autogen.sh
+          ./configure --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --with-sensors --with-capabilities
+          make -k
+          make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-setuid --enable-delayacct --with-sensors --with-capabilities'
+
   build-ubuntu-latest-clang-analyzer:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Previously the Travis CI was building on linux on s390x but there is not the same out of the box support under GitHub Actions. It is fairly straightforward to use the https://github.com/marketplace/actions/run-on-architecture action to build on s390x and other architectures.

This PR adds a job to run a full featured gcc build on s390x. Other architectures could be added to the matrix as well.

The run-on-architecture builds are slower than the GitHub runner native builds probably because they are running on an emulator. It could be made to only run on pull_request and maybe the make distcheck step is not needed which would reduce the build time.

Thoughts? I'm happy for any suggestions on making this better.