### PR TITLE
Fix integer sizing issues in the DiskIO Meter

### DIFF
--- a/DiskIOMeter.c
+++ b/DiskIOMeter.c
@@ -26,12 +26,12 @@ static const int DiskIOMeter_attributes[] = {
 };
 
 static bool hasData = false;
-static unsigned long int cached_read_diff = 0;
-static unsigned long int cached_write_diff = 0;
-static double cached_utilisation_diff = 0.0;
+static unsigned long int cached_read_diff;
+static unsigned long int cached_write_diff;
+static double cached_utilisation_diff;
 
 static void DiskIOMeter_updateValues(Meter* this, char* buffer, size_t len) {
-   static unsigned long long int cached_last_update = 0;
+   static unsigned long long int cached_last_update;
 
    struct timeval tv;
    gettimeofday(&tv, NULL);
@@ -40,9 +40,10 @@ static void DiskIOMeter_updateValues(Meter* this, char* buffer, size_t len) {
 
    /* update only every 500ms */
    if (passedTimeInMs > 500) {
-      static unsigned long int cached_read_total = 0;
-      static unsigned long int cached_write_total = 0;
-      static unsigned long int cached_msTimeSpend_total = 0;
+      static unsigned long long int cached_read_total;
+      static unsigned long long int cached_write_total;
+      static unsigned long long int cached_msTimeSpend_total;
+      unsigned long long int diff;
 
       cached_last_update = timeInMilliSeconds;
 
@@ -56,21 +57,26 @@ static void DiskIOMeter_updateValues(Meter* this, char* buffer, size_t len) {
       }
 
       if (data.totalBytesRead > cached_read_total) {
-         cached_read_diff = (data.totalBytesRead - cached_read_total) / 1024; /* Meter_humanUnit() expects unit in kilo */
+         diff = data.totalBytesRead - cached_read_total;
+         diff /= 1024; /* Meter_humanUnit() expects unit in kilo */
+         cached_read_diff = (unsigned int)diff;
       } else {
-         cached_read_diff = 0;
+         cached_read_diff = 0UL;
       }
       cached_read_total = data.totalBytesRead;
 
       if (data.totalBytesWritten > cached_write_total) {
-         cached_write_diff = (data.totalBytesWritten - cached_write_total) / 1024; /* Meter_humanUnit() expects unit in kilo */
+         diff = data.totalBytesWritten - cached_write_total;
+         diff /= 1024; /* Meter_humanUnit() expects unit in kilo */
+         cached_write_diff = (unsigned int)diff;
       } else {
-         cached_write_diff = 0;
+         cached_write_diff = 0UL;
       }
       cached_write_total = data.totalBytesWritten;
 
       if (data.totalMsTimeSpend > cached_msTimeSpend_total) {
-         cached_utilisation_diff = 100 * (double)(data.totalMsTimeSpend - cached_msTimeSpend_total) / passedTimeInMs;
+         diff = data.totalMsTimeSpend - cached_msTimeSpend_total;
+         cached_utilisation_diff = 100.0 * (double)diff / passedTimeInMs;
       } else {
          cached_utilisation_diff = 0.0;
       }

--- a/DiskIOMeter.c
+++ b/DiskIOMeter.c
@@ -26,24 +26,24 @@ static const int DiskIOMeter_attributes[] = {
 };
 
 static bool hasData = false;
-static unsigned long int cached_read_diff;
-static unsigned long int cached_write_diff;
+static uint32_t cached_read_diff;
+static uint32_t cached_write_diff;
 static double cached_utilisation_diff;
 
 static void DiskIOMeter_updateValues(Meter* this, char* buffer, size_t len) {
-   static unsigned long long int cached_last_update;
+   static uint64_t cached_last_update;
 
    struct timeval tv;
    gettimeofday(&tv, NULL);
-   unsigned long long int timeInMilliSeconds = (unsigned long long int)tv.tv_sec * 1000 + (unsigned long long int)tv.tv_usec / 1000;
-   unsigned long long int passedTimeInMs = timeInMilliSeconds - cached_last_update;
+   uint64_t timeInMilliSeconds = (uint64_t)tv.tv_sec * 1000 + (uint64_t)tv.tv_usec / 1000;
+   uint64_t passedTimeInMs = timeInMilliSeconds - cached_last_update;
 
    /* update only every 500ms */
    if (passedTimeInMs > 500) {
-      static unsigned long long int cached_read_total;
-      static unsigned long long int cached_write_total;
-      static unsigned long long int cached_msTimeSpend_total;
-      unsigned long long int diff;
+      static uint64_t cached_read_total;
+      static uint64_t cached_write_total;
+      static uint64_t cached_msTimeSpend_total;
+      uint64_t diff;
 
       cached_last_update = timeInMilliSeconds;
 
@@ -59,18 +59,18 @@ static void DiskIOMeter_updateValues(Meter* this, char* buffer, size_t len) {
       if (data.totalBytesRead > cached_read_total) {
          diff = data.totalBytesRead - cached_read_total;
          diff /= 1024; /* Meter_humanUnit() expects unit in kilo */
-         cached_read_diff = (unsigned int)diff;
+         cached_read_diff = (uint32_t)diff;
       } else {
-         cached_read_diff = 0UL;
+         cached_read_diff = 0;
       }
       cached_read_total = data.totalBytesRead;
 
       if (data.totalBytesWritten > cached_write_total) {
          diff = data.totalBytesWritten - cached_write_total;
          diff /= 1024; /* Meter_humanUnit() expects unit in kilo */
-         cached_write_diff = (unsigned int)diff;
+         cached_write_diff = (uint32_t)diff;
       } else {
-         cached_write_diff = 0UL;
+         cached_write_diff = 0;
       }
       cached_write_total = data.totalBytesWritten;
 

--- a/DiskIOMeter.h
+++ b/DiskIOMeter.h
@@ -10,9 +10,9 @@ in the source distribution for its full text.
 #include "Meter.h"
 
 typedef struct DiskIOData_ {
-   unsigned long int totalBytesRead;
-   unsigned long int totalBytesWritten;
-   unsigned long int totalMsTimeSpend;
+   unsigned long long int totalBytesRead;
+   unsigned long long int totalBytesWritten;
+   unsigned long long int totalMsTimeSpend;
 } DiskIOData;
 
 extern const MeterClass DiskIOMeter_class;

--- a/DiskIOMeter.h
+++ b/DiskIOMeter.h
@@ -10,9 +10,9 @@ in the source distribution for its full text.
 #include "Meter.h"
 
 typedef struct DiskIOData_ {
-   unsigned long long int totalBytesRead;
-   unsigned long long int totalBytesWritten;
-   unsigned long long int totalMsTimeSpend;
+   uint64_t totalBytesRead;
+   uint64_t totalBytesWritten;
+   uint64_t totalMsTimeSpend;
 } DiskIOData;
 
 extern const MeterClass DiskIOMeter_class;

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -289,7 +289,7 @@ bool Platform_getDiskIO(DiskIOData* data) {
 
    int count = current.dinfo->numdevs;
 
-   unsigned long int bytesReadSum = 0, bytesWriteSum = 0, timeSpendSum = 0;
+   unsigned long long int bytesReadSum = 0, bytesWriteSum = 0, timeSpendSum = 0;
 
    // get data
    for (int i = 0; i < count; i++) {

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -494,12 +494,12 @@ bool Platform_getDiskIO(DiskIOData* data) {
    if (!fd)
       return false;
 
-   unsigned long int read_sum = 0, write_sum = 0, timeSpend_sum = 0;
+   unsigned long long int read_sum = 0, write_sum = 0, timeSpend_sum = 0;
    char lineBuffer[256];
    while (fgets(lineBuffer, sizeof(lineBuffer), fd)) {
       char diskname[32];
-      unsigned long int read_tmp, write_tmp, timeSpend_tmp;
-      if (sscanf(lineBuffer, "%*d %*d %31s %*u %*u %lu %*u %*u %*u %lu %*u %*u %lu", diskname, &read_tmp, &write_tmp, &timeSpend_tmp) == 4) {
+      unsigned long long int read_tmp, write_tmp, timeSpend_tmp;
+      if (sscanf(lineBuffer, "%*d %*d %31s %*u %*u %llu %*u %*u %*u %llu %*u %*u %llu", diskname, &read_tmp, &write_tmp, &timeSpend_tmp) == 4) {
          if (String_startsWith(diskname, "dm-"))
             continue;
 


### PR DESCRIPTION
On Linux kernels the size of the values exported for block
device bytes has used a 64 bit integer for quite some time
(2.6+ IIRC).  Make the procfs value extraction use correct
types and change internal types used to rate convert these
counters (within the DiskIO Meter) 64 bit integers, where
appropriate.