### PR TITLE
Fix truncation of the intermediate strings in the SysArch meter

### DIFF
--- a/SysArchMeter.c
+++ b/SysArchMeter.c
@@ -62,11 +62,18 @@ static void parseOSRelease(char* buffer, size_t bufferLen) {
 }
 
 static void SysArchMeter_updateValues(ATTR_UNUSED Meter* this, char* buffer, size_t size) {
-   static char savedString[128] = {'\0'};
+   static struct utsname uname_info;
+
+   static char savedString[
+      /* uname structure fields - manpages recommend sizeof */
+      sizeof(uname_info.sysname) +
+      sizeof(uname_info.release) +
+      sizeof(uname_info.machine) +
+      16/*markup*/ +
+      128/*distro*/] = {'\0'};
    static bool loaded_data = false;
 
    if (!loaded_data) {
-      struct utsname uname_info;
       int uname_result = uname(&uname_info);
 
       char distro[128];


### PR DESCRIPTION
Found by @natoscott …

```
SysArchMeter.c: In function ‘SysArchMeter_updateValues’:
SysArchMeter.c:78:80: warning: ‘%s’ directive output may be truncated writing up to 127 bytes into a region of size 125 [-Wformat-truncation=]
   78 |             snprintf(savedString + written, sizeof(savedString) - written, " @ %s", distro);
      |                                                                                ^~   ~~~~~~
SysArchMeter.c:78:13: note: ‘snprintf’ output between 4 and 131 bytes into a destination of size 128
   78 |             snprintf(savedString + written, sizeof(savedString) - written, " @ %s", distro);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```