### PR TITLE
RichString: do not unnecessarily clean whole buffer

### DIFF
--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -102,7 +102,6 @@ static void CPUMeter_updateValues(Meter* this) {
 static void CPUMeter_display(const Object* cast, RichString* out) {
    char buffer[50];
    const Meter* this = (const Meter*)cast;
-   RichString_prune(out);
    if (this->param > this->pl->cpuCount) {
       RichString_appendAscii(out, CRT_colors[METER_TEXT], "absent");
       return;

--- a/ListItem.c
+++ b/ListItem.c
@@ -34,8 +34,6 @@ static void ListItem_display(const Object* cast, RichString* out) {
                        CRT_utf8 ? "↕ " :
 #endif
                        "+ ");
-   } else {
-      RichString_prune(out);
    }
    RichString_appendWide(out, CRT_colors[DEFAULT_COLOR], this->value);
 }

--- a/Meter.c
+++ b/Meter.c
@@ -167,7 +167,7 @@ static void TextMeterMode_draw(Meter* this, int x, int y, ATTR_UNUSED int w) {
    RichString_begin(out);
    Meter_displayBuffer(this, &out);
    RichString_printoffnVal(out, y, x, 0, w - 1);
-   RichString_end(out);
+   RichString_delete(&out);
 }
 
 /* ---------- BarMeterMode ---------- */
@@ -257,7 +257,7 @@ static void BarMeterMode_draw(Meter* this, int x, int y, int w) {
       RichString_printoffnVal(bar, y, x + offset, startPos + offset, w - offset);
    }
 
-   RichString_end(bar);
+   RichString_delete(&bar);
 
    move(y, x + w + 1);
    attrset(CRT_colors[RESET_COLOR]);
@@ -414,7 +414,7 @@ static void LEDMeterMode_draw(Meter* this, int x, int y, ATTR_UNUSED int w) {
       }
    }
    attrset(CRT_colors[RESET_COLOR]);
-   RichString_end(out);
+   RichString_delete(&out);
 }
 
 static MeterMode BarMeterMode = {
@@ -456,8 +456,7 @@ static void BlankMeter_updateValues(Meter* this) {
    this->txtBuffer[0] = '\0';
 }
 
-static void BlankMeter_display(ATTR_UNUSED const Object* cast, RichString* out) {
-   RichString_prune(out);
+static void BlankMeter_display(ATTR_UNUSED const Object* cast, ATTR_UNUSED RichString* out) {
 }
 
 static const int BlankMeter_attributes[] = {

--- a/Panel.c
+++ b/Panel.c
@@ -69,7 +69,7 @@ void Panel_done(Panel* this) {
    free(this->eventHandlerState);
    Vector_delete(this->items);
    FunctionBar_delete(this->defaultBar);
-   RichString_end(this->header);
+   RichString_delete(&this->header);
 }
 
 void Panel_setSelectionColor(Panel* this, ColorElements colorId) {
@@ -287,7 +287,7 @@ void Panel_draw(Panel* this, bool force_redraw, bool focus, bool highlightSelect
             RichString_printoffnVal(item, y + line, x, scrollH, amt);
          if (item.highlightAttr)
             attrset(CRT_colors[RESET_COLOR]);
-         RichString_end(item);
+         RichString_delete(&item);
          line++;
       }
       while (line < h) {
@@ -316,8 +316,8 @@ void Panel_draw(Panel* this, bool force_redraw, bool focus, bool highlightSelect
          RichString_printoffnVal(new, y + this->selected - first, x,
             scrollH, MINIMUM(newLen - scrollH, this->w));
       attrset(CRT_colors[RESET_COLOR]);
-      RichString_end(new);
-      RichString_end(old);
+      RichString_delete(&new);
+      RichString_delete(&old);
    }
 
    if (focus && (this->needsRedraw || force_redraw || !this->wasFocus)) {

--- a/Process.c
+++ b/Process.c
@@ -406,7 +406,6 @@ void Process_writeField(const Process* this, RichString* str, ProcessField field
 void Process_display(const Object* cast, RichString* out) {
    const Process* this = (const Process*) cast;
    const ProcessField* fields = this->settings->fields;
-   RichString_prune(out);
    for (int i = 0; fields[i]; i++)
       As_Process(this)->writeField(this, out, fields[i]);
 

--- a/ProcessList.c
+++ b/ProcessList.c
@@ -94,7 +94,7 @@ static const char* alignedProcessFieldTitle(ProcessField field) {
 }
 
 void ProcessList_printHeader(const ProcessList* this, RichString* header) {
-   RichString_prune(header);
+   RichString_rewind(header, RichString_size(header));
 
    const Settings* settings = this->settings;
    const ProcessField* fields = settings->fields;

--- a/RichString.c
+++ b/RichString.c
@@ -185,11 +185,11 @@ int RichString_findChar(const RichString* this, char c, int start) {
 
 #endif /* HAVE_LIBNCURSESW */
 
-void RichString_prune(RichString* this) {
-   if (this->chlen > RICHSTRING_MAXLEN)
+void RichString_delete(RichString* this) {
+   if (this->chlen > RICHSTRING_MAXLEN) {
       free(this->chptr);
-   memset(this, 0, sizeof(RichString));
-   this->chptr = this->chstr;
+      this->chptr = this->chstr;
+   }
 }
 
 void RichString_setAttr(RichString* this, int attrs) {

--- a/RichString.h
+++ b/RichString.h
@@ -16,8 +16,13 @@ in the source distribution for its full text.
 #define RichString_sizeVal(this) ((this).chlen)
 
 #define RichString_begin(this) RichString (this); RichString_beginAllocated(this)
-#define RichString_beginAllocated(this) do { memset(&(this), 0, sizeof(RichString)); (this).chptr = (this).chstr; } while(0)
-#define RichString_end(this) RichString_prune(&(this))
+#define RichString_beginAllocated(this) \
+   do {                                 \
+      (this).chlen = 0,                 \
+      (this).chptr = (this).chstr;      \
+      RichString_setChar(&this, 0, 0);  \
+      (this).highlightAttr = 0;         \
+   } while(0)
 
 #ifdef HAVE_LIBNCURSESW
 #define RichString_printVal(this, y, x) mvadd_wchstr(y, x, (this).chptr)
@@ -42,13 +47,13 @@ typedef struct RichString_ {
    int highlightAttr;
 } RichString;
 
+void RichString_delete(RichString* this);
+
 void RichString_rewind(RichString* this, int count);
 
 void RichString_setAttrn(RichString* this, int attrs, int start, int charcount);
 
 int RichString_findChar(const RichString* this, char c, int start);
-
-void RichString_prune(RichString* this);
 
 void RichString_setAttr(RichString* this, int attrs);
 


### PR DESCRIPTION
The local stack buffer does not need to be cleaned to zeros when
  - just initialized, cause the length is set to 0 and the first
    character is set to '\0', so all printing functions will safely stop
  - no further used, i.e. the variable goes out of scope