### PR TITLE
Separate display from sampling in SysArch and Hostname Meters

### DIFF
--- a/Generic.c
+++ b/Generic.c
@@ -1,0 +1,102 @@
+/*
+htop - Generic.c
+(C) 2021 htop dev team
+Released under the GNU GPLv2, see the COPYING file
+in the source distribution for its full text.
+*/
+#include "config.h"  // IWYU pragma: keep
+
+#include "Generic.h"
+
+#include <stdio.h>
+#ifdef HAVE_SYS_UTSNAME_H
+#include <sys/utsname.h>
+#endif
+#include <unistd.h>
+
+#include "XUtils.h"
+
+void Generic_Hostname(char* buffer, size_t size) {
+   gethostname(buffer, size - 1);
+}
+
+#ifdef HAVE_SYS_UTSNAME_H
+
+#ifndef OSRELEASEFILE
+#define OSRELEASEFILE "/etc/os-release"
+#endif
+
+static void parseOSRelease(char* buffer, size_t bufferLen) {
+   FILE* stream = fopen(OSRELEASEFILE, "r");
+   if (!stream) {
+      xSnprintf(buffer, bufferLen, "No OS Release");
+      return;
+   }
+
+   char name[64] = {'\0'};
+   char version[64] = {'\0'};
+   char lineBuffer[256];
+   while (fgets(lineBuffer, sizeof(lineBuffer), stream)) {
+      if (String_startsWith(lineBuffer, "PRETTY_NAME=\"")) {
+         const char* start = lineBuffer + strlen("PRETTY_NAME=\"");
+         const char* stop = strrchr(lineBuffer, '"');
+         if (!stop || stop <= start)
+            continue;
+         String_safeStrncpy(buffer, start, MINIMUM(bufferLen, (size_t)(stop - start + 1)));
+         fclose(stream);
+         return;
+      }
+      if (String_startsWith(lineBuffer, "NAME=\"")) {
+         const char* start = lineBuffer + strlen("NAME=\"");
+         const char* stop = strrchr(lineBuffer, '"');
+         if (!stop || stop <= start)
+            continue;
+         String_safeStrncpy(name, start, MINIMUM(sizeof(name), (size_t)(stop - start + 1)));
+         continue;
+      }
+      if (String_startsWith(lineBuffer, "VERSION=\"")) {
+         const char* start = lineBuffer + strlen("VERSION=\"");
+         const char* stop = strrchr(lineBuffer, '"');
+         if (!stop || stop <= start)
+            continue;
+         String_safeStrncpy(version, start, MINIMUM(sizeof(version), (size_t)(stop - start + 1)));
+         continue;
+      }
+   }
+   fclose(stream);
+
+   snprintf(buffer, bufferLen, "%s%s%s", name[0] ? name : "", name[0] && version[0] ? " " : "", version);
+}
+
+char* Generic_OSRelease(void) {
+   static struct utsname uname_info;
+
+   static char savedString[
+      /* uname structure fields - manpages recommend sizeof */
+      sizeof(uname_info.sysname) +
+      sizeof(uname_info.release) +
+      sizeof(uname_info.machine) +
+      16/*markup*/ +
+      128/*distro*/] = {'\0'};
+   static bool loaded_data = false;
+
+   if (!loaded_data) {
+      int uname_result = uname(&uname_info);
+
+      char distro[128];
+      parseOSRelease(distro, sizeof(distro));
+
+      if (uname_result == 0) {
+         size_t written = xSnprintf(savedString, sizeof(savedString), "%s %s [%s]", uname_info.sysname, uname_info.release, uname_info.machine);
+         if (!String_contains_i(savedString, distro) && sizeof(savedString) > written)
+            snprintf(savedString + written, sizeof(savedString) - written, " @ %s", distro);
+      } else {
+         snprintf(savedString, sizeof(savedString), "%s", distro);
+      }
+
+      loaded_data = true;
+   }
+
+   return savedString;
+}
+#endif

--- a/Generic.h
+++ b/Generic.h
@@ -1,0 +1,16 @@
+#ifndef HEADER_Generic
+#define HEADER_Generic
+/*
+htop - Generic.h
+(C) 2021 htop dev team
+Released under the GNU GPLv2, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include <stddef.h>
+
+void Generic_Hostname(char* buffer, size_t size);
+
+char* Generic_OSRelease(void);
+
+#endif

--- a/HostnameMeter.c
+++ b/HostnameMeter.c
@@ -8,6 +8,7 @@ in the source distribution for its full text.
 #include "config.h" // IWYU pragma: keep
 
 #include "HostnameMeter.h"
+#include "Platform.h"
 
 #include <unistd.h>
 
@@ -19,9 +20,8 @@ static const int HostnameMeter_attributes[] = {
    HOSTNAME
 };
 
-static void HostnameMeter_updateValues(Meter* this, char* buffer, size_t size) {
-   (void) this;
-   gethostname(buffer, size - 1);
+static void HostnameMeter_updateValues(ATTR_UNUSED Meter* this, char* buffer, size_t size) {
+   Platform_getHostname(buffer, size);
 }
 
 const MeterClass HostnameMeter_class = {

--- a/Makefile.am
+++ b/Makefile.am
@@ -42,6 +42,7 @@ myhtopsources = \
 	DisplayOptionsPanel.c \
 	EnvScreen.c \
 	FunctionBar.c \
+	Generic.c \
 	Hashtable.c \
 	Header.c \
 	HostnameMeter.c \
@@ -96,6 +97,7 @@ myhtopheaders = \
 	DisplayOptionsPanel.h \
 	EnvScreen.h \
 	FunctionBar.h \
+	Generic.h \
 	Hashtable.h \
 	Header.h \
 	HostnameMeter.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -42,7 +42,6 @@ myhtopsources = \
 	DisplayOptionsPanel.c \
 	EnvScreen.c \
 	FunctionBar.c \
-	Generic.c \
 	Hashtable.c \
 	Header.c \
 	HostnameMeter.c \
@@ -97,7 +96,6 @@ myhtopheaders = \
 	DisplayOptionsPanel.h \
 	EnvScreen.h \
 	FunctionBar.h \
-	Generic.h \
 	Hashtable.h \
 	Header.h \
 	HostnameMeter.h \
@@ -136,6 +134,8 @@ myhtopheaders = \
 # -----
 
 linux_platform_headers = \
+	generic/hostname.h \
+	generic/uname.h \
 	linux/HugePageMeter.h \
 	linux/IOPriority.h \
 	linux/IOPriorityPanel.h \
@@ -153,9 +153,9 @@ linux_platform_headers = \
 	zfs/ZfsArcStats.h \
 	zfs/ZfsCompressedArcMeter.h
 
-if HTOP_LINUX
-AM_LDFLAGS += -rdynamic
-myhtopplatsources = \
+linux_platform_sources = \
+	generic/hostname.c \
+	generic/uname.c \
 	linux/HugePageMeter.c \
 	linux/IOPriorityPanel.c \
 	linux/LibSensors.c \
@@ -169,7 +169,10 @@ myhtopplatsources = \
 	zfs/ZfsArcMeter.c \
 	zfs/ZfsCompressedArcMeter.c
 
+if HTOP_LINUX
+AM_LDFLAGS += -rdynamic
 myhtopplatheaders = $(linux_platform_headers)
+myhtopplatsources = $(linux_platform_sources)
 endif
 
 # FreeBSD
@@ -180,17 +183,26 @@ freebsd_platform_headers = \
 	freebsd/FreeBSDProcess.h \
 	freebsd/Platform.h \
 	freebsd/ProcessField.h \
+	generic/hostname.h \
+	generic/openzfs_sysctl.h \
+	generic/uname.h \
 	zfs/ZfsArcMeter.h \
-	zfs/ZfsCompressedArcMeter.h \
 	zfs/ZfsArcStats.h \
-	zfs/openzfs_sysctl.h
+	zfs/ZfsCompressedArcMeter.h
+
+freebsd_platform_sources = \
+	freebsd/Platform.c \
+	freebsd/FreeBSDProcessList.c \
+	freebsd/FreeBSDProcess.c \
+	generic/hostname.c \
+	generic/openzfs_sysctl.c \
+	generic/uname.c \
+	zfs/ZfsArcMeter.c \
+	zfs/ZfsCompressedArcMeter.c
 
 if HTOP_FREEBSD
-myhtopplatsources = freebsd/Platform.c freebsd/FreeBSDProcessList.c \
-freebsd/FreeBSDProcess.c \
-zfs/ZfsArcMeter.c zfs/ZfsCompressedArcMeter.c zfs/openzfs_sysctl.c
-
 myhtopplatheaders = $(freebsd_platform_headers)
+myhtopplatsources = $(freebsd_platform_sources)
 endif
 
 # DragonFlyBSD
@@ -200,31 +212,43 @@ dragonflybsd_platform_headers = \
 	dragonflybsd/DragonFlyBSDProcessList.h \
 	dragonflybsd/DragonFlyBSDProcess.h \
 	dragonflybsd/Platform.h \
-	dragonflybsd/ProcessField.h
+	dragonflybsd/ProcessField.h \
+	generic/hostname.h \
+	generic/uname.h
+
+dragonflybsd_platform_sources = \
+	dragonflybsd/DragonFlyBSDProcessList.c \
+	dragonflybsd/DragonFlyBSDProcess.c \
+	dragonflybsd/Platform.c \
+	generic/hostname.c \
+	generic/uname.c
 
 if HTOP_DRAGONFLYBSD
-myhtopplatsources = \
-	dragonflybsd/Platform.c \
-	dragonflybsd/DragonFlyBSDProcessList.c \
-	dragonflybsd/DragonFlyBSDProcess.c
-
 myhtopplatheaders = $(dragonflybsd_platform_headers)
+myhtopplatsources = $(dragonflybsd_platform_sources)
 endif
 
 # OpenBSD
 # -------
 
 openbsd_platform_headers = \
+	generic/hostname.h \
+	generic/uname.h \
 	openbsd/OpenBSDProcessList.h \
 	openbsd/OpenBSDProcess.h \
 	openbsd/Platform.h \
 	openbsd/ProcessField.h
 
-if HTOP_OPENBSD
-myhtopplatsources = openbsd/Platform.c openbsd/OpenBSDProcessList.c \
-openbsd/OpenBSDProcess.c
+openbsd_platform_sources = \
+	generic/hostname.c \
+	generic/uname.c \
+	openbsd/OpenBSDProcessList.c \
+	openbsd/OpenBSDProcess.c \
+	openbsd/Platform.c
 
+if HTOP_OPENBSD
 myhtopplatheaders = $(openbsd_platform_headers)
+myhtopplatsources = $(openbsd_platform_sources)
 endif
 
 # Darwin
@@ -235,38 +259,55 @@ darwin_platform_headers = \
 	darwin/DarwinProcessList.h \
 	darwin/Platform.h \
 	darwin/ProcessField.h \
+	generic/hostname.h \
+	generic/openzfs_sysctl.h \
+	generic/uname.h \
 	zfs/ZfsArcMeter.h \
-	zfs/ZfsCompressedArcMeter.h \
 	zfs/ZfsArcStats.h \
-	zfs/openzfs_sysctl.h
+	zfs/ZfsCompressedArcMeter.h
+
+darwin_platform_sources = \
+	darwin/Platform.c \
+	darwin/DarwinProcess.c \
+	darwin/DarwinProcessList.c \
+	generic/hostname.c \
+	generic/openzfs_sysctl.c \
+	generic/uname.c \
+	zfs/ZfsArcMeter.c \
+	zfs/ZfsCompressedArcMeter.c
 
 if HTOP_DARWIN
 AM_LDFLAGS += -framework IOKit -framework CoreFoundation
-myhtopplatsources = darwin/Platform.c darwin/DarwinProcess.c \
-darwin/DarwinProcessList.c \
-zfs/ZfsArcMeter.c zfs/ZfsCompressedArcMeter.c zfs/openzfs_sysctl.c
-
 myhtopplatheaders = $(darwin_platform_headers)
+myhtopplatsources = $(darwin_platform_sources)
 endif
 
 # Solaris
 # -------
 
 solaris_platform_headers = \
-	solaris/Platform.h \
+	generic/hostname.h \
+	generic/uname.h \
 	solaris/ProcessField.h \
+	solaris/Platform.h \
 	solaris/SolarisProcess.h \
 	solaris/SolarisProcessList.h \
 	zfs/ZfsArcMeter.h \
-	zfs/ZfsCompressedArcMeter.h \
-	zfs/ZfsArcStats.h
+	zfs/ZfsArcStats.h \
+	zfs/ZfsCompressedArcMeter.h
+
+solaris_platform_sources = \
+	generic/hostname.c \
+	generic/uname.c \
+	solaris/Platform.c \
+	solaris/SolarisProcess.c \
+	solaris/SolarisProcessList.c \
+	zfs/ZfsArcMeter.c \
+	zfs/ZfsCompressedArcMeter.c
 
 if HTOP_SOLARIS
-myhtopplatsources = solaris/Platform.c \
-solaris/SolarisProcess.c solaris/SolarisProcessList.c \
-zfs/ZfsArcMeter.c zfs/ZfsCompressedArcMeter.c
-
 myhtopplatheaders = $(solaris_platform_headers)
+myhtopplatsources = $(solaris_platform_sources)
 endif
 
 # Unsupported
@@ -278,10 +319,13 @@ unsupported_platform_headers = \
 	unsupported/UnsupportedProcess.h \
 	unsupported/UnsupportedProcessList.h
 
-if HTOP_UNSUPPORTED
-myhtopplatsources = unsupported/Platform.c \
-unsupported/UnsupportedProcess.c unsupported/UnsupportedProcessList.c
+unsupported_platform_sources = \
+	unsupported/Platform.c \
+	unsupported/UnsupportedProcess.c \
+	unsupported/UnsupportedProcessList.c
 
+if HTOP_UNSUPPORTED
+myhtopplatsources = $(unsupported_platform_sources)
 myhtopplatheaders = $(unsupported_platform_headers)
 endif
 

--- a/SysArchMeter.c
+++ b/SysArchMeter.c
@@ -6,91 +6,21 @@ in the source distribution for its full text.
 */
 #include "config.h"  // IWYU pragma: keep
 
+#include "Platform.h"
 #include "SysArchMeter.h"
-
-#include <stdio.h>
-#include <sys/utsname.h>
 
 #include "XUtils.h"
 
 
 static const int SysArchMeter_attributes[] = {HOSTNAME};
 
-static void parseOSRelease(char* buffer, size_t bufferLen) {
-   FILE* stream = fopen("/etc/os-release", "r");
-   if (!stream) {
-      stream = fopen("/usr/lib/os-release", "r");
-      if (!stream) {
-         xSnprintf(buffer, bufferLen, "Unknown Distro");
-         return;
-      }
-   }
-
-   char name[64] = {'\0'};
-   char version[64] = {'\0'};
-   char lineBuffer[256];
-   while (fgets(lineBuffer, sizeof(lineBuffer), stream)) {
-      if (String_startsWith(lineBuffer, "PRETTY_NAME=\"")) {
-         const char* start = lineBuffer + strlen("PRETTY_NAME=\"");
-         const char* stop = strrchr(lineBuffer, '"');
-         if (!stop || stop <= start)
-            continue;
-         String_safeStrncpy(buffer, start, MINIMUM(bufferLen, (size_t)(stop - start + 1)));
-         fclose(stream);
-         return;
-      }
-      if (String_startsWith(lineBuffer, "NAME=\"")) {
-         const char* start = lineBuffer + strlen("NAME=\"");
-         const char* stop = strrchr(lineBuffer, '"');
-         if (!stop || stop <= start)
-            continue;
-         String_safeStrncpy(name, start, MINIMUM(sizeof(name), (size_t)(stop - start + 1)));
-         continue;
-      }
-      if (String_startsWith(lineBuffer, "VERSION=\"")) {
-         const char* start = lineBuffer + strlen("VERSION=\"");
-         const char* stop = strrchr(lineBuffer, '"');
-         if (!stop || stop <= start)
-            continue;
-         String_safeStrncpy(version, start, MINIMUM(sizeof(version), (size_t)(stop - start + 1)));
-         continue;
-      }
-   }
-   fclose(stream);
-
-   snprintf(buffer, bufferLen, "%s%s%s", name[0] ? name : "", name[0] && version[0] ? " " : "", version);
-}
-
 static void SysArchMeter_updateValues(ATTR_UNUSED Meter* this, char* buffer, size_t size) {
-   static struct utsname uname_info;
+   static char* string;
 
-   static char savedString[
-      /* uname structure fields - manpages recommend sizeof */
-      sizeof(uname_info.sysname) +
-      sizeof(uname_info.release) +
-      sizeof(uname_info.machine) +
-      16/*markup*/ +
-      128/*distro*/] = {'\0'};
-   static bool loaded_data = false;
+   if (string == NULL)
+      Platform_getRelease(&string);
 
-   if (!loaded_data) {
-      int uname_result = uname(&uname_info);
-
-      char distro[128];
-      parseOSRelease(distro, sizeof(distro));
-
-      if (uname_result == 0) {
-         size_t written = xSnprintf(savedString, sizeof(savedString), "%s %s [%s]", uname_info.sysname, uname_info.release, uname_info.machine);
-         if (!String_contains_i(savedString, distro) && sizeof(savedString) > written)
-            snprintf(savedString + written, sizeof(savedString) - written, " @ %s", distro);
-      } else {
-         snprintf(savedString, sizeof(savedString), "%s", distro);
-      }
-
-      loaded_data = true;
-   }
-
-   String_safeStrncpy(buffer, savedString, size);
+   String_safeStrncpy(buffer, string, size);
 }
 
 const MeterClass SysArchMeter_class = {

--- a/configure.ac
+++ b/configure.ac
@@ -108,6 +108,7 @@ AC_CHECK_HEADERS([ \
     strings.h \
     sys/param.h \
     sys/time.h \
+    sys/utsname.h \
     unistd.h
    ], [], [AC_MSG_ERROR([can not find required generic header files])])
 
@@ -315,6 +316,18 @@ case "$enable_hwloc" in
       AC_MSG_ERROR([bad value '$enable_hwloc' for --enable-hwloc])
       ;;
 esac
+
+AC_ARG_WITH([os-release],
+            [AS_HELP_STRING([--with-os-release=FILE],
+			    [location of an os-release file @<:@default=/etc/os-release@:>@])],
+            [],
+            [with_os_release=/etc/os-release])
+if test -n "$with_os_release" -a ! -f "$with_os_release"; then
+   if test -f "/usr/lib/os-release"; then
+      with_os_release="/usr/lib/os-release"
+   fi
+fi
+AC_DEFINE_UNQUOTED([OSRELEASEFILE], ["$with_os_release"], [File with OS release details.])
 
 # ----------------------------------------------------------------------
 
@@ -608,6 +621,7 @@ AC_MSG_RESULT([
   ${PACKAGE_NAME} ${VERSION}
 
   platform:                  $my_htop_platform
+  os-release file:           $with_os_release
   (Linux) proc directory:    $with_proc
   (Linux) openvz:            $enable_openvz
   (Linux) vserver:           $enable_vserver

--- a/darwin/DarwinProcessList.c
+++ b/darwin/DarwinProcessList.c
@@ -20,9 +20,9 @@ in the source distribution for its full text.
 
 #include "CRT.h"
 #include "DarwinProcess.h"
-#include "generic/openzfs_sysctl.h"
 #include "Platform.h"
 #include "ProcessList.h"
+#include "generic/openzfs_sysctl.h"
 #include "zfs/ZfsArcStats.h"
 
 

--- a/darwin/DarwinProcessList.c
+++ b/darwin/DarwinProcessList.c
@@ -20,9 +20,9 @@ in the source distribution for its full text.
 
 #include "CRT.h"
 #include "DarwinProcess.h"
+#include "generic/openzfs_sysctl.h"
 #include "Platform.h"
 #include "ProcessList.h"
-#include "zfs/openzfs_sysctl.h"
 #include "zfs/ZfsArcStats.h"
 
 

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -16,11 +16,11 @@ in the source distribution for its full text.
 #include "CPUMeter.h"
 #include "DarwinProcess.h"
 #include "DiskIOMeter.h"
-#include "generic/hostname.h"
-#include "generic/uname.h"
 #include "NetworkIOMeter.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
+#include "generic/hostname.h"
+#include "generic/uname.h"
 
 
 extern const ProcessField Platform_defaultFields[];

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -16,6 +16,7 @@ in the source distribution for its full text.
 #include "CPUMeter.h"
 #include "DarwinProcess.h"
 #include "DiskIOMeter.h"
+#include "Generic.h"
 #include "NetworkIOMeter.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
@@ -66,5 +67,13 @@ bool Platform_getDiskIO(DiskIOData* data);
 bool Platform_getNetworkIO(NetworkIOData* data);
 
 void Platform_getBattery(double *percent, ACPresence *isOnAC);
+
+static inline void Platform_getHostname(char* buffer, size_t size) {
+   Generic_Hostname(buffer, size);
+}
+
+static inline void Platform_getRelease(char** string) {
+   *string = Generic_OSRelease();
+}
 
 #endif

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -16,7 +16,8 @@ in the source distribution for its full text.
 #include "CPUMeter.h"
 #include "DarwinProcess.h"
 #include "DiskIOMeter.h"
-#include "Generic.h"
+#include "generic/hostname.h"
+#include "generic/uname.h"
 #include "NetworkIOMeter.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
@@ -69,11 +70,11 @@ bool Platform_getNetworkIO(NetworkIOData* data);
 void Platform_getBattery(double *percent, ACPresence *isOnAC);
 
 static inline void Platform_getHostname(char* buffer, size_t size) {
-   Generic_Hostname(buffer, size);
+   Generic_hostname(buffer, size);
 }
 
 static inline void Platform_getRelease(char** string) {
-   *string = Generic_OSRelease();
+   *string = Generic_uname();
 }
 
 #endif

--- a/dragonflybsd/Platform.h
+++ b/dragonflybsd/Platform.h
@@ -14,11 +14,11 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
-#include "generic/hostname.h"
-#include "generic/uname.h"
 #include "NetworkIOMeter.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
+#include "generic/hostname.h"
+#include "generic/uname.h"
 
 
 extern const ProcessField Platform_defaultFields[];

--- a/dragonflybsd/Platform.h
+++ b/dragonflybsd/Platform.h
@@ -14,7 +14,8 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
-#include "Generic.h"
+#include "generic/hostname.h"
+#include "generic/uname.h"
 #include "NetworkIOMeter.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
@@ -59,11 +60,11 @@ bool Platform_getNetworkIO(NetworkIOData* data);
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
 
 static inline void Platform_getHostname(char* buffer, size_t size) {
-   Generic_Hostname(buffer, size);
+   Generic_hostname(buffer, size);
 }
 
 static inline void Platform_getRelease(char** string) {
-   *string = Generic_OSRelease();
+   *string = Generic_uname();
 }
 
 #endif

--- a/dragonflybsd/Platform.h
+++ b/dragonflybsd/Platform.h
@@ -14,6 +14,7 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
+#include "Generic.h"
 #include "NetworkIOMeter.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
@@ -56,5 +57,13 @@ bool Platform_getDiskIO(DiskIOData* data);
 bool Platform_getNetworkIO(NetworkIOData* data);
 
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
+
+static inline void Platform_getHostname(char* buffer, size_t size) {
+   Generic_Hostname(buffer, size);
+}
+
+static inline void Platform_getRelease(char** string) {
+   *string = Generic_OSRelease();
+}
 
 #endif

--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -30,13 +30,13 @@ in the source distribution for its full text.
 #include "CRT.h"
 #include "Compat.h"
 #include "FreeBSDProcess.h"
-#include "generic/openzfs_sysctl.h"
 #include "Macros.h"
 #include "Object.h"
 #include "Process.h"
 #include "ProcessList.h"
 #include "Settings.h"
 #include "XUtils.h"
+#include "generic/openzfs_sysctl.h"
 #include "zfs/ZfsArcStats.h"
 
 

--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -30,6 +30,7 @@ in the source distribution for its full text.
 #include "CRT.h"
 #include "Compat.h"
 #include "FreeBSDProcess.h"
+#include "generic/openzfs_sysctl.h"
 #include "Macros.h"
 #include "Object.h"
 #include "Process.h"
@@ -37,7 +38,6 @@ in the source distribution for its full text.
 #include "Settings.h"
 #include "XUtils.h"
 #include "zfs/ZfsArcStats.h"
-#include "zfs/openzfs_sysctl.h"
 
 
 static int MIB_hw_physmem[2];

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -13,13 +13,13 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
-#include "generic/hostname.h"
-#include "generic/uname.h"
 #include "Meter.h"
 #include "NetworkIOMeter.h"
 #include "Process.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
+#include "generic/hostname.h"
+#include "generic/uname.h"
 
 
 extern const ProcessField Platform_defaultFields[];

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -13,6 +13,7 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
+#include "Generic.h"
 #include "Meter.h"
 #include "NetworkIOMeter.h"
 #include "Process.h"
@@ -61,5 +62,13 @@ bool Platform_getDiskIO(DiskIOData* data);
 bool Platform_getNetworkIO(NetworkIOData* data);
 
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
+
+static inline void Platform_getHostname(char* buffer, size_t size) {
+   Generic_Hostname(buffer, size);
+}
+
+static inline void Platform_getRelease(char** string) {
+   *string = Generic_OSRelease();
+}
 
 #endif

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -13,7 +13,8 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
-#include "Generic.h"
+#include "generic/hostname.h"
+#include "generic/uname.h"
 #include "Meter.h"
 #include "NetworkIOMeter.h"
 #include "Process.h"
@@ -64,11 +65,11 @@ bool Platform_getNetworkIO(NetworkIOData* data);
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
 
 static inline void Platform_getHostname(char* buffer, size_t size) {
-   Generic_Hostname(buffer, size);
+   Generic_hostname(buffer, size);
 }
 
 static inline void Platform_getRelease(char** string) {
-   *string = Generic_OSRelease();
+   *string = Generic_uname();
 }
 
 #endif

--- a/generic/hostname.c
+++ b/generic/hostname.c
@@ -1,0 +1,16 @@
+/*
+htop - generic/hostname.c
+(C) 2021 htop dev team
+Released under the GNU GPLv2, see the COPYING file
+in the source distribution for its full text.
+*/
+#include "config.h"  // IWYU pragma: keep
+
+#include "generic/hostname.h"
+
+#include <unistd.h>
+
+
+void Generic_hostname(char* buffer, size_t size) {
+   gethostname(buffer, size - 1);
+}

--- a/generic/hostname.h
+++ b/generic/hostname.h
@@ -1,7 +1,7 @@
-#ifndef HEADER_Generic
-#define HEADER_Generic
+#ifndef HEADER_hostname
+#define HEADER_hostname
 /*
-htop - Generic.h
+htop - generic/hostname.h
 (C) 2021 htop dev team
 Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
@@ -9,8 +9,6 @@ in the source distribution for its full text.
 
 #include <stddef.h>
 
-void Generic_Hostname(char* buffer, size_t size);
-
-char* Generic_OSRelease(void);
+void Generic_hostname(char* buffer, size_t size);
 
 #endif

--- a/generic/hostname.h
+++ b/generic/hostname.h
@@ -9,6 +9,7 @@ in the source distribution for its full text.
 
 #include <stddef.h>
 
+
 void Generic_hostname(char* buffer, size_t size);
 
 #endif

--- a/generic/openzfs_sysctl.c
+++ b/generic/openzfs_sysctl.c
@@ -1,11 +1,11 @@
 /*
-htop - zfs/openzfs_sysctl.c
+htop - generic/openzfs_sysctl.c
 (C) 2014 Hisham H. Muhammad
 Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 
-#include "zfs/openzfs_sysctl.h"
+#include "generic/openzfs_sysctl.h"
 
 #include <stdlib.h>
 #include <sys/types.h> // IWYU pragma: keep

--- a/generic/openzfs_sysctl.h
+++ b/generic/openzfs_sysctl.h
@@ -9,6 +9,7 @@ in the source distribution for its full text.
 
 #include "zfs/ZfsArcStats.h"
 
+
 void openzfs_sysctl_init(ZfsArcStats* stats);
 
 void openzfs_sysctl_updateArcStats(ZfsArcStats* stats);

--- a/generic/openzfs_sysctl.h
+++ b/generic/openzfs_sysctl.h
@@ -1,7 +1,7 @@
 #ifndef HEADER_openzfs_sysctl
 #define HEADER_openzfs_sysctl
 /*
-htop - zfs/openzfs_sysctl.h
+htop - generic/openzfs_sysctl.h
 (C) 2014 Hisham H. Muhammad
 Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.

--- a/generic/uname.c
+++ b/generic/uname.c
@@ -1,26 +1,20 @@
 /*
-htop - Generic.c
+htop - generic/uname.c
 (C) 2021 htop dev team
 Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
 #include "config.h"  // IWYU pragma: keep
 
-#include "Generic.h"
+#include "generic/uname.h"
 
 #include <stdio.h>
 #ifdef HAVE_SYS_UTSNAME_H
 #include <sys/utsname.h>
 #endif
-#include <unistd.h>
 
 #include "XUtils.h"
 
-void Generic_Hostname(char* buffer, size_t size) {
-   gethostname(buffer, size - 1);
-}
-
-#ifdef HAVE_SYS_UTSNAME_H
 
 #ifndef OSRELEASEFILE
 #define OSRELEASEFILE "/etc/os-release"
@@ -68,7 +62,7 @@ static void parseOSRelease(char* buffer, size_t bufferLen) {
    snprintf(buffer, bufferLen, "%s%s%s", name[0] ? name : "", name[0] && version[0] ? " " : "", version);
 }
 
-char* Generic_OSRelease(void) {
+char* Generic_uname(void) {
    static char savedString[
       /* uname structure fields - manpages recommend sizeof */
       sizeof(((struct utsname*)0)->sysname) +
@@ -98,4 +92,3 @@ char* Generic_OSRelease(void) {
 
    return savedString;
 }
-#endif

--- a/generic/uname.h
+++ b/generic/uname.h
@@ -1,0 +1,12 @@
+#ifndef HEADER_uname
+#define HEADER_uname
+/*
+htop - generic/uname.h
+(C) 2021 htop dev team
+Released under the GNU GPLv2, see the COPYING file
+in the source distribution for its full text.
+*/
+
+char* Generic_uname(void);
+
+#endif

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -14,6 +14,7 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
+#include "Generic.h"
 #include "Meter.h"
 #include "NetworkIOMeter.h"
 #include "Process.h"
@@ -71,5 +72,13 @@ bool Platform_getDiskIO(DiskIOData* data);
 bool Platform_getNetworkIO(NetworkIOData* data);
 
 void Platform_getBattery(double *percent, ACPresence *isOnAC);
+
+static inline void Platform_getHostname(char* buffer, size_t size) {
+   Generic_Hostname(buffer, size);
+}
+
+static inline void Platform_getRelease(char** string) {
+   *string = Generic_OSRelease();
+}
 
 #endif

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -14,13 +14,13 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
-#include "generic/hostname.h"
-#include "generic/uname.h"
 #include "Meter.h"
 #include "NetworkIOMeter.h"
 #include "Process.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
+#include "generic/hostname.h"
+#include "generic/uname.h"
 
 /* GNU/Hurd does not have PATH_MAX in limits.h */
 #ifndef PATH_MAX

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -14,7 +14,8 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
-#include "Generic.h"
+#include "generic/hostname.h"
+#include "generic/uname.h"
 #include "Meter.h"
 #include "NetworkIOMeter.h"
 #include "Process.h"
@@ -74,11 +75,11 @@ bool Platform_getNetworkIO(NetworkIOData* data);
 void Platform_getBattery(double *percent, ACPresence *isOnAC);
 
 static inline void Platform_getHostname(char* buffer, size_t size) {
-   Generic_Hostname(buffer, size);
+   Generic_hostname(buffer, size);
 }
 
 static inline void Platform_getRelease(char** string) {
-   *string = Generic_OSRelease();
+   *string = Generic_uname();
 }
 
 #endif

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -14,6 +14,7 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
+#include "Generic.h"
 #include "Meter.h"
 #include "NetworkIOMeter.h"
 #include "Process.h"
@@ -59,5 +60,13 @@ bool Platform_getDiskIO(DiskIOData* data);
 bool Platform_getNetworkIO(NetworkIOData* data);
 
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
+
+static inline void Platform_getHostname(char* buffer, size_t size) {
+   Generic_Hostname(buffer, size);
+}
+
+static inline void Platform_getRelease(char** string) {
+   *string = Generic_OSRelease();
+}
 
 #endif

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -14,13 +14,13 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
-#include "generic/hostname.h"
-#include "generic/uname.h"
 #include "Meter.h"
 #include "NetworkIOMeter.h"
 #include "Process.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
+#include "generic/hostname.h"
+#include "generic/uname.h"
 
 
 extern const ProcessField Platform_defaultFields[];

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -14,7 +14,8 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
-#include "Generic.h"
+#include "generic/hostname.h"
+#include "generic/uname.h"
 #include "Meter.h"
 #include "NetworkIOMeter.h"
 #include "Process.h"
@@ -62,11 +63,11 @@ bool Platform_getNetworkIO(NetworkIOData* data);
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
 
 static inline void Platform_getHostname(char* buffer, size_t size) {
-   Generic_Hostname(buffer, size);
+   Generic_hostname(buffer, size);
 }
 
 static inline void Platform_getRelease(char** string) {
-   *string = Generic_OSRelease();
+   *string = Generic_uname();
 }
 
 #endif

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -19,7 +19,8 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
-#include "Generic.h"
+#include "generic/hostname.h"
+#include "generic/uname.h"
 #include "NetworkIOMeter.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
@@ -81,11 +82,11 @@ bool Platform_getNetworkIO(NetworkIOData* data);
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
 
 static inline void Platform_getHostname(char* buffer, size_t size) {
-   Generic_Hostname(buffer, size);
+   Generic_hostname(buffer, size);
 }
 
 static inline void Platform_getRelease(char** string) {
-   *string = Generic_OSRelease();
+   *string = Generic_uname();
 }
 
 #endif

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -19,11 +19,11 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
-#include "generic/hostname.h"
-#include "generic/uname.h"
 #include "NetworkIOMeter.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
+#include "generic/hostname.h"
+#include "generic/uname.h"
 
 
 #define  kill(pid, signal) kill(pid / 1024, signal)

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -19,6 +19,7 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "DiskIOMeter.h"
+#include "Generic.h"
 #include "NetworkIOMeter.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
@@ -78,5 +79,13 @@ bool Platform_getDiskIO(DiskIOData* data);
 bool Platform_getNetworkIO(NetworkIOData* data);
 
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
+
+static inline void Platform_getHostname(char* buffer, size_t size) {
+   Generic_Hostname(buffer, size);
+}
+
+static inline void Platform_getRelease(char** string) {
+   *string = Generic_OSRelease();
+}
 
 #endif

--- a/unsupported/Platform.c
+++ b/unsupported/Platform.c
@@ -64,6 +64,8 @@ const MeterClass* const Platform_meterTypes[] = {
    NULL
 };
 
+static const char Platform_unsupported[] = "unsupported";
+
 void Platform_init(void) {
    /* no platform-specific setup needed */
 }
@@ -145,4 +147,12 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
 void Platform_getBattery(double* percent, ACPresence* isOnAC) {
    *percent = NAN;
    *isOnAC = AC_ERROR;
+}
+
+void Platform_getHostname(char* buffer, size_t size) {
+   String_safeStrncpy(buffer, Platform_unsupported, size);
+}
+
+void Platform_getRelease(char** string) {
+    *string = xStrdup(Platform_unsupported);
 }

--- a/unsupported/Platform.h
+++ b/unsupported/Platform.h
@@ -57,4 +57,8 @@ bool Platform_getNetworkIO(NetworkIOData* data);
 
 void Platform_getBattery(double *percent, ACPresence *isOnAC);
 
+void Platform_getHostname(char* buffer, size_t size);
+
+void Platform_getRelease(char** string);
+
 #endif


### PR DESCRIPTION
Several of our newer meters have merged coding concerns in terms
of extracting values and displaying those values.  This commit
rectifies that for the SysArch and Hostname meters, allowing use
of this code with alternative front/back ends.  The SysArch code
is also refined to detect whether the platform has an os-release
file at all and/or the sys/utsname.h header via configure.ac.