### PR TITLE
MemoryMeter: show shared memory before cached

### DIFF
--- a/MemoryMeter.c
+++ b/MemoryMeter.c
@@ -18,8 +18,8 @@ in the source distribution for its full text.
 static const int MemoryMeter_attributes[] = {
    MEMORY_USED,
    MEMORY_BUFFERS,
-   MEMORY_CACHE,
-   MEMORY_SHARED
+   MEMORY_SHARED,
+   MEMORY_CACHE
 };
 
 static void MemoryMeter_updateValues(Meter* this) {
@@ -28,7 +28,7 @@ static void MemoryMeter_updateValues(Meter* this) {
    int written;
 
    /* shared and available memory are not supported on all platforms */
-   this->values[3] = NAN;
+   this->values[2] = NAN;
    this->values[4] = NAN;
    Platform_setMemoryValues(this);
 
@@ -59,16 +59,16 @@ static void MemoryMeter_display(const Object* cast, RichString* out) {
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " buffers:");
    RichString_appendAscii(out, CRT_colors[MEMORY_BUFFERS_TEXT], buffer);
 
-   Meter_humanUnit(buffer, this->values[2], sizeof(buffer));
-   RichString_appendAscii(out, CRT_colors[METER_TEXT], " cache:");
-   RichString_appendAscii(out, CRT_colors[MEMORY_CACHE], buffer);
-
    /* shared memory is not supported on all platforms */
-   if (!isnan(this->values[3])) {
-      Meter_humanUnit(buffer, this->values[3], sizeof(buffer));
+   if (!isnan(this->values[2])) {
+      Meter_humanUnit(buffer, this->values[2], sizeof(buffer));
       RichString_appendAscii(out, CRT_colors[METER_TEXT], " shared:");
       RichString_appendAscii(out, CRT_colors[MEMORY_SHARED], buffer);
    }
+
+   Meter_humanUnit(buffer, this->values[3], sizeof(buffer));
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " cache:");
+   RichString_appendAscii(out, CRT_colors[MEMORY_CACHE], buffer);
 
    /* available memory is not supported on all platforms */
    if (!isnan(this->values[4])) {

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -241,7 +241,9 @@ void Platform_setMemoryValues(Meter* mtr) {
    mtr->total = dpl->host_info.max_mem / 1024;
    mtr->values[0] = (double)(vm->active_count + vm->wire_count) * page_K;
    mtr->values[1] = (double)vm->purgeable_count * page_K;
-   mtr->values[2] = (double)vm->inactive_count * page_K;
+   // mtr->values[2] = "shared memory, like tmpfs and shm"
+   mtr->values[3] = (double)vm->inactive_count * page_K;
+   // mtr->values[4] = "available memory"
 }
 
 void Platform_setSwapValues(Meter* mtr) {

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -200,7 +200,9 @@ void Platform_setMemoryValues(Meter* this) {
    this->total = pl->totalMem;
    this->values[0] = pl->usedMem;
    this->values[1] = pl->buffersMem;
-   this->values[2] = pl->cachedMem;
+   // this->values[2] = "shared memory, like tmpfs and shm"
+   this->values[3] = pl->cachedMem;
+   // this->values[4] = "available memory"
 }
 
 void Platform_setSwapValues(Meter* this) {

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -221,7 +221,9 @@ void Platform_setMemoryValues(Meter* this) {
    this->total = pl->totalMem;
    this->values[0] = pl->usedMem;
    this->values[1] = pl->buffersMem;
-   this->values[2] = pl->cachedMem;
+   // this->values[2] = "shared memory, like tmpfs and shm"
+   this->values[3] = pl->cachedMem;
+   // this->values[4] = "available memory"
 }
 
 void Platform_setSwapValues(Meter* this) {

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -286,13 +286,13 @@ void Platform_setMemoryValues(Meter* this) {
    this->total     = pl->totalMem > lpl->totalHugePageMem ? pl->totalMem - lpl->totalHugePageMem : pl->totalMem;
    this->values[0] = pl->usedMem > lpl->totalHugePageMem ? pl->usedMem - lpl->totalHugePageMem : pl->usedMem;
    this->values[1] = pl->buffersMem;
-   this->values[2] = pl->cachedMem;
-   this->values[3] = pl->sharedMem;
+   this->values[2] = pl->sharedMem;
+   this->values[3] = pl->cachedMem;
    this->values[4] = pl->availableMem;
 
    if (lpl->zfs.enabled != 0) {
       this->values[0] -= lpl->zfs.size;
-      this->values[2] += lpl->zfs.size;
+      this->values[3] += lpl->zfs.size;
    }
 }
 

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -208,7 +208,9 @@ void Platform_setMemoryValues(Meter* this) {
    this->total = pl->totalMem;
    this->values[0] = usedMem;
    this->values[1] = buffersMem;
-   this->values[2] = cachedMem;
+   // this->values[2] = "shared memory, like tmpfs and shm"
+   this->values[3] = cachedMem;
+   // this->values[4] = "available memory"
 }
 
 void Platform_setSwapValues(Meter* this) {

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -218,7 +218,9 @@ void Platform_setMemoryValues(Meter* this) {
    this->total = pl->totalMem;
    this->values[0] = pl->usedMem;
    this->values[1] = pl->buffersMem;
-   this->values[2] = pl->cachedMem;
+   // this->values[2] = "shared memory, like tmpfs and shm"
+   this->values[3] = pl->cachedMem;
+   // this->values[4] = "available memory"
 }
 
 void Platform_setSwapValues(Meter* this) {


### PR DESCRIPTION
Shared memory is less free-able than cached memory.

Show it beforehand.

Follow up of: #558