### PR TITLE
Forgot to correctly color ZFS ARC ratio

### DIFF
--- a/zfs/ZfsCompressedArcMeter.c
+++ b/zfs/ZfsCompressedArcMeter.c
@@ -54,7 +54,7 @@ static void ZfsCompressedArcMeter_display(const Object* cast, RichString* out) {
       RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
       RichString_appendAscii(out, CRT_colors[METER_TEXT], " Compressed, ");
       ZfsCompressedArcMeter_printRatioString(this, buffer, sizeof(buffer));
-      RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
+      RichString_appendAscii(out, CRT_colors[ZFS_RATIO], buffer);
       RichString_appendAscii(out, CRT_colors[METER_TEXT], " Ratio");
    } else {
       RichString_writeAscii(out, CRT_colors[METER_TEXT], " ");


### PR DESCRIPTION
`ZFS_RATIO` in `CRT.c` was unused, because I forgot
to colorize the ARC ratio in the Compressed ARC meter.

The intent was to improve readability of the meter by
highlighting the most relevant value, the ratio, in
a brighter color, for most themes. This change effects
that intent.

Resolves #456.