### PR TITLE
Move libcap use to (Linux) platform-specific code

### DIFF
--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -23,6 +23,9 @@ in the source distribution for its full text.
 #include "generic/uname.h"
 
 
+#define PLATFORM_LONG_OPTIONS
+#define PLATFORM_LONG_OPTIONS_USAGE
+
 extern const ProcessField Platform_defaultFields[];
 
 extern double Platform_timebaseToNS;
@@ -77,7 +80,7 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
-static bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
+static inline bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
    return false;
 }
 

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -23,9 +23,6 @@ in the source distribution for its full text.
 #include "generic/uname.h"
 
 
-#define PLATFORM_LONG_OPTIONS
-#define PLATFORM_LONG_OPTIONS_USAGE
-
 extern const ProcessField Platform_defaultFields[];
 
 extern double Platform_timebaseToNS;
@@ -79,6 +76,10 @@ static inline void Platform_getHostname(char* buffer, size_t size) {
 static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
+
+#define PLATFORM_LONG_OPTIONS
+
+static inline void Platform_longOptionsUsage(ATTR_UNUSED const char* name) { }
 
 static inline bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
    return false;

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -77,4 +77,8 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
+static bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
+   return false;
+}
+
 #endif

--- a/dragonflybsd/Platform.h
+++ b/dragonflybsd/Platform.h
@@ -67,4 +67,8 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
+static bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
+   return false;
+}
+
 #endif

--- a/dragonflybsd/Platform.h
+++ b/dragonflybsd/Platform.h
@@ -21,9 +21,6 @@ in the source distribution for its full text.
 #include "generic/uname.h"
 
 
-#define PLATFORM_LONG_OPTIONS
-#define PLATFORM_LONG_OPTIONS_USAGE
-
 extern const ProcessField Platform_defaultFields[];
 
 extern const SignalItem Platform_signals[];
@@ -69,6 +66,10 @@ static inline void Platform_getHostname(char* buffer, size_t size) {
 static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
+
+#define PLATFORM_LONG_OPTIONS
+
+static inline void Platform_longOptionsUsage(ATTR_UNUSED const char* name) { }
 
 static inline bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
    return false;

--- a/dragonflybsd/Platform.h
+++ b/dragonflybsd/Platform.h
@@ -21,6 +21,9 @@ in the source distribution for its full text.
 #include "generic/uname.h"
 
 
+#define PLATFORM_LONG_OPTIONS
+#define PLATFORM_LONG_OPTIONS_USAGE
+
 extern const ProcessField Platform_defaultFields[];
 
 extern const SignalItem Platform_signals[];
@@ -67,7 +70,7 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
-static bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
+static inline bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
    return false;
 }
 

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -72,4 +72,8 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
+static bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
+   return false;
+}
+
 #endif

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -22,6 +22,9 @@ in the source distribution for its full text.
 #include "generic/uname.h"
 
 
+#define PLATFORM_LONG_OPTIONS
+#define PLATFORM_LONG_OPTIONS_USAGE
+
 extern const ProcessField Platform_defaultFields[];
 
 extern const SignalItem Platform_signals[];
@@ -72,7 +75,7 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
-static bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
+static inline bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
    return false;
 }
 

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -22,9 +22,6 @@ in the source distribution for its full text.
 #include "generic/uname.h"
 
 
-#define PLATFORM_LONG_OPTIONS
-#define PLATFORM_LONG_OPTIONS_USAGE
-
 extern const ProcessField Platform_defaultFields[];
 
 extern const SignalItem Platform_signals[];
@@ -74,6 +71,10 @@ static inline void Platform_getHostname(char* buffer, size_t size) {
 static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
+
+#define PLATFORM_LONG_OPTIONS
+
+static inline void Platform_longOptionsUsage(ATTR_UNUSED const char* name) { }
 
 static inline bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
    return false;

--- a/htop.c
+++ b/htop.c
@@ -36,20 +36,12 @@ in the source distribution for its full text.
 #include "XUtils.h"
 
 
-#ifndef PLATFORM_LONG_OPTIONS
-#define PLATFORM_LONG_OPTIONS
-#endif
-
-#ifndef PLATFORM_LONG_OPTIONS_USAGE
-#define PLATFORM_LONG_OPTIONS_USAGE
-#endif
-
 static void printVersionFlag(const char* name) {
-   fprintf(stdout, "%s " VERSION "\n", name);
+   printf("%s " VERSION "\n", name);
 }
 
 static void printHelpFlag(const char* name) {
-   fprintf(stdout, "%s " VERSION "\n"
+   printf("%s " VERSION "\n"
          COPYRIGHT "\n"
          "Released under the GNU GPLv2.\n\n"
          "-C --no-color                   Use a monochrome color scheme\n"

--- a/htop.c
+++ b/htop.c
@@ -48,7 +48,6 @@ static void printHelpFlag(const char* name) {
          "-d --delay=DELAY                Set the delay between updates, in tenths of seconds\n"
          "-F --filter=FILTER              Show only the commands matching the given filter\n"
          "-h --help                       Print this help screen\n"
-         PLATFORM_LONG_OPTIONS_USAGE
          "-H --highlight-changes[=DELAY]  Highlight new and old processes\n"
          "-M --no-mouse                   Disable the mouse\n"
          "-p --pid=PID[,PID,PID...]       Show only the given PIDs\n"
@@ -56,12 +55,12 @@ static void printHelpFlag(const char* name) {
          "-t --tree                       Show the tree view (can be combined with -s)\n"
          "-u --user[=USERNAME]            Show only processes for a given user (or $USER)\n"
          "-U --no-unicode                 Do not use unicode but plain ASCII\n"
-         "-V --version                    Print version info\n"
-         "\n"
+         "-V --version                    Print version info\n", name);
+   Platform_longOptionsUsage(name);
+   printf("\n"
          "Long options may be passed with a single dash.\n\n"
          "Press F1 inside %s for online help.\n"
-         "See 'man %s' for more information.\n",
-         name, name, name);
+         "See 'man %s' for more information.\n", name, name);
 }
 
 // ----------------------------------------

--- a/htop.c
+++ b/htop.c
@@ -1,6 +1,7 @@
 /*
 htop - htop.c
 (C) 2004-2011 Hisham H. Muhammad
+(C) 2020-2021 htop dev team
 Released under the GNU GPLv2, see the COPYING file
 in the source distribution for its full text.
 */
@@ -8,7 +9,6 @@ in the source distribution for its full text.
 #include "config.h" // IWYU pragma: keep
 
 #include <assert.h>
-#include <errno.h>
 #include <getopt.h>
 #include <locale.h>
 #include <stdbool.h>
@@ -35,37 +35,28 @@ in the source distribution for its full text.
 #include "UsersTable.h"
 #include "XUtils.h"
 
-#ifdef HAVE_LIBCAP
-#include <sys/capability.h>
+
+#ifndef PLATFORM_LONG_OPTIONS
+#define PLATFORM_LONG_OPTIONS
 #endif
 
-
-#ifdef HAVE_LIBCAP
-enum CapMode {
-   CAP_MODE_NONE,
-   CAP_MODE_BASIC,
-   CAP_MODE_STRICT
-};
+#ifndef PLATFORM_LONG_OPTIONS_USAGE
+#define PLATFORM_LONG_OPTIONS_USAGE
 #endif
 
-static void printVersionFlag(void) {
-   fputs(PACKAGE " " VERSION "\n", stdout);
+static void printVersionFlag(const char* name) {
+   fprintf(stdout, "%s " VERSION "\n", name);
 }
 
-static void printHelpFlag(void) {
-   fputs(PACKAGE " " VERSION "\n"
+static void printHelpFlag(const char* name) {
+   fprintf(stdout, "%s " VERSION "\n"
          COPYRIGHT "\n"
          "Released under the GNU GPLv2.\n\n"
          "-C --no-color                   Use a monochrome color scheme\n"
          "-d --delay=DELAY                Set the delay between updates, in tenths of seconds\n"
          "-F --filter=FILTER              Show only the commands matching the given filter\n"
          "-h --help                       Print this help screen\n"
-#ifdef HAVE_LIBCAP
-         "   --drop-capabilities[=none|basic|strict] Drop Linux capabilities when running as root\n"
-         "                                none - do not drop any capabilities\n"
-         "                                basic (default) - drop all capabilities not needed by htop\n"
-         "                                strict - drop all capabilities except those needed for core functionality\n"
-#endif
+         PLATFORM_LONG_OPTIONS_USAGE
          "-H --highlight-changes[=DELAY]  Highlight new and old processes\n"
          "-M --no-mouse                   Disable the mouse\n"
          "-p --pid=PID[,PID,PID...]       Show only the given PIDs\n"
@@ -76,9 +67,9 @@ static void printHelpFlag(void) {
          "-V --version                    Print version info\n"
          "\n"
          "Long options may be passed with a single dash.\n\n"
-         "Press F1 inside " PACKAGE " for online help.\n"
-         "See 'man " PACKAGE "' for more information.\n",
-         stdout);
+         "Press F1 inside %s for online help.\n"
+         "See 'man %s' for more information.\n",
+         name, name, name);
 }
 
 // ----------------------------------------
@@ -95,12 +86,9 @@ typedef struct CommandLineSettings_ {
    bool allowUnicode;
    bool highlightChanges;
    int highlightDelaySecs;
-#ifdef HAVE_LIBCAP
-   enum CapMode capabilitiesMode;
-#endif
 } CommandLineSettings;
 
-static CommandLineSettings parseArguments(int argc, char** argv) {
+static CommandLineSettings parseArguments(const char* program, int argc, char** argv) {
 
    CommandLineSettings flags = {
       .pidMatchList = NULL,
@@ -114,9 +102,6 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
       .allowUnicode = true,
       .highlightChanges = false,
       .highlightDelaySecs = -1,
-#ifdef HAVE_LIBCAP
-      .capabilitiesMode = CAP_MODE_BASIC,
-#endif
    };
 
    const struct option long_opts[] =
@@ -134,9 +119,7 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
       {"pid",        required_argument,   0, 'p'},
       {"filter",     required_argument,   0, 'F'},
       {"highlight-changes", optional_argument, 0, 'H'},
-#ifdef HAVE_LIBCAP
-      {"drop-capabilities", optional_argument, 0, 128},
-#endif
+      PLATFORM_LONG_OPTIONS
       {0,0,0,0}
    };
 
@@ -146,10 +129,10 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
       if (opt == EOF) break;
       switch (opt) {
          case 'h':
-            printHelpFlag();
+            printHelpFlag(program);
             exit(0);
          case 'V':
-            printVersionFlag();
+            printVersionFlag(program);
             exit(0);
          case 's':
             assert(optarg); /* please clang analyzer, cause optarg can be NULL in the 'u' case */
@@ -218,7 +201,7 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
             char* saveptr;
             const char* pid = strtok_r(argCopy, ",", &saveptr);
 
-            if(!flags.pidMatchList) {
+            if (!flags.pidMatchList) {
                flags.pidMatchList = Hashtable_new(8, false);
             }
 
@@ -255,29 +238,11 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
             flags.highlightChanges = true;
             break;
          }
-#ifdef HAVE_LIBCAP
-         case 128: {
-            const char* mode = optarg;
-            if (!mode && optind < argc && argv[optind] != NULL &&
-               (argv[optind][0] != '\0' && argv[optind][0] != '-')) {
-               mode = argv[optind++];
-            }
 
-            if (!mode || String_eq(mode, "basic")) {
-               flags.capabilitiesMode = CAP_MODE_BASIC;
-            } else if (String_eq(mode, "none")) {
-               flags.capabilitiesMode = CAP_MODE_NONE;
-            } else if (String_eq(mode, "strict")) {
-               flags.capabilitiesMode = CAP_MODE_STRICT;
-            } else {
-               fprintf(stderr, "Error: invalid capabilities mode \"%s\".\n", mode);
-               exit(1);
-            }
-            break;
-         }
-#endif
          default:
-            exit(1);
+           if (Platform_getLongOption(opt, argc, argv) == false)
+              exit(1);
+           break;
       }
    }
    return flags;
@@ -304,92 +269,6 @@ static void setCommFilter(State* state, char** commFilter) {
    *commFilter = NULL;
 }
 
-#ifdef HAVE_LIBCAP
-static int dropCapabilities(enum CapMode mode) {
-
-   if (mode == CAP_MODE_NONE)
-      return 0;
-
-   /* capabilities we keep to operate */
-   const cap_value_t keepcapsStrict[] = {
-      CAP_DAC_READ_SEARCH,
-      CAP_SYS_PTRACE,
-   };
-   const cap_value_t keepcapsBasic[] = {
-      CAP_DAC_READ_SEARCH,   /* read non world-readable process files of other users, like /proc/[pid]/io */
-      CAP_KILL,              /* send signals to processes of other users */
-      CAP_SYS_NICE,          /* lower process nice value / change nice value for arbitrary processes */
-      CAP_SYS_PTRACE,        /* read /proc/[pid]/exe */
-#ifdef HAVE_DELAYACCT
-      CAP_NET_ADMIN,         /* communicate over netlink socket for delay accounting */
-#endif
-   };
-   const cap_value_t* const keepcaps = (mode == CAP_MODE_BASIC) ? keepcapsBasic : keepcapsStrict;
-   const size_t ncap = (mode == CAP_MODE_BASIC) ? ARRAYSIZE(keepcapsBasic) : ARRAYSIZE(keepcapsStrict);
-
-   cap_t caps = cap_init();
-   if (caps == NULL) {
-      fprintf(stderr, "Error: can not initialize capabilities: %s\n", strerror(errno));
-      return -1;
-   }
-
-   if (cap_clear(caps) < 0) {
-      fprintf(stderr, "Error: can not clear capabilities: %s\n", strerror(errno));
-      cap_free(caps);
-      return -1;
-   }
-
-   cap_t currCaps = cap_get_proc();
-   if (currCaps == NULL) {
-      fprintf(stderr, "Error: can not get current process capabilities: %s\n", strerror(errno));
-      cap_free(caps);
-      return -1;
-   }
-
-   for (size_t i = 0; i < ncap; i++) {
-      if (!CAP_IS_SUPPORTED(keepcaps[i]))
-         continue;
-
-      cap_flag_value_t current;
-      if (cap_get_flag(currCaps, keepcaps[i], CAP_PERMITTED, &current) < 0) {
-         fprintf(stderr, "Error: can not get current value of capability %d: %s\n", keepcaps[i], strerror(errno));
-         cap_free(currCaps);
-         cap_free(caps);
-         return -1;
-      }
-
-      if (current != CAP_SET)
-         continue;
-
-      if (cap_set_flag(caps, CAP_PERMITTED, 1, &keepcaps[i], CAP_SET) < 0) {
-         fprintf(stderr, "Error: can not set permitted capability %d: %s\n", keepcaps[i], strerror(errno));
-         cap_free(currCaps);
-         cap_free(caps);
-         return -1;
-      }
-
-      if (cap_set_flag(caps, CAP_EFFECTIVE, 1, &keepcaps[i], CAP_SET) < 0) {
-         fprintf(stderr, "Error: can not set effective capability %d: %s\n", keepcaps[i], strerror(errno));
-         cap_free(currCaps);
-         cap_free(caps);
-         return -1;
-      }
-   }
-
-   if (cap_set_proc(caps) < 0) {
-      fprintf(stderr, "Error: can not set process capabilities: %s\n", strerror(errno));
-      cap_free(currCaps);
-      cap_free(caps);
-      return -1;
-   }
-
-   cap_free(currCaps);
-   cap_free(caps);
-
-   return 0;
-}
-#endif
-
 int main(int argc, char** argv) {
 
    /* initialize locale */
@@ -399,12 +278,7 @@ int main(int argc, char** argv) {
    else
       setlocale(LC_CTYPE, "");
 
-   CommandLineSettings flags = parseArguments(argc, argv);
-
-#ifdef HAVE_LIBCAP
-   if (dropCapabilities(flags.capabilitiesMode) < 0)
-      exit(1);
-#endif
+   CommandLineSettings flags = parseArguments(PACKAGE, argc, argv);
 
    Platform_init();
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -846,6 +846,20 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
    Platform_Battery_cacheTime = now;
 }
 
+void Platform_longOptionsUsage(const char* name)
+{
+#ifdef HAVE_LIBCAP
+   printf(
+"   --drop-capabilities[=none|basic|strict] Drop Linux capabilities when running as root\n"
+"                                none - do not drop any capabilities\n"
+"                                basic (default) - drop all capabilities not needed by %s\n"
+"                                strict - drop all capabilities except those needed for\n"
+"                                         core functionality\n", name);
+#else
+   (void) name;
+#endif
+}
+
 bool Platform_getLongOption(int opt, int argc, char** argv) {
 #ifndef HAVE_LIBCAP
    (void) argc;

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -12,6 +12,7 @@ in the source distribution for its full text.
 #include <assert.h>
 #include <ctype.h>
 #include <dirent.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
 #include <math.h>
@@ -61,10 +62,22 @@ in the source distribution for its full text.
 #include "zfs/ZfsArcStats.h"
 #include "zfs/ZfsCompressedArcMeter.h"
 
+#ifdef HAVE_LIBCAP
+#include <sys/capability.h>
+#endif
+
 #ifdef HAVE_SENSORS_SENSORS_H
 #include "LibSensors.h"
 #endif
 
+
+#ifdef HAVE_LIBCAP
+enum CapMode {
+   CAP_MODE_NONE,
+   CAP_MODE_BASIC,
+   CAP_MODE_STRICT
+};
+#endif
 
 const ProcessField Platform_defaultFields[] = { PID, USER, PRIORITY, NICE, M_VIRT, M_RESIDENT, M_SHARE, STATE, PERCENT_CPU, PERCENT_MEM, TIME, COMM, 0 };
 
@@ -112,22 +125,9 @@ static time_t Platform_Battery_cacheTime;
 static double Platform_Battery_cachePercent = NAN;
 static ACPresence Platform_Battery_cacheIsOnAC;
 
-void Platform_init(void) {
-   if (access(PROCDIR, R_OK) != 0) {
-      fprintf(stderr, "Error: could not read procfs (compiled to look in %s).\n", PROCDIR);
-      exit(1);
-   }
-
-#ifdef HAVE_SENSORS_SENSORS_H
-   LibSensors_init(NULL);
+#ifdef HAVE_LIBCAP
+static enum CapMode Platform_capabilitiesMode = CAP_MODE_BASIC;
 #endif
-}
-
-void Platform_done(void) {
-#ifdef HAVE_SENSORS_SENSORS_H
-   LibSensors_cleanup();
-#endif
-}
 
 static Htop_Reaction Platform_actionSetIOPriority(State* st) {
    const LinuxProcess* p = (const LinuxProcess*) Panel_getSelected((Panel*)st->mainPanel);
@@ -844,4 +844,147 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
    Platform_Battery_cachePercent = *percent;
    Platform_Battery_cacheIsOnAC = *isOnAC;
    Platform_Battery_cacheTime = now;
+}
+
+bool Platform_getLongOption(int opt, int argc, char** argv) {
+#ifndef HAVE_LIBCAP
+   (void) argc;
+   (void) argv;
+#endif
+
+   switch (opt) {
+#ifdef HAVE_LIBCAP
+      case 128: {
+         const char* mode = optarg;
+         if (!mode && optind < argc && argv[optind] != NULL &&
+            (argv[optind][0] != '\0' && argv[optind][0] != '-')) {
+            mode = argv[optind++];
+         }
+
+         if (!mode || String_eq(mode, "basic")) {
+            Platform_capabilitiesMode = CAP_MODE_BASIC;
+         } else if (String_eq(mode, "none")) {
+            Platform_capabilitiesMode = CAP_MODE_NONE;
+         } else if (String_eq(mode, "strict")) {
+            Platform_capabilitiesMode = CAP_MODE_STRICT;
+         } else {
+            fprintf(stderr, "Error: invalid capabilities mode \"%s\".\n", mode);
+            exit(1);
+         }
+         break;
+      }
+#endif
+
+      default:
+         break;
+   }
+   return false;
+}
+
+#ifdef HAVE_LIBCAP
+static int dropCapabilities(enum CapMode mode) {
+
+   if (mode == CAP_MODE_NONE)
+      return 0;
+
+   /* capabilities we keep to operate */
+   const cap_value_t keepcapsStrict[] = {
+      CAP_DAC_READ_SEARCH,
+      CAP_SYS_PTRACE,
+   };
+   const cap_value_t keepcapsBasic[] = {
+      CAP_DAC_READ_SEARCH,   /* read non world-readable process files of other users, like /proc/[pid]/io */
+      CAP_KILL,              /* send signals to processes of other users */
+      CAP_SYS_NICE,          /* lower process nice value / change nice value for arbitrary processes */
+      CAP_SYS_PTRACE,        /* read /proc/[pid]/exe */
+#ifdef HAVE_DELAYACCT
+      CAP_NET_ADMIN,         /* communicate over netlink socket for delay accounting */
+#endif
+   };
+   const cap_value_t* const keepcaps = (mode == CAP_MODE_BASIC) ? keepcapsBasic : keepcapsStrict;
+   const size_t ncap = (mode == CAP_MODE_BASIC) ? ARRAYSIZE(keepcapsBasic) : ARRAYSIZE(keepcapsStrict);
+
+   cap_t caps = cap_init();
+   if (caps == NULL) {
+      fprintf(stderr, "Error: can not initialize capabilities: %s\n", strerror(errno));
+      return -1;
+   }
+
+   if (cap_clear(caps) < 0) {
+      fprintf(stderr, "Error: can not clear capabilities: %s\n", strerror(errno));
+      cap_free(caps);
+      return -1;
+   }
+
+   cap_t currCaps = cap_get_proc();
+   if (currCaps == NULL) {
+      fprintf(stderr, "Error: can not get current process capabilities: %s\n", strerror(errno));
+      cap_free(caps);
+      return -1;
+   }
+
+   for (size_t i = 0; i < ncap; i++) {
+      if (!CAP_IS_SUPPORTED(keepcaps[i]))
+         continue;
+
+      cap_flag_value_t current;
+      if (cap_get_flag(currCaps, keepcaps[i], CAP_PERMITTED, &current) < 0) {
+         fprintf(stderr, "Error: can not get current value of capability %d: %s\n", keepcaps[i], strerror(errno));
+         cap_free(currCaps);
+         cap_free(caps);
+         return -1;
+      }
+
+      if (current != CAP_SET)
+         continue;
+
+      if (cap_set_flag(caps, CAP_PERMITTED, 1, &keepcaps[i], CAP_SET) < 0) {
+         fprintf(stderr, "Error: can not set permitted capability %d: %s\n", keepcaps[i], strerror(errno));
+         cap_free(currCaps);
+         cap_free(caps);
+         return -1;
+      }
+
+      if (cap_set_flag(caps, CAP_EFFECTIVE, 1, &keepcaps[i], CAP_SET) < 0) {
+         fprintf(stderr, "Error: can not set effective capability %d: %s\n", keepcaps[i], strerror(errno));
+         cap_free(currCaps);
+         cap_free(caps);
+         return -1;
+      }
+   }
+
+   if (cap_set_proc(caps) < 0) {
+      fprintf(stderr, "Error: can not set process capabilities: %s\n", strerror(errno));
+      cap_free(currCaps);
+      cap_free(caps);
+      return -1;
+   }
+
+   cap_free(currCaps);
+   cap_free(caps);
+
+   return 0;
+}
+#endif
+
+void Platform_init(void) {
+#ifdef HAVE_LIBCAP
+   if (dropCapabilities(Platform_capabilitiesMode) < 0)
+      exit(1);
+#endif
+
+   if (access(PROCDIR, R_OK) != 0) {
+      fprintf(stderr, "Error: could not read procfs (compiled to look in %s).\n", PROCDIR);
+      exit(1);
+   }
+
+#ifdef HAVE_SENSORS_SENSORS_H
+   LibSensors_init(NULL);
+#endif
+}
+
+void Platform_done(void) {
+#ifdef HAVE_SENSORS_SENSORS_H
+   LibSensors_cleanup();
+#endif
 }

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -27,6 +27,19 @@ in the source distribution for its full text.
    #define PATH_MAX 4096
 #endif
 
+#ifdef HAVE_LIBCAP
+   #define PLATFORM_LONG_OPTIONS \
+      {"drop-capabilities", optional_argument, 0, 128},
+   #define PLATFORM_LONG_OPTIONS_USAGE \
+         "   --drop-capabilities[=none|basic|strict] Drop Linux capabilities when running as root\n" \
+         "                                none - do not drop any capabilities\n" \
+         "                                basic (default) - drop all capabilities not needed by htop\n" \
+         "                                strict - drop all capabilities except those needed for core functionality\n"
+#else
+   #define PLATFORM_LONG_OPTIONS
+   #define PLATFORM_LONG_OPTIONS_USAGE
+#endif
+
 
 extern const ProcessField Platform_defaultFields[];
 
@@ -81,5 +94,7 @@ static inline void Platform_getHostname(char* buffer, size_t size) {
 static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
+
+bool Platform_getLongOption(int opt, int argc, char** argv);
 
 #endif

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -27,19 +27,6 @@ in the source distribution for its full text.
    #define PATH_MAX 4096
 #endif
 
-#ifdef HAVE_LIBCAP
-   #define PLATFORM_LONG_OPTIONS \
-      {"drop-capabilities", optional_argument, 0, 128},
-   #define PLATFORM_LONG_OPTIONS_USAGE \
-         "   --drop-capabilities[=none|basic|strict] Drop Linux capabilities when running as root\n" \
-         "                                none - do not drop any capabilities\n" \
-         "                                basic (default) - drop all capabilities not needed by htop\n" \
-         "                                strict - drop all capabilities except those needed for core functionality\n"
-#else
-   #define PLATFORM_LONG_OPTIONS
-   #define PLATFORM_LONG_OPTIONS_USAGE
-#endif
-
 
 extern const ProcessField Platform_defaultFields[];
 
@@ -94,6 +81,15 @@ static inline void Platform_getHostname(char* buffer, size_t size) {
 static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
+
+#ifdef HAVE_LIBCAP
+   #define PLATFORM_LONG_OPTIONS \
+      {"drop-capabilities", optional_argument, 0, 128},
+#else
+   #define PLATFORM_LONG_OPTIONS
+#endif
+
+void Platform_longOptionsUsage(const char* name);
 
 bool Platform_getLongOption(int opt, int argc, char** argv);
 

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -70,4 +70,8 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
+static bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
+   return false;
+}
+
 #endif

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -23,9 +23,6 @@ in the source distribution for its full text.
 #include "generic/uname.h"
 
 
-#define PLATFORM_LONG_OPTIONS
-#define PLATFORM_LONG_OPTIONS_USAGE
-
 extern const ProcessField Platform_defaultFields[];
 
 /* see /usr/include/sys/signal.h */
@@ -72,6 +69,10 @@ static inline void Platform_getHostname(char* buffer, size_t size) {
 static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
+
+#define PLATFORM_LONG_OPTIONS
+
+static inline void Platform_longOptionsUsage(ATTR_UNUSED const char* name) { }
 
 static inline bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
    return false;

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -23,6 +23,9 @@ in the source distribution for its full text.
 #include "generic/uname.h"
 
 
+#define PLATFORM_LONG_OPTIONS
+#define PLATFORM_LONG_OPTIONS_USAGE
+
 extern const ProcessField Platform_defaultFields[];
 
 /* see /usr/include/sys/signal.h */
@@ -70,7 +73,7 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
-static bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
+static inline bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
    return false;
 }
 

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -89,4 +89,8 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
+static bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
+   return false;
+}
+
 #endif

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -26,9 +26,6 @@ in the source distribution for its full text.
 #include "generic/uname.h"
 
 
-#define PLATFORM_LONG_OPTIONS
-#define PLATFORM_LONG_OPTIONS_USAGE
-
 #define  kill(pid, signal) kill(pid / 1024, signal)
 
 typedef struct var kvar_t;
@@ -91,6 +88,10 @@ static inline void Platform_getHostname(char* buffer, size_t size) {
 static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
+
+#define PLATFORM_LONG_OPTIONS
+
+static inline void Platform_longOptionsUsage(ATTR_UNUSED const char* name) { }
 
 static inline bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
    return false;

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -26,6 +26,9 @@ in the source distribution for its full text.
 #include "generic/uname.h"
 
 
+#define PLATFORM_LONG_OPTIONS
+#define PLATFORM_LONG_OPTIONS_USAGE
+
 #define  kill(pid, signal) kill(pid / 1024, signal)
 
 typedef struct var kvar_t;
@@ -89,7 +92,7 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
-static bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
+static inline bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
    return false;
 }
 

--- a/unsupported/Platform.h
+++ b/unsupported/Platform.h
@@ -61,4 +61,8 @@ void Platform_getHostname(char* buffer, size_t size);
 
 void Platform_getRelease(char** string);
 
+static bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
+   return false;
+}
+
 #endif

--- a/unsupported/Platform.h
+++ b/unsupported/Platform.h
@@ -17,6 +17,9 @@ in the source distribution for its full text.
 #include "UnsupportedProcess.h"
 
 
+#define PLATFORM_LONG_OPTIONS
+#define PLATFORM_LONG_OPTIONS_USAGE
+
 extern const SignalItem Platform_signals[];
 
 extern const unsigned int Platform_numberOfSignals;
@@ -61,7 +64,7 @@ void Platform_getHostname(char* buffer, size_t size);
 
 void Platform_getRelease(char** string);
 
-static bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
+static inline bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
    return false;
 }
 

--- a/unsupported/Platform.h
+++ b/unsupported/Platform.h
@@ -17,9 +17,6 @@ in the source distribution for its full text.
 #include "UnsupportedProcess.h"
 
 
-#define PLATFORM_LONG_OPTIONS
-#define PLATFORM_LONG_OPTIONS_USAGE
-
 extern const SignalItem Platform_signals[];
 
 extern const unsigned int Platform_numberOfSignals;
@@ -63,6 +60,10 @@ void Platform_getBattery(double *percent, ACPresence *isOnAC);
 void Platform_getHostname(char* buffer, size_t size);
 
 void Platform_getRelease(char** string);
+
+#define PLATFORM_LONG_OPTIONS
+
+static inline void Platform_longOptionsUsage(ATTR_UNUSED const char* name) { }
 
 static inline bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
    return false;


### PR DESCRIPTION
The libcap code is Linux-specific so move it all below
the linux/ platform subdirectory.  As this feature has
custom command-line long options I provide a mechanism
whereby each platform can add custom long options that
augment the main htop options.  We'll make use this of
this with the pcp/ platform in due course to implement
the --host and --archive options there.

Related to https://github.com/htop-dev/htop/pull/536