### PR TITLE
Fix integer sizing issues in the NetworkIO Meter

### DIFF
--- a/NetworkIOMeter.c
+++ b/NetworkIOMeter.c
@@ -19,26 +19,26 @@ static const int NetworkIOMeter_attributes[] = {
 
 static bool hasData = false;
 
-static unsigned long int cached_rxb_diff;
-static unsigned long int cached_rxp_diff;
-static unsigned long int cached_txb_diff;
-static unsigned long int cached_txp_diff;
+static uint32_t cached_rxb_diff;
+static uint32_t cached_rxp_diff;
+static uint32_t cached_txb_diff;
+static uint32_t cached_txp_diff;
 
 static void NetworkIOMeter_updateValues(Meter* this, char* buffer, size_t len) {
-   static unsigned long long int cached_last_update = 0;
+   static uint64_t cached_last_update = 0;
 
    struct timeval tv;
    gettimeofday(&tv, NULL);
-   unsigned long long int timeInMilliSeconds = (unsigned long long int)tv.tv_sec * 1000 + (unsigned long long int)tv.tv_usec / 1000;
-   unsigned long long int passedTimeInMs = timeInMilliSeconds - cached_last_update;
+   uint64_t timeInMilliSeconds = (uint64_t)tv.tv_sec * 1000 + (uint64_t)tv.tv_usec / 1000;
+   uint64_t passedTimeInMs = timeInMilliSeconds - cached_last_update;
 
    /* update only every 500ms */
    if (passedTimeInMs > 500) {
-      static unsigned long long int cached_rxb_total;
-      static unsigned long long int cached_rxp_total;
-      static unsigned long long int cached_txb_total;
-      static unsigned long long int cached_txp_total;
-      unsigned long long diff;
+      static uint64_t cached_rxb_total;
+      static uint64_t cached_rxp_total;
+      static uint64_t cached_txb_total;
+      static uint64_t cached_txp_total;
+      uint64_t diff;
 
       cached_last_update = timeInMilliSeconds;
 
@@ -53,17 +53,17 @@ static void NetworkIOMeter_updateValues(Meter* this, char* buffer, size_t len) {
          diff = data.bytesReceived - cached_rxb_total;
          diff /= ONE_K; /* Meter_humanUnit() expects unit in kilo */
          diff = (1000 * diff) / passedTimeInMs; /* convert to per second */
-         cached_rxb_diff = (unsigned long)diff;
+         cached_rxb_diff = (uint32_t)diff;
       } else {
-         cached_rxb_diff = 0UL;
+         cached_rxb_diff = 0;
       }
       cached_rxb_total = data.bytesReceived;
 
       if (data.packetsReceived > cached_rxp_total) {
          diff = data.packetsReceived - cached_rxp_total;
-         cached_rxp_diff = (unsigned long)diff;
+         cached_rxp_diff = (uint32_t)diff;
       } else {
-         cached_rxp_diff = 0UL;
+         cached_rxp_diff = 0;
       }
       cached_rxp_total = data.packetsReceived;
 
@@ -71,17 +71,17 @@ static void NetworkIOMeter_updateValues(Meter* this, char* buffer, size_t len) {
          diff = data.bytesTransmitted - cached_txb_total;
          diff /= ONE_K; /* Meter_humanUnit() expects unit in kilo */
          diff = (1000 * diff) / passedTimeInMs; /* convert to per second */
-         cached_txb_diff = (unsigned long)diff;
+         cached_txb_diff = (uint32_t)diff;
       } else {
-         cached_txb_diff = 0UL;
+         cached_txb_diff = 0;
       }
       cached_txb_total = data.bytesTransmitted;
 
       if (data.packetsTransmitted > cached_txp_total) {
          diff = data.packetsTransmitted - cached_txp_total;
-         cached_txp_diff = (unsigned long)diff;
+         cached_txp_diff = (uint32_t)diff;
       } else {
-         cached_txp_diff = 0UL;
+         cached_txp_diff = 0;
       }
       cached_txp_total = data.packetsTransmitted;
    }
@@ -116,7 +116,7 @@ static void NetworkIOMeter_display(ATTR_UNUSED const Object* cast, RichString* o
    RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], buffer);
    RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], "iB/s");
 
-   xSnprintf(buffer, sizeof(buffer), " (%lu/%lu packets) ", cached_rxp_diff, cached_txp_diff);
+   xSnprintf(buffer, sizeof(buffer), " (%u/%u packets) ", cached_rxp_diff, cached_txp_diff);
    RichString_appendAscii(out, CRT_colors[METER_TEXT], buffer);
 }
 

--- a/NetworkIOMeter.h
+++ b/NetworkIOMeter.h
@@ -3,6 +3,13 @@
 
 #include "Meter.h"
 
+typedef struct NetworkIOData_ {
+   unsigned long long int bytesReceived;
+   unsigned long long int packetsReceived;
+   unsigned long long int bytesTransmitted;
+   unsigned long long int packetsTransmitted;
+} NetworkIOData;
+
 extern const MeterClass NetworkIOMeter_class;
 
 #endif /* HEADER_NetworkIOMeter */

--- a/NetworkIOMeter.h
+++ b/NetworkIOMeter.h
@@ -4,10 +4,10 @@
 #include "Meter.h"
 
 typedef struct NetworkIOData_ {
-   unsigned long long int bytesReceived;
-   unsigned long long int packetsReceived;
-   unsigned long long int bytesTransmitted;
-   unsigned long long int packetsTransmitted;
+   uint64_t bytesReceived;
+   uint64_t packetsReceived;
+   uint64_t bytesTransmitted;
+   uint64_t packetsTransmitted;
 } NetworkIOData;
 
 extern const MeterClass NetworkIOMeter_class;

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -334,15 +334,9 @@ bool Platform_getDiskIO(DiskIOData* data) {
    return false;
 }
 
-bool Platform_getNetworkIO(unsigned long int* bytesReceived,
-                           unsigned long int* packetsReceived,
-                           unsigned long int* bytesTransmitted,
-                           unsigned long int* packetsTransmitted) {
+bool Platform_getNetworkIO(NetworkIOData* data) {
    // TODO
-   *bytesReceived = 0;
-   *packetsReceived = 0;
-   *bytesTransmitted = 0;
-   *packetsTransmitted = 0;
+   (void)data;
    return false;
 }
 

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -16,6 +16,7 @@ in the source distribution for its full text.
 #include "CPUMeter.h"
 #include "DarwinProcess.h"
 #include "DiskIOMeter.h"
+#include "NetworkIOMeter.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
 
@@ -62,10 +63,7 @@ FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 bool Platform_getDiskIO(DiskIOData* data);
 
-bool Platform_getNetworkIO(unsigned long int* bytesReceived,
-                           unsigned long int* packetsReceived,
-                           unsigned long int* bytesTransmitted,
-                           unsigned long int* packetsTransmitted);
+bool Platform_getNetworkIO(NetworkIOData* data);
 
 void Platform_getBattery(double *percent, ACPresence *isOnAC);
 

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -233,15 +233,9 @@ bool Platform_getDiskIO(DiskIOData* data) {
    return false;
 }
 
-bool Platform_getNetworkIO(unsigned long int* bytesReceived,
-                           unsigned long int* packetsReceived,
-                           unsigned long int* bytesTransmitted,
-                           unsigned long int* packetsTransmitted) {
+bool Platform_getNetworkIO(NetworkIOData* data) {
    // TODO
-   *bytesReceived = 0;
-   *packetsReceived = 0;
-   *bytesTransmitted = 0;
-   *packetsTransmitted = 0;
+   (void)data;
    return false;
 }
 

--- a/dragonflybsd/Platform.h
+++ b/dragonflybsd/Platform.h
@@ -14,6 +14,7 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
+#include "NetworkIOMeter.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
 
@@ -52,10 +53,7 @@ FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 bool Platform_getDiskIO(DiskIOData* data);
 
-bool Platform_getNetworkIO(unsigned long int* bytesReceived,
-                           unsigned long int* packetsReceived,
-                           unsigned long int* bytesTransmitted,
-                           unsigned long int* packetsTransmitted);
+bool Platform_getNetworkIO(NetworkIOData* data);
 
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
 

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -321,8 +321,7 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    size_t countLen = sizeof(count);
    const int countMib[] = { CTL_NET, PF_LINK, NETLINK_GENERIC, IFMIB_SYSTEM, IFMIB_IFCOUNT };
 
-   int r;
-   r = sysctl(countMib, ARRAYSIZE(countMib), &count, &countLen, NULL, 0);
+   int r = sysctl(countMib, ARRAYSIZE(countMib), &count, &countLen, NULL, 0);
    if (r < 0)
       return false;
 

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -315,24 +315,18 @@ bool Platform_getDiskIO(DiskIOData* data) {
    return true;
 }
 
-bool Platform_getNetworkIO(unsigned long int* bytesReceived,
-                           unsigned long int* packetsReceived,
-                           unsigned long int* bytesTransmitted,
-                           unsigned long int* packetsTransmitted) {
-   int r;
-
+bool Platform_getNetworkIO(NetworkIOData* data) {
    // get number of interfaces
    int count;
    size_t countLen = sizeof(count);
    const int countMib[] = { CTL_NET, PF_LINK, NETLINK_GENERIC, IFMIB_SYSTEM, IFMIB_IFCOUNT };
 
+   int r;
    r = sysctl(countMib, ARRAYSIZE(countMib), &count, &countLen, NULL, 0);
    if (r < 0)
       return false;
 
-
-   unsigned long int bytesReceivedSum = 0, packetsReceivedSum = 0, bytesTransmittedSum = 0, packetsTransmittedSum = 0;
-
+   memset(data, 0, sizeof(NetworkIOData));
    for (int i = 1; i <= count; i++) {
       struct ifmibdata ifmd;
       size_t ifmdLen = sizeof(ifmd);
@@ -346,16 +340,12 @@ bool Platform_getNetworkIO(unsigned long int* bytesReceived,
       if (ifmd.ifmd_flags & IFF_LOOPBACK)
          continue;
 
-      bytesReceivedSum += ifmd.ifmd_data.ifi_ibytes;
-      packetsReceivedSum += ifmd.ifmd_data.ifi_ipackets;
-      bytesTransmittedSum += ifmd.ifmd_data.ifi_obytes;
-      packetsTransmittedSum += ifmd.ifmd_data.ifi_opackets;
+      data->bytesReceived += ifmd.ifmd_data.ifi_ibytes;
+      data->packetsReceived += ifmd.ifmd_data.ifi_ipackets;
+      data->bytesTransmitted += ifmd.ifmd_data.ifi_obytes;
+      data->packetsTransmitted += ifmd.ifmd_data.ifi_opackets;
    }
 
-   *bytesReceived = bytesReceivedSum;
-   *packetsReceived = packetsReceivedSum;
-   *bytesTransmitted = bytesTransmittedSum;
-   *packetsTransmitted = packetsTransmittedSum;
    return true;
 }
 

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -14,6 +14,7 @@ in the source distribution for its full text.
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
 #include "Meter.h"
+#include "NetworkIOMeter.h"
 #include "Process.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
@@ -57,10 +58,7 @@ FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 bool Platform_getDiskIO(DiskIOData* data);
 
-bool Platform_getNetworkIO(unsigned long int* bytesReceived,
-                           unsigned long int* packetsReceived,
-                           unsigned long int* bytesTransmitted,
-                           unsigned long int* packetsTransmitted);
+bool Platform_getNetworkIO(NetworkIOData* data);
 
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -534,42 +534,35 @@ bool Platform_getDiskIO(DiskIOData* data) {
    return true;
 }
 
-bool Platform_getNetworkIO(unsigned long int* bytesReceived,
-                           unsigned long int* packetsReceived,
-                           unsigned long int* bytesTransmitted,
-                           unsigned long int* packetsTransmitted) {
+bool Platform_getNetworkIO(NetworkIOData* data) {
    FILE* fd = fopen(PROCDIR "/net/dev", "r");
    if (!fd)
       return false;
 
-   unsigned long int bytesReceivedSum = 0, packetsReceivedSum = 0, bytesTransmittedSum = 0, packetsTransmittedSum = 0;
+   memset(data, 0, sizeof(NetworkIOData));
    char lineBuffer[512];
    while (fgets(lineBuffer, sizeof(lineBuffer), fd)) {
       char interfaceName[32];
-      unsigned long int bytesReceivedParsed, packetsReceivedParsed, bytesTransmittedParsed, packetsTransmittedParsed;
-      if (sscanf(lineBuffer, "%31s %lu %lu %*u %*u %*u %*u %*u %*u %lu %lu",
+      unsigned long long int bytesReceived, packetsReceived, bytesTransmitted, packetsTransmitted;
+      if (sscanf(lineBuffer, "%31s %llu %llu %*u %*u %*u %*u %*u %*u %llu %llu",
                              interfaceName,
-                             &bytesReceivedParsed,
-                             &packetsReceivedParsed,
-                             &bytesTransmittedParsed,
-                             &packetsTransmittedParsed) != 5)
+                             &bytesReceived,
+                             &packetsReceived,
+                             &bytesTransmitted,
+                             &packetsTransmitted) != 5)
          continue;
 
       if (String_eq(interfaceName, "lo:"))
          continue;
 
-      bytesReceivedSum += bytesReceivedParsed;
-      packetsReceivedSum += packetsReceivedParsed;
-      bytesTransmittedSum += bytesTransmittedParsed;
-      packetsTransmittedSum += packetsTransmittedParsed;
+      data->bytesReceived += bytesReceived;
+      data->packetsReceived += packetsReceived;
+      data->bytesTransmitted += bytesTransmitted;
+      data->packetsTransmitted += packetsTransmitted;
    }
 
    fclose(fd);
 
-   *bytesReceived = bytesReceivedSum;
-   *packetsReceived = packetsReceivedSum;
-   *bytesTransmitted = bytesTransmittedSum;
-   *packetsTransmitted = packetsTransmittedSum;
    return true;
 }
 

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -15,6 +15,7 @@ in the source distribution for its full text.
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
 #include "Meter.h"
+#include "NetworkIOMeter.h"
 #include "Process.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
@@ -67,10 +68,7 @@ void Platform_getPressureStall(const char *file, bool some, double* ten, double*
 
 bool Platform_getDiskIO(DiskIOData* data);
 
-bool Platform_getNetworkIO(unsigned long int* bytesReceived,
-                           unsigned long int* packetsReceived,
-                           unsigned long int* bytesTransmitted,
-                           unsigned long int* packetsTransmitted);
+bool Platform_getNetworkIO(NetworkIOData* data);
 
 void Platform_getBattery(double *percent, ACPresence *isOnAC);
 

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -283,15 +283,9 @@ bool Platform_getDiskIO(DiskIOData* data) {
    return false;
 }
 
-bool Platform_getNetworkIO(unsigned long int* bytesReceived,
-                           unsigned long int* packetsReceived,
-                           unsigned long int* bytesTransmitted,
-                           unsigned long int* packetsTransmitted) {
+bool Platform_getNetworkIO(NetworkIOData* data) {
    // TODO
-   *bytesReceived = 0;
-   *packetsReceived = 0;
-   *bytesTransmitted = 0;
-   *packetsTransmitted = 0;
+   (void)data;
    return false;
 }
 

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -15,6 +15,7 @@ in the source distribution for its full text.
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
 #include "Meter.h"
+#include "NetworkIOMeter.h"
 #include "Process.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
@@ -55,10 +56,7 @@ FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 bool Platform_getDiskIO(DiskIOData* data);
 
-bool Platform_getNetworkIO(unsigned long int* bytesReceived,
-                           unsigned long int* packetsReceived,
-                           unsigned long int* bytesTransmitted,
-                           unsigned long int* packetsTransmitted);
+bool Platform_getNetworkIO(NetworkIOData* data);
 
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
 

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -296,15 +296,9 @@ bool Platform_getDiskIO(DiskIOData* data) {
    return false;
 }
 
-bool Platform_getNetworkIO(unsigned long int* bytesReceived,
-                           unsigned long int* packetsReceived,
-                           unsigned long int* bytesTransmitted,
-                           unsigned long int* packetsTransmitted) {
+bool Platform_getNetworkIO(NetworkIOData* data) {
    // TODO
-   *bytesReceived = 0;
-   *packetsReceived = 0;
-   *bytesTransmitted = 0;
-   *packetsTransmitted = 0;
+   (void)data;
    return false;
 }
 

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -19,6 +19,7 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
+#include "NetworkIOMeter.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
 
@@ -74,10 +75,7 @@ FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 bool Platform_getDiskIO(DiskIOData* data);
 
-bool Platform_getNetworkIO(unsigned long int* bytesReceived,
-                           unsigned long int* packetsReceived,
-                           unsigned long int* bytesTransmitted,
-                           unsigned long int* packetsTransmitted);
+bool Platform_getNetworkIO(NetworkIOData* data);
 
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
 

--- a/unsupported/Platform.c
+++ b/unsupported/Platform.c
@@ -137,14 +137,8 @@ bool Platform_getDiskIO(DiskIOData* data) {
    return false;
 }
 
-bool Platform_getNetworkIO(unsigned long int* bytesReceived,
-                           unsigned long int* packetsReceived,
-                           unsigned long int* bytesTransmitted,
-                           unsigned long int* packetsTransmitted) {
-   *bytesReceived = 0;
-   *packetsReceived = 0;
-   *bytesTransmitted = 0;
-   *packetsTransmitted = 0;
+bool Platform_getNetworkIO(NetworkIOData* data) {
+   (void)data;
    return false;
 }
 

--- a/unsupported/Platform.h
+++ b/unsupported/Platform.h
@@ -11,6 +11,7 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
+#include "NetworkIOMeter.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
 #include "UnsupportedProcess.h"
@@ -52,10 +53,7 @@ FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 bool Platform_getDiskIO(DiskIOData* data);
 
-bool Platform_getNetworkIO(unsigned long int* bytesReceived,
-                           unsigned long int* packetsReceived,
-                           unsigned long int* bytesTransmitted,
-                           unsigned long int* packetsTransmitted);
+bool Platform_getNetworkIO(NetworkIOData* data);
 
 void Platform_getBattery(double *percent, ACPresence *isOnAC);
 


### PR DESCRIPTION
On Linux kernels the size of the values exported for network
device bytes and packets has used a 64 bit integer for quite
some time (2.6+ IIRC).  Make the procfs value extraction use
correct types and change internal types used to rate convert
these counters (within the NetworkIO Meter) 64 bit integers,
where appropriate.