### PR TITLE
SysArchMeter: read os-release instead of running lsb-release

### DIFF
--- a/SysArchMeter.c
+++ b/SysArchMeter.c
@@ -9,7 +9,6 @@ in the source distribution for its full text.
 #include "SysArchMeter.h"
 
 #include <stdio.h>
-#include <string.h>
 #include <sys/utsname.h>
 
 #include "XUtils.h"
@@ -17,59 +16,74 @@ in the source distribution for its full text.
 
 static const int SysArchMeter_attributes[] = {HOSTNAME};
 
-static void SysArchMeter_updateValues(Meter* this, char* buffer, size_t size) {
-   static struct utsname uname_info;
-   static int uname_result;
-   static char distro[3][64] = { {'\0'}, {'\0'}, {'\0'} };
+static void parseOSRelease(char* buffer, size_t bufferLen) {
+   FILE* stream = fopen("/etc/os-release", "r");
+   if (!stream) {
+      stream = fopen("/usr/lib/os-release", "r");
+      if (!stream) {
+         xSnprintf(buffer, bufferLen, "Unknown Distro");
+         return;
+      }
+   }
+
+   char name[64] = {'\0'};
+   char version[64] = {'\0'};
+   char lineBuffer[256];
+   while (fgets(lineBuffer, sizeof(lineBuffer), stream)) {
+      if (String_startsWith(lineBuffer, "PRETTY_NAME=\"")) {
+         const char* start = lineBuffer + strlen("PRETTY_NAME=\"");
+         const char* stop = strrchr(lineBuffer, '"');
+         if (!stop || stop <= start)
+            continue;
+         String_safeStrncpy(buffer, start, MINIMUM(bufferLen, (size_t)(stop - start + 1)));
+         fclose(stream);
+         return;
+      }
+      if (String_startsWith(lineBuffer, "NAME=\"")) {
+         const char* start = lineBuffer + strlen("NAME=\"");
+         const char* stop = strrchr(lineBuffer, '"');
+         if (!stop || stop <= start)
+            continue;
+         String_safeStrncpy(name, start, MINIMUM(sizeof(name), (size_t)(stop - start + 1)));
+         continue;
+      }
+      if (String_startsWith(lineBuffer, "VERSION=\"")) {
+         const char* start = lineBuffer + strlen("VERSION=\"");
+         const char* stop = strrchr(lineBuffer, '"');
+         if (!stop || stop <= start)
+            continue;
+         String_safeStrncpy(version, start, MINIMUM(sizeof(version), (size_t)(stop - start + 1)));
+         continue;
+      }
+   }
+   fclose(stream);
+
+   snprintf(buffer, bufferLen, "%s%s%s", name[0] ? name : "", name[0] && version[0] ? " " : "", version);
+}
+
+static void SysArchMeter_updateValues(ATTR_UNUSED Meter* this, char* buffer, size_t size) {
+   static char savedString[128] = {'\0'};
    static bool loaded_data = false;
 
-   (void)this;
+   if (!loaded_data) {
+      struct utsname uname_info;
+      int uname_result = uname(&uname_info);
 
-   if(!loaded_data) {
-      uname_result = uname(&uname_info);
-      FILE* fp = popen("lsb_release --id --release --codename", "r");
-      if(fp) {
-         char line[96] = {'\0'};
-         size_t n = 0;
+      char distro[128];
+      parseOSRelease(distro, sizeof(distro));
 
-         while(fgets(line, sizeof(line), fp)) {
-            n = strcspn(line, ":");
-            if(n > 0 && (n + 1) < strlen(line)) {
-               char* value = String_trim(&line[n + 1]);
-               line[n] = '\0';
-
-               if(String_eq(value, "n/a")) {
-                  free(value);
-                  continue;
-               }
-
-               if(String_eq(line, "Distributor ID"))
-                  snprintf(distro[0], sizeof(distro[0]), "%s", value);
-               else if(String_eq(line, "Release"))
-                  snprintf(distro[1], sizeof(distro[1]), "%s", value);
-               else if(String_eq(line, "Codename"))
-                  snprintf(distro[2], sizeof(distro[2]), "%s", value);
-
-               free(value);
-            }
-         }
-         if(!distro[0][0])
-            snprintf(distro[0], sizeof(distro[0]), "Unknown");
-         pclose(fp);
+      if (uname_result == 0) {
+         size_t written = xSnprintf(savedString, sizeof(savedString), "%s %s [%s]", uname_info.sysname, uname_info.release, uname_info.machine);
+         if (!String_contains_i(savedString, distro) && sizeof(savedString) > written)
+            snprintf(savedString + written, sizeof(savedString) - written, " @ %s", distro);
+      } else {
+         snprintf(savedString, sizeof(savedString), "%s", distro);
       }
+
       loaded_data = true;
    }
 
-   if(uname_result == 0) {
-      if (distro[1][0] && distro[2][0])
-         snprintf(buffer, size, "%s %s [%s] / %s %s (%s)", uname_info.sysname, uname_info.release, uname_info.machine, distro[0], distro[1], distro[2]);
-      else if(distro[1][0])
-         snprintf(buffer, size, "%s %s [%s] / %s %s", uname_info.sysname, uname_info.release, uname_info.machine, distro[0], distro[1]);
-      else
-         snprintf(buffer, size, "%s %s [%s]", uname_info.sysname, uname_info.release, uname_info.machine);
-   } else {
-      snprintf(buffer, size, "Unknown");
-   }
+   String_safeStrncpy(buffer, savedString, size);
 }
 
 const MeterClass SysArchMeter_class = {


### PR DESCRIPTION
`os-release` is available on FreeBSD by default.
Also avoid executing a third-party program.

Examples:
```
  Linux 5.10.0-3-amd64 [x86_64] @ Debian GNU/Linux bullseye/sid
  FreeBSD 12.2-RELEASE-p3 [amd64]
```

Closes: #516