### PR TITLE
InfoScreen: Remove old lines before scanning again

### DIFF
--- a/InfoScreen.c
+++ b/InfoScreen.c
@@ -145,8 +145,10 @@ void InfoScreen_run(InfoScreen* this) {
          break;
       case KEY_F(5):
          clear();
-         if (As_InfoScreen(this)->scan)
+         if (As_InfoScreen(this)->scan) {
+            Vector_prune(this->lines);
             InfoScreen_scan(this);
+         }
 
          InfoScreen_draw(this);
          break;
@@ -161,8 +163,10 @@ void InfoScreen_run(InfoScreen* this) {
          break;
       case KEY_RESIZE:
          Panel_resize(panel, COLS, LINES - 2);
-         if (As_InfoScreen(this)->scan)
+         if (As_InfoScreen(this)->scan) {
+            Vector_prune(this->lines);
             InfoScreen_scan(this);
+         }
 
          InfoScreen_draw(this);
          break;


### PR DESCRIPTION
When refreshing a InfoScreen with a scan method the screen can be filled with duplicate entries, like in the image below.

![htop-duplicate-lines](https://user-images.githubusercontent.com/4452746/107988799-12408b80-6fd1-11eb-8edc-bde9f7d337b4.png)

The bug can be reproduced by refreshing the screen with F5 and filtering with F4 afterwards. It shows up in OpenFilesScreen, EnvScreen, CommandScreen and ProcessLocksScreen.

This pull request fixes this bug by emptying the lines vector before doing another scan.
