### PR TITLE
Openbsd Update

### DIFF
--- a/ProcessList.c
+++ b/ProcessList.c
@@ -311,6 +311,11 @@ static void ProcessList_updateTreeSet(ProcessList* this) {
 }
 
 static void ProcessList_buildTreeBranch(ProcessList* this, pid_t pid, int level, int indent, int direction, bool show, int* node_counter, int* node_index) {
+   // On OpenBSD the kernel thread 'swapper' has pid 0.
+   // Do not treat it as root of any tree.
+   if (pid == 0)
+      return;
+
    Vector* children = Vector_new(Class(Process), false, DEFAULT_SIZE);
 
    for (int i = Vector_size(this->processes) - 1; i >= 0; i--) {

--- a/ProcessList.h
+++ b/ProcessList.h
@@ -115,4 +115,8 @@ Process* ProcessList_getProcess(ProcessList* this, pid_t pid, bool* preExisting,
 
 void ProcessList_scan(ProcessList* this, bool pauseProcessUpdate);
 
+static inline Process* ProcessList_findProcess(ProcessList* this, pid_t pid) {
+   return (Process*) Hashtable_get(this->processTable, pid);
+}
+
 #endif

--- a/openbsd/OpenBSDProcess.h
+++ b/openbsd/OpenBSDProcess.h
@@ -17,11 +17,18 @@ in the source distribution for its full text.
 
 typedef struct OpenBSDProcess_ {
    Process super;
+
+   /* 'Kernel virtual addr of u-area' to detect main threads */
+   uint64_t addr;
 } OpenBSDProcess;
 
-#define Process_isKernelThread(_process) (_process->pgrp == 0)
+static inline bool Process_isKernelThread(const Process* this) {
+   return this->pgrp == 0;
+}
 
-#define Process_isUserlandThread(_process) (_process->pid != _process->tgid)
+static inline bool Process_isUserlandThread(const Process* this) {
+   return this->pid != this->tgid;
+}
 
 extern const ProcessClass OpenBSDProcess_class;
 

--- a/openbsd/OpenBSDProcessList.h
+++ b/openbsd/OpenBSDProcessList.h
@@ -42,6 +42,7 @@ typedef struct OpenBSDProcessList_ {
    kvm_t* kd;
 
    CPUData* cpus;
+   int cpuSpeed;
 
 } OpenBSDProcessList;
 

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -15,6 +15,8 @@ in the source distribution for its full text.
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <sys/signal.h>  // needs to be included before <sys/proc.h> for 'struct sigaltstack'
+#include <sys/proc.h>
 #include <sys/resource.h>
 #include <sys/sensors.h>
 #include <sys/sysctl.h>
@@ -162,8 +164,7 @@ void Platform_getLoadAverage(double* one, double* five, double* fifteen) {
 }
 
 int Platform_getMaxPid() {
-   // this is hard-coded in sys/proc.h - no sysctl exists
-   return 99999;
+   return 2 * THREAD_PID_OFFSET;
 }
 
 double Platform_setCPUValues(Meter* this, int cpu) {
@@ -195,6 +196,8 @@ double Platform_setCPUValues(Meter* this, int cpu) {
    totalPercent = CLAMP(totalPercent, 0.0, 100.0);
 
    v[CPU_METER_TEMPERATURE] = NAN;
+
+   v[CPU_METER_FREQUENCY] = (pl->cpuSpeed != -1) ? pl->cpuSpeed : NAN;
 
    return totalPercent;
 }


### PR DESCRIPTION
* ProcessList: fix treeview on OpenBSD when hiding kernel threads

  Currently the tree-view is empty on OpenBSD when kernel threads are
  hidden, cause the kernel thread 'swapper' has pid 0 and gets treated as
  root of the tree and parent of 'init'.

* Set process data for:
    - minflt
    - majflt
    - processor
    - nlwp

* Drop unimplemented nlwp column

* Scan userland threads

* Mark a 'Thread is currently on a CPU.' with 'R', and processes
  'Currently runnable' with 'P', do confine with man:ps(1) and Linux.
  See https://man.openbsd.org/ps.1

* Show CPU frequency