### PR TITLE
Improve process following

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -267,7 +267,7 @@ static Htop_Reaction actionInvertSortOrder(State* st) {
    Settings_invertSortOrder(st->settings);
    if (st->pauseProcessUpdate)
       ProcessList_sort(st->pl);
-   return HTOP_REFRESH | HTOP_SAVE_SETTINGS;
+   return HTOP_REFRESH | HTOP_SAVE_SETTINGS | HTOP_KEEP_FOLLOWING;
 }
 
 static Htop_Reaction actionExpandOrCollapse(State* st) {
@@ -582,7 +582,7 @@ static Htop_Reaction actionHelp(State* st) {
    CRT_readKey();
    clear();
 
-   return HTOP_RECALCULATE | HTOP_REDRAW_BAR;
+   return HTOP_RECALCULATE | HTOP_REDRAW_BAR | HTOP_KEEP_FOLLOWING;
 }
 
 static Htop_Reaction actionUntagAll(State* st) {

--- a/ProcessList.c
+++ b/ProcessList.c
@@ -507,16 +507,26 @@ void ProcessList_collapseAllBranches(ProcessList* this) {
 void ProcessList_rebuildPanel(ProcessList* this) {
    const char* incFilter = this->incFilter;
 
-   int currPos = Panel_getSelectedIndex(this->panel);
-   int currScrollV = this->panel->scrollV;
-   int currSize = Panel_size(this->panel);
+   const int currPos = Panel_getSelectedIndex(this->panel);
+   const int currScrollV = this->panel->scrollV;
+   const int currSize = Panel_size(this->panel);
 
    Panel_prune(this->panel);
-   int size = ProcessList_size(this);
+
+   /* Follow main process if followed a userland thread and threads are now hidden */
+   const Settings* settings = this->settings;
+   if (this->following != -1 && settings->hideUserlandThreads) {
+      const Process* followedProcess = (const Process*) Hashtable_get(this->processTable, this->following);
+      if (followedProcess && Process_isThread(followedProcess) && Hashtable_get(this->processTable, followedProcess->tgid) != NULL) {
+         this->following = followedProcess->tgid;
+      }
+   }
+
+   const int processCount = ProcessList_size(this);
    int idx = 0;
    bool foundFollowed = false;
 
-   for (int i = 0; i < size; i++) {
+   for (int i = 0; i < processCount; i++) {
       Process* p = ProcessList_get(this, i);
 
       if ( (!p->show)


### PR DESCRIPTION
- stay in follow mode on sort inversion (I)
- stay in follow mode after viewing help screen (h)
- select parent process (where available) when having followed a thread
  and hiding these (H)

Closes: #560