### PR TITLE
Use `#if defined()` syntax when `#elif` is present

### DIFF
--- a/Affinity.c
+++ b/Affinity.c
@@ -14,7 +14,7 @@ in the source distribution for its full text.
 
 #include "XUtils.h"
 
-#ifdef HAVE_LIBHWLOC
+#if defined(HAVE_LIBHWLOC)
 #include <hwloc.h>
 #include <hwloc/bitmap.h>
 #ifdef __linux__
@@ -50,7 +50,7 @@ void Affinity_add(Affinity* this, int id) {
 }
 
 
-#ifdef HAVE_LIBHWLOC
+#if defined(HAVE_LIBHWLOC)
 
 Affinity* Affinity_get(const Process* proc, ProcessList* pl) {
    hwloc_cpuset_t cpuset = hwloc_bitmap_alloc();

--- a/CRT.c
+++ b/CRT.c
@@ -669,7 +669,7 @@ static int stderrRedirectNewFd = -1;
 static int stderrRedirectBackupFd = -1;
 
 static int createStderrCacheFile(void) {
-#ifdef HAVE_MEMFD_CREATE
+#if defined(HAVE_MEMFD_CREATE)
    return memfd_create("htop.stderr-redirect", 0);
 #elif defined(O_TMPFILE)
    return open("/tmp", O_TMPFILE | O_CREAT | O_EXCL | O_RDWR, S_IRUSR | S_IWUSR);

--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -120,7 +120,7 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    Panel_add(super, (Object*) CheckItem_newByRef("Also show CPU frequency", &(settings->showCPUFrequency)));
    #ifdef BUILD_WITH_CPU_TEMP
    Panel_add(super, (Object*) CheckItem_newByRef(
-   #ifdef HTOP_LINUX
+   #if defined(HTOP_LINUX)
                                                  "Also show CPU temperature (requires libsensors)",
    #elif defined(HTOP_FREEBSD)
                                                  "Also show CPU temperature",

--- a/Macros.h
+++ b/Macros.h
@@ -52,7 +52,7 @@
 // ignore casts discarding const specifier, e.g.
 //     const char []     ->  char * / void *
 //     const char *[2]'  ->  char *const *
-#ifdef __clang__
+#if defined(__clang__)
 #define IGNORE_WCASTQUAL_BEGIN  _Pragma("clang diagnostic push") \
                                 _Pragma("clang diagnostic ignored \"-Wcast-qual\"")
 #define IGNORE_WCASTQUAL_END    _Pragma("clang diagnostic pop")

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -48,7 +48,7 @@ in the source distribution for its full text.
 #include "Settings.h"
 #include "XUtils.h"
 
-#ifdef MAJOR_IN_MKDEV
+#if defined(MAJOR_IN_MKDEV)
 #include <sys/mkdev.h>
 #elif defined(MAJOR_IN_SYSMACROS)
 #include <sys/sysmacros.h>


### PR DESCRIPTION
This prefers the `#if defined()` syntax over the `#ifdef` variant whenever there's also a `#elif defined()` clause, thus making the multiple branching structure more obvious and the overall use more consistent.