### PR TITLE
Implement graph and bar for NetworkIOMeter & rescale graphs when total changed

### DIFF
--- a/Meter.c
+++ b/Meter.c
@@ -334,7 +334,6 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
       double value = 0.0;
       for (uint8_t i = 0; i < this->curItems; i++)
          value += this->values[i];
-      value /= this->total;
       data->values[nValues - 1] = value;
    }
 
@@ -345,8 +344,10 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
    }
    for (; i < nValues - 1; i += 2, k++) {
       int pix = GraphMeterMode_pixPerRow * GRAPH_HEIGHT;
-      int v1 = CLAMP((int) lround(data->values[i] * pix), 1, pix);
-      int v2 = CLAMP((int) lround(data->values[i + 1] * pix), 1, pix);
+      if (this->total < 1)
+         this->total = 1;
+      int v1 = CLAMP((int) lround(data->values[i] / this->total * pix), 1, pix);
+      int v2 = CLAMP((int) lround(data->values[i + 1] / this->total * pix), 1, pix);
 
       int colorIdx = GRAPH_1;
       for (int line = 0; line < GRAPH_HEIGHT; line++) {

--- a/NetworkIOMeter.c
+++ b/NetworkIOMeter.c
@@ -24,7 +24,7 @@ static unsigned long int cached_rxp_diff = 0;
 static unsigned long int cached_txb_diff = 0;
 static unsigned long int cached_txp_diff = 0;
 
-static void NetworkIOMeter_updateValues(ATTR_UNUSED Meter* this, char* buffer, size_t len) {
+static void NetworkIOMeter_updateValues(Meter* this, char* buffer, size_t len) {
    static unsigned long long int cached_last_update = 0;
 
    struct timeval tv;
@@ -80,6 +80,12 @@ static void NetworkIOMeter_updateValues(ATTR_UNUSED Meter* this, char* buffer, s
       cached_txp_total = packetsTransmitted;
    }
 
+   this->values[0] = cached_rxb_diff;
+   this->values[1] = cached_txb_diff;
+   if (cached_rxb_diff + cached_txb_diff > this->total) {
+      this->total = cached_rxb_diff + cached_txb_diff;
+   }
+
    char bufferBytesReceived[12], bufferBytesTransmitted[12];
    Meter_humanUnit(bufferBytesReceived, cached_rxb_diff, sizeof(bufferBytesReceived));
    Meter_humanUnit(bufferBytesTransmitted, cached_txb_diff, sizeof(bufferBytesTransmitted));
@@ -116,7 +122,7 @@ const MeterClass NetworkIOMeter_class = {
    },
    .updateValues = NetworkIOMeter_updateValues,
    .defaultMode = TEXT_METERMODE,
-   .maxItems = 0,
+   .maxItems = 2,
    .total = 100.0,
    .attributes = NetworkIOMeter_attributes,
    .name = "NetworkIO",


### PR DESCRIPTION
NetworkIOMeter currently only works in text and LED mode, bar and graph mode were not supported meaning they stayed empty (#408). This PR changes that. Graph and bar are plotted as they are for other meters. The total is set to 100kib/s initially and continuously changed to the maximum value seen so far.
While implementing this, I noticed an unexpected behavior of the graph display method: When the total is changed the new values will be displayed in respect to that, but the old values will continue to be displayed relative to the old total value. Through this the graph is rendered incorrectly. This bug does not only occur to the new graph of NetworkIOMeter, but currently already affects  LoadAverageMeter, DiskIOMeter, UptimeMeter & TasksMeter. The first patch in this PR fixes this issue for all graphs.