### PR TITLE
[#480] SysarchMeter to view kernel version/arch info

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -67,6 +67,7 @@ myhtopsources = \
 	Settings.c \
 	SignalsPanel.c \
 	SwapMeter.c \
+	SysArchMeter.c \
 	TasksMeter.c \
 	TraceScreen.c \
 	UptimeMeter.c \
@@ -121,6 +122,7 @@ myhtopheaders = \
 	Settings.h \
 	SignalsPanel.h \
 	SwapMeter.h \
+	SysArchMeter.h \
 	TasksMeter.h \
 	TraceScreen.h \
 	UptimeMeter.h \

--- a/SysArchMeter.c
+++ b/SysArchMeter.c
@@ -1,0 +1,83 @@
+/*
+htop - SysArchMeter.c
+(C) 2021 htop dev team
+Released under the GNU GPLv2, see the COPYING file
+in the source distribution for its full text.
+*/
+#include "config.h"  // IWYU pragma: keep
+
+#include "SysArchMeter.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/utsname.h>
+
+#include "XUtils.h"
+
+
+static const int SysArchMeter_attributes[] = {HOSTNAME};
+
+static void SysArchMeter_updateValues(Meter* this, char* buffer, size_t size) {
+   static struct utsname uname_info;
+   static int uname_result;
+   static char distro[3][64] = { {'\0'}, {'\0'}, {'\0'} };
+   static bool loaded_data = false;
+
+   (void)this;
+
+   if(!loaded_data) {
+      uname_result = uname(&uname_info);
+      FILE* fp = popen("lsb_release --id --release --codename", "r");
+      if(fp) {
+         char line[96] = {'\0'};
+         size_t n = 0;
+
+         while(fgets(line, sizeof(line), fp)) {
+            n = strcspn(line, ":");
+            if(n > 0 && (n + 1) < strlen(line)) {
+               char* value = String_trim(&line[n + 1]);
+               line[n] = '\0';
+
+               if(String_eq(line, "Distributor ID"))
+                  snprintf(distro[0], sizeof(distro[0]), "%s", value);
+               else if(String_eq(line, "Release"))
+                  snprintf(distro[1], sizeof(distro[1]), "%s", value);
+               else if(String_eq(line, "Codename"))
+                  snprintf(distro[2], sizeof(distro[2]), "%s", value);
+
+               free(value);
+            }
+         }
+         if(!distro[0][0])
+            snprintf(distro[0], sizeof(distro[0]), "Unknown");
+         pclose(fp);
+      }
+      loaded_data = true;
+   }
+
+   if(uname_result == 0) {
+      if (distro[1][0] && distro[2][0])
+         snprintf(buffer, size, "%s %s [%s] / %s %s (%s)", uname_info.sysname, uname_info.release, uname_info.machine, distro[0], distro[1], distro[2]);
+      else if(distro[1][0])
+         snprintf(buffer, size, "%s %s [%s] / %s %s", uname_info.sysname, uname_info.release, uname_info.machine, distro[0], distro[1]);
+      else
+         snprintf(buffer, size, "%s %s [%s]", uname_info.sysname, uname_info.release, uname_info.machine);
+   } else {
+      snprintf(buffer, size, "Unknown");
+   }
+}
+
+const MeterClass SysArchMeter_class = {
+   .super = {
+      .extends = Class(Meter),
+      .delete = Meter_delete
+   },
+   .updateValues = SysArchMeter_updateValues,
+   .defaultMode = TEXT_METERMODE,
+   .maxItems = 0,
+   .total = 100.0,
+   .attributes = SysArchMeter_attributes,
+   .name = "System",
+   .uiName = "System",
+   .caption = "System: ",
+};

--- a/SysArchMeter.h
+++ b/SysArchMeter.h
@@ -1,0 +1,14 @@
+#ifndef HEADER_SysArchMeter
+#define HEADER_SysArchMeter
+/*
+htop - SysArchMeter.h
+(C) 2021 htop dev team
+Released under the GNU GPLv2, see the COPYING file
+in the source distribution for its full text.
+*/
+#include "Meter.h"
+
+
+extern const MeterClass SysArchMeter_class;
+
+#endif

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -31,6 +31,7 @@ in the source distribution for its full text.
 #include "MemoryMeter.h"
 #include "ProcessLocksScreen.h"
 #include "SwapMeter.h"
+#include "SysArchMeter.h"
 #include "TasksMeter.h"
 #include "UptimeMeter.h"
 #include "zfs/ZfsArcMeter.h"
@@ -93,6 +94,7 @@ const MeterClass* const Platform_meterTypes[] = {
    &TasksMeter_class,
    &BatteryMeter_class,
    &HostnameMeter_class,
+   &SysArchMeter_class,
    &UptimeMeter_class,
    &AllCPUsMeter_class,
    &AllCPUs2Meter_class,

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -19,6 +19,7 @@ in the source distribution for its full text.
 #include "DateMeter.h"
 #include "DateTimeMeter.h"
 #include "HostnameMeter.h"
+#include "SysArchMeter.h"
 #include "DragonFlyBSDProcess.h"
 #include "DragonFlyBSDProcessList.h"
 
@@ -85,6 +86,7 @@ const MeterClass* const Platform_meterTypes[] = {
    &UptimeMeter_class,
    &BatteryMeter_class,
    &HostnameMeter_class,
+   &SysArchMeter_class,
    &AllCPUsMeter_class,
    &AllCPUs2Meter_class,
    &AllCPUs4Meter_class,

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -42,6 +42,7 @@ in the source distribution for its full text.
 #include "ProcessList.h"
 #include "Settings.h"
 #include "SwapMeter.h"
+#include "SysArchMeter.h"
 #include "TasksMeter.h"
 #include "UptimeMeter.h"
 #include "XUtils.h"
@@ -103,6 +104,7 @@ const MeterClass* const Platform_meterTypes[] = {
    &UptimeMeter_class,
    &BatteryMeter_class,
    &HostnameMeter_class,
+   &SysArchMeter_class,
    &AllCPUsMeter_class,
    &AllCPUs2Meter_class,
    &AllCPUs4Meter_class,

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -49,6 +49,7 @@ in the source distribution for its full text.
 #include "SELinuxMeter.h"
 #include "Settings.h"
 #include "SwapMeter.h"
+#include "SysArchMeter.h"
 #include "SystemdMeter.h"
 #include "TasksMeter.h"
 #include "UptimeMeter.h"
@@ -162,6 +163,7 @@ const MeterClass* const Platform_meterTypes[] = {
    &LoadMeter_class,
    &MemoryMeter_class,
    &SwapMeter_class,
+   &SysArchMeter_class,
    &HugePageMeter_class,
    &TasksMeter_class,
    &UptimeMeter_class,

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -37,6 +37,7 @@ in the source distribution for its full text.
 #include "Settings.h"
 #include "SignalsPanel.h"
 #include "SwapMeter.h"
+#include "SysArchMeter.h"
 #include "TasksMeter.h"
 #include "UptimeMeter.h"
 #include "XUtils.h"
@@ -99,6 +100,7 @@ const MeterClass* const Platform_meterTypes[] = {
    &UptimeMeter_class,
    &BatteryMeter_class,
    &HostnameMeter_class,
+   &SysArchMeter_class,
    &AllCPUsMeter_class,
    &AllCPUs2Meter_class,
    &AllCPUs4Meter_class,

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -19,6 +19,7 @@ in the source distribution for its full text.
 #include "DateMeter.h"
 #include "DateTimeMeter.h"
 #include "HostnameMeter.h"
+#include "SysArchMeter.h"
 #include "UptimeMeter.h"
 #include "zfs/ZfsArcMeter.h"
 #include "zfs/ZfsCompressedArcMeter.h"
@@ -100,6 +101,7 @@ const MeterClass* const Platform_meterTypes[] = {
    &TasksMeter_class,
    &BatteryMeter_class,
    &HostnameMeter_class,
+   &SysArchMeter_class,
    &UptimeMeter_class,
    &AllCPUsMeter_class,
    &AllCPUs2Meter_class,

--- a/unsupported/Platform.c
+++ b/unsupported/Platform.c
@@ -21,6 +21,7 @@ in the source distribution for its full text.
 #include "Macros.h"
 #include "MemoryMeter.h"
 #include "SwapMeter.h"
+#include "SysArchMeter.h"
 #include "TasksMeter.h"
 #include "UptimeMeter.h"
 
@@ -45,6 +46,7 @@ const MeterClass* const Platform_meterTypes[] = {
    &TasksMeter_class,
    &BatteryMeter_class,
    &HostnameMeter_class,
+   &SysArchMeter_class,
    &UptimeMeter_class,
    &AllCPUsMeter_class,
    &AllCPUs2Meter_class,


### PR DESCRIPTION
`SysarchMeter` calls the [`uname`](https://man7.org/linux/man-pages/man2/uname.2.html) function to obtain the kernel version and
architecture in a `utsname` variable. If the `version` data of the `utsname` is not empty, the distro version is also printed.

`SysarchMeter` follows the style of 
* `HostnameMeter` (uses the same attributes) and 
* `DiskIOMeter` (uses `snprintf` to print to buffer).

Used `astyle -r -xb -s3 -p -xg -c -k1 -W1 \*.c \*.h` to format the two newly added files.

Sample Screenshot:
![Screenshot from 2021-01-27 15-27-00](https://user-images.githubusercontent.com/41098605/105975683-3e917800-60b5-11eb-8c99-8bcf885790b5.png)
