### PR TITLE
Remove force sort order to ASC when returning to tree mode

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -226,9 +226,6 @@ static Htop_Reaction actionToggleMergedCommand(State* st) {
 
 static Htop_Reaction actionToggleTreeView(State* st) {
    st->settings->treeView = !st->settings->treeView;
-   if (st->settings->treeView) {
-      st->settings->treeDirection = 1;
-   }
 
    ProcessList_expandTree(st->pl);
    return HTOP_REFRESH | HTOP_SAVE_SETTINGS | HTOP_KEEP_FOLLOWING | HTOP_REDRAW_BAR | HTOP_UPDATE_PANELHDR;


### PR DESCRIPTION
Bug found by @BenBE via IRC

Quote from IRC:
> Setup: Go to tree view, sort DESC by RES, hit F5, sort by DESC
> Test: Press F5 repeatedly to change between list view and tree view.
> Expectation: Should stay in DESC order for both views
> Actual: Switches to ASC when re-entering tree view mode.