### PR TITLE
OptionsPanel: ignore mouse click if disabled

### DIFF
--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -40,6 +40,9 @@ static HandlerResult DisplayOptionsPanel_eventHandler(Panel* super, int ch) {
    case '\r':
    case KEY_ENTER:
    case KEY_MOUSE:
+      if (!this->settings->enableMouse)
+         break;
+      /* else fallthrough */
    case KEY_RECLICK:
    case ' ':
       switch (OptionItem_kind(selected)) {


### PR DESCRIPTION
Even though mouse is disabled, options panel handler still handles it, which results in toggle since changing selected item by mouse is disabled.