### PR TITLE
Correctly detect failure to initialize boottime

### DIFF
--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -65,7 +65,7 @@ in the source distribution for its full text.
 # define O_PATH 010000000
 #endif
 
-static long long btime;
+static long long btime = -1;
 
 static long jiffy;
 
@@ -241,7 +241,7 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidMatchList, ui
       }
       fclose(statfile);
 
-      if (!btime)
+      if (btime == -1)
          CRT_fatalError("No btime in " PROCSTATFILE);
    }
 


### PR DESCRIPTION
A zero value for btime (boottime) in /proc/stat is a
real situation that happens, so deal with this case.

Resolves https://github.com/htop-dev/htop/issues/527