### PR TITLE
Rework TTY column

### DIFF
--- a/Compat.c
+++ b/Compat.c
@@ -43,7 +43,7 @@ int Compat_faccessat(int dirfd,
 #endif
 
    // Error out on unsupported configurations
-   if (dirfd != AT_FDCWD || mode != F_OK) {
+   if (dirfd != (int)AT_FDCWD || mode != F_OK) {
       errno = EINVAL;
       return -1;
    }

--- a/Macros.h
+++ b/Macros.h
@@ -4,27 +4,31 @@
 #include <assert.h> // IWYU pragma: keep
 
 #ifndef MINIMUM
-#define MINIMUM(a, b)             ((a) < (b) ? (a) : (b))
+#define MINIMUM(a, b)                  ((a) < (b) ? (a) : (b))
 #endif
 
 #ifndef MAXIMUM
-#define MAXIMUM(a, b)             ((a) > (b) ? (a) : (b))
+#define MAXIMUM(a, b)                  ((a) > (b) ? (a) : (b))
 #endif
 
 #ifndef CLAMP
-#define CLAMP(x, low, high)       (assert((low) <= (high)), ((x) > (high)) ? (high) : MAXIMUM(x, low))
+#define CLAMP(x, low, high)            (assert((low) <= (high)), ((x) > (high)) ? (high) : MAXIMUM(x, low))
 #endif
 
 #ifndef ARRAYSIZE
-#define ARRAYSIZE(x)              (sizeof(x) / sizeof((x)[0]))
+#define ARRAYSIZE(x)                   (sizeof(x) / sizeof((x)[0]))
 #endif
 
 #ifndef SPACESHIP_NUMBER
-#define SPACESHIP_NUMBER(a, b)    (((a) > (b)) - ((a) < (b)))
+#define SPACESHIP_NUMBER(a, b)         (((a) > (b)) - ((a) < (b)))
 #endif
 
 #ifndef SPACESHIP_NULLSTR
-#define SPACESHIP_NULLSTR(a, b)   strcmp((a) ? (a) : "", (b) ? (b) : "")
+#define SPACESHIP_NULLSTR(a, b)        strcmp((a) ? (a) : "", (b) ? (b) : "")
+#endif
+
+#ifndef SPACESHIP_DEFAULTSTR
+#define SPACESHIP_DEFAULTSTR(a, b, s)  strcmp((a) ? (a) : (s), (b) ? (b) : (s))
 #endif
 
 #ifdef  __GNUC__  // defined by GCC and Clang

--- a/Process.c
+++ b/Process.c
@@ -374,17 +374,15 @@ void Process_writeField(const Process* this, RichString* str, ProcessField field
       xSnprintf(buffer, n, "%*d ", Process_pidDigits, this->tgid);
       break;
    case TPGID: xSnprintf(buffer, n, "%*d ", Process_pidDigits, this->tpgid); break;
-   case TTY_NR: {
-      unsigned int major = major(this->tty_nr);
-      unsigned int minor = minor(this->tty_nr);
-      if (major == 0 && minor == 0) {
+   case TTY:
+      if (!this->tty_name) {
          attr = CRT_colors[PROCESS_SHADOW];
-         xSnprintf(buffer, n, "(none)   ");
+         xSnprintf(buffer, n, "(no tty) ");
       } else {
-         xSnprintf(buffer, n, "%3u:%3u  ", major, minor);
+         const char* name = String_startsWith(this->tty_name, "/dev/") ? (this->tty_name + strlen("/dev/")) : this->tty_name;
+         xSnprintf(buffer, n, "%-8s ", name);
       }
       break;
-   }
    case USER:
       if (Process_getuid != this->st_uid)
          attr = CRT_colors[PROCESS_SHADOW];
@@ -431,6 +429,7 @@ void Process_display(const Object* cast, RichString* out) {
 void Process_done(Process* this) {
    assert (this != NULL);
    free(this->comm);
+   free(this->tty_name);
 }
 
 static const char* Process_getCommandStr(const Process* p) {
@@ -605,8 +604,9 @@ int Process_compareByKey_Base(const Process* p1, const Process* p2, ProcessField
       return SPACESHIP_NUMBER(p1->tgid, p2->tgid);
    case TPGID:
       return SPACESHIP_NUMBER(p1->tpgid, p2->tpgid);
-   case TTY_NR:
-      return SPACESHIP_NUMBER(p1->tty_nr, p2->tty_nr);
+   case TTY:
+      /* Order no tty last */
+      return SPACESHIP_DEFAULTSTR(p1->tty_name, p2->tty_name, "\x7F");
    case USER:
       return SPACESHIP_NULLSTR(p1->user, p2->user);
    default:

--- a/Process.h
+++ b/Process.h
@@ -28,7 +28,7 @@ typedef enum ProcessField_ {
    PPID = 4,
    PGRP = 5,
    SESSION = 6,
-   TTY_NR = 7,
+   TTY = 7,
    TPGID = 8,
    MINFLT = 10,
    MAJFLT = 12,
@@ -84,11 +84,11 @@ typedef struct Process_ {
    /* Foreground group identifier of the controlling terminal */
    int tpgid;
 
-   /*
-    * Controlling terminal of the process.
-    * The minor device number is contained in the combination of bits 31 to 20 and 7 to 0; the major device number is in bits 15 to 8.
-    * */
-   unsigned int tty_nr;
+   /* Controlling terminal identifier of the process */
+   unsigned long int tty_nr;
+
+   /* Controlling terminal name of the process */
+   char* tty_name;
 
    /* User identifier */
    uid_t st_uid;

--- a/dragonflybsd/DragonFlyBSDProcess.c
+++ b/dragonflybsd/DragonFlyBSDProcess.c
@@ -26,7 +26,7 @@ const ProcessFieldData Process_fields[LAST_PROCESSFIELD] = {
    [PPID] = { .name = "PPID", .title = "PPID", .description = "Parent process ID", .flags = 0, .pidColumn = true, },
    [PGRP] = { .name = "PGRP", .title = "PGRP", .description = "Process group ID", .flags = 0, .pidColumn = true, },
    [SESSION] = { .name = "SESSION", .title = "SID", .description = "Process's session ID", .flags = 0, .pidColumn = true, },
-   [TTY_NR] = { .name = "TTY_NR", .title = "    TTY ", .description = "Controlling terminal", .flags = 0, },
+   [TTY] = { .name = "TTY", .title = "TTY     ", .description = "Controlling terminal", .flags = 0, },
    [TPGID] = { .name = "TPGID", .title = "TPGID", .description = "Process ID of the fg process group of the controlling terminal", .flags = 0, .pidColumn = true, },
    [MINFLT] = { .name = "MINFLT", .title = "     MINFLT ", .description = "Number of minor faults which have not required loading a memory page from disk", .flags = 0, .defaultSortDesc = true, },
    [MAJFLT] = { .name = "MAJFLT", .title = "     MAJFLT ", .description = "Number of major faults which have required loading a memory page from disk", .flags = 0, .defaultSortDesc = true, },

--- a/dragonflybsd/DragonFlyBSDProcessList.c
+++ b/dragonflybsd/DragonFlyBSDProcessList.c
@@ -396,11 +396,19 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
          proc->tgid = kproc->kp_pid;		// thread group id
          proc->pgrp = kproc->kp_pgid;		// process group id
          proc->session = kproc->kp_sid;
-         proc->tty_nr = kproc->kp_tdev;		// control terminal device number
          proc->st_uid = kproc->kp_uid;		// user ID
          proc->processor = kproc->kp_lwp.kl_origcpu;
          proc->starttime_ctime = kproc->kp_start.tv_sec;
          proc->user = UsersTable_getRef(super->usersTable, proc->st_uid);
+
+         proc->tty_nr = kproc->kp_tdev; // control terminal device number
+         const char* name = (kproc->kp_tdev != NODEV) ? devname(kproc->kp_tdev, S_IFCHR) : NULL;
+         if (!name) {
+            free(proc->tty_name);
+            proc->tty_name = NULL;
+         } else {
+            free_and_xStrdup(&proc->tty_name, name);
+         }
 
          ProcessList_add(super, proc);
          proc->comm = DragonFlyBSDProcessList_readProcessName(dfpl->kd, kproc, &proc->basenameOffset);

--- a/freebsd/FreeBSDProcess.c
+++ b/freebsd/FreeBSDProcess.c
@@ -26,7 +26,7 @@ const ProcessFieldData Process_fields[LAST_PROCESSFIELD] = {
    [PPID] = { .name = "PPID", .title = "PPID", .description = "Parent process ID", .flags = 0, .pidColumn = true, },
    [PGRP] = { .name = "PGRP", .title = "PGRP", .description = "Process group ID", .flags = 0, .pidColumn = true, },
    [SESSION] = { .name = "SESSION", .title = "SID", .description = "Process's session ID", .flags = 0, .pidColumn = true, },
-   [TTY_NR] = { .name = "TTY_NR", .title = "    TTY ", .description = "Controlling terminal", .flags = PROCESS_FLAG_FREEBSD_TTY, },
+   [TTY] = { .name = "TTY", .title = "TTY      ", .description = "Controlling terminal", .flags = 0, },
    [TPGID] = { .name = "TPGID", .title = "TPGID", .description = "Process ID of the fg process group of the controlling terminal", .flags = 0, .pidColumn = true, },
    [MAJFLT] = { .name = "MAJFLT", .title = "     MAJFLT ", .description = "Number of copy-on-write faults", .flags = 0, .defaultSortDesc = true, },
    [PRIORITY] = { .name = "PRIORITY", .title = "PRI ", .description = "Kernel's internal priority for the process", .flags = 0, },
@@ -74,16 +74,6 @@ static void FreeBSDProcess_writeField(const Process* this, RichString* str, Proc
    case JAIL:
       Process_printLeftAlignedField(str, attr, fp->jname ? fp->jname : "N/A", 11);
       return;
-   case TTY_NR:
-      if (fp->ttyPath) {
-         if (fp->ttyPath == nodevStr)
-            attr = CRT_colors[PROCESS_SHADOW];
-         xSnprintf(buffer, n, "%-8s", fp->ttyPath);
-      } else {
-         attr = CRT_colors[PROCESS_SHADOW];
-         xSnprintf(buffer, n, "?        ");
-      }
-      break;
    default:
       Process_writeField(this, str, field);
       return;
@@ -101,8 +91,6 @@ static int FreeBSDProcess_compareByKey(const Process* v1, const Process* v2, Pro
       return SPACESHIP_NUMBER(p1->jid, p2->jid);
    case JAIL:
       return SPACESHIP_NULLSTR(p1->jname, p2->jname);
-   case TTY_NR:
-      return SPACESHIP_NULLSTR(p1->ttyPath, p2->ttyPath);
    default:
       return Process_compareByKey_Base(v1, v2, key);
    }

--- a/freebsd/FreeBSDProcess.h
+++ b/freebsd/FreeBSDProcess.h
@@ -14,16 +14,11 @@ in the source distribution for its full text.
 #include "Settings.h"
 
 
-#define PROCESS_FLAG_FREEBSD_TTY   0x0100
-
-extern const char* const nodevStr;
-
 typedef struct FreeBSDProcess_ {
    Process super;
    bool  isKernelThread;
    int   jid;
    char* jname;
-   const char* ttyPath;
 } FreeBSDProcess;
 
 static inline bool Process_isKernelThread(const Process* this) {

--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -249,7 +249,7 @@ static inline void FreeBSDProcessList_scanCPU(ProcessList* pl) {
       cpuData->temperature = NAN;
       cpuData->frequency = NAN;
 
-      const int coreId = (cpus == 1) ? 0 : (i - 1);
+      const int coreId = (cpus == 1) ? 0 : ((int)i - 1);
       if (coreId < 0)
          continue;
 

--- a/freebsd/FreeBSDProcessList.h
+++ b/freebsd/FreeBSDProcessList.h
@@ -39,8 +39,6 @@ typedef struct FreeBSDProcessList_ {
 
    CPUData* cpus;
 
-   Hashtable* ttys;
-
    unsigned long* cp_time_o;
    unsigned long* cp_time_n;
 

--- a/htop.1.in
+++ b/htop.1.in
@@ -285,7 +285,7 @@ The process's group ID.
 .B SESSION (SID)
 The process's session ID.
 .TP
-.B TTY_NR (TTY)
+.B TTY
 The controlling terminal of the process.
 .TP
 .B TPGID

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -38,7 +38,7 @@ const ProcessFieldData Process_fields[LAST_PROCESSFIELD] = {
    [PPID] = { .name = "PPID", .title = "PPID", .description = "Parent process ID", .flags = 0, .pidColumn = true, },
    [PGRP] = { .name = "PGRP", .title = "PGRP", .description = "Process group ID", .flags = 0, .pidColumn = true, },
    [SESSION] = { .name = "SESSION", .title = "SID", .description = "Process's session ID", .flags = 0, .pidColumn = true, },
-   [TTY_NR] = { .name = "TTY_NR", .title = "TTY      ", .description = "Controlling terminal", .flags = 0, },
+   [TTY] = { .name = "TTY", .title = "TTY      ", .description = "Controlling terminal", .flags = 0, },
    [TPGID] = { .name = "TPGID", .title = "TPGID", .description = "Process ID of the fg process group of the controlling terminal", .flags = 0, .pidColumn = true, },
    [MINFLT] = { .name = "MINFLT", .title = "     MINFLT ", .description = "Number of minor faults which have not required loading a memory page from disk", .flags = 0, .defaultSortDesc = true, },
    [CMINFLT] = { .name = "CMINFLT", .title = "    CMINFLT ", .description = "Children processes' minor faults", .flags = 0, .defaultSortDesc = true, },
@@ -129,7 +129,6 @@ void Process_delete(Object* cast) {
 #endif
    free(this->cwd);
    free(this->secattr);
-   free(this->ttyDevice);
    free(this->procExe);
    free(this->procComm);
    free(this->mergedCommand.str);
@@ -610,14 +609,6 @@ static void LinuxProcess_writeField(const Process* this, RichString* str, Proces
    int attr = CRT_colors[DEFAULT_COLOR];
    size_t n = sizeof(buffer) - 1;
    switch (field) {
-   case TTY_NR:
-      if (lp->ttyDevice) {
-         xSnprintf(buffer, n, "%-8s ", lp->ttyDevice + 5 /* skip "/dev/" */);
-         break;
-      }
-
-      Process_writeField(this, str, field);
-      return;
    case CMINFLT: Process_colorNumber(str, lp->cminflt, coloring); return;
    case CMAJFLT: Process_colorNumber(str, lp->cmajflt, coloring); return;
    case M_DRS: Process_humanNumber(str, lp->m_drs * pageSizeKB, coloring); return;

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -117,7 +117,6 @@ typedef struct LinuxProcess_ {
    #endif
    char* cgroup;
    unsigned int oom;
-   char* ttyDevice;
    #ifdef HAVE_DELAYACCT
    unsigned long long int delay_read_time;
    unsigned long long cpu_delay_total;

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -1196,7 +1196,7 @@ static bool LinuxProcessList_readCmdlineFile(Process* process, openat_arg_t proc
    return true;
 }
 
-static char* LinuxProcessList_updateTtyDevice(TtyDriver* ttyDrivers, unsigned int tty_nr) {
+static char* LinuxProcessList_updateTtyDevice(TtyDriver* ttyDrivers, unsigned long int tty_nr) {
    unsigned int maj = major(tty_nr);
    unsigned int min = minor(tty_nr);
 
@@ -1363,13 +1363,13 @@ static bool LinuxProcessList_recurseProcTree(LinuxProcessList* this, openat_arg_
 
       char command[MAX_NAME + 1];
       unsigned long long int lasttimes = (lp->utime + lp->stime);
-      unsigned int tty_nr = proc->tty_nr;
+      unsigned long int tty_nr = proc->tty_nr;
       if (! LinuxProcessList_readStatFile(proc, procFd, command, sizeof(command)))
          goto errorReadingProcess;
 
       if (tty_nr != proc->tty_nr && this->ttyDrivers) {
-         free(lp->ttyDevice);
-         lp->ttyDevice = LinuxProcessList_updateTtyDevice(this->ttyDrivers, proc->tty_nr);
+         free(proc->tty_name);
+         proc->tty_name = LinuxProcessList_updateTtyDevice(this->ttyDrivers, proc->tty_nr);
       }
 
       if (settings->flags & PROCESS_FLAG_LINUX_IOPRIO) {

--- a/openbsd/OpenBSDProcess.c
+++ b/openbsd/OpenBSDProcess.c
@@ -63,9 +63,9 @@ const ProcessFieldData Process_fields[LAST_PROCESSFIELD] = {
       .flags = 0,
       .pidColumn = true,
    },
-   [TTY_NR] = {
-      .name = "TTY_NR",
-      .title = "    TTY ",
+   [TTY] = {
+      .name = "TTY",
+      .title = "TTY      ",
       .description = "Controlling terminal",
       .flags = 0,
    },

--- a/openbsd/OpenBSDProcessList.c
+++ b/openbsd/OpenBSDProcessList.c
@@ -225,7 +225,6 @@ static void OpenBSDProcessList_scanProcs(OpenBSDProcessList* this) {
          proc->tpgid = kproc->p_tpgid;
          proc->tgid = kproc->p_pid;
          proc->session = kproc->p_sid;
-         proc->tty_nr = kproc->p_tdev;
          proc->pgrp = kproc->p__pgid;
          proc->st_uid = kproc->p_uid;
          proc->starttime_ctime = kproc->p_ustart_sec;
@@ -233,6 +232,15 @@ static void OpenBSDProcessList_scanProcs(OpenBSDProcessList* this) {
          proc->user = UsersTable_getRef(this->super.usersTable, proc->st_uid);
          ProcessList_add(&this->super, proc);
          proc->comm = OpenBSDProcessList_readProcessName(this->kd, kproc, &proc->basenameOffset);
+
+         proc->tty_nr = kproc->p_tdev;
+         const char* name = ((dev_t)kproc->p_tdev != NODEV) ? devname(kproc->p_tdev, S_IFCHR) : NULL;
+         if (!name || String_eq(name, "??")) {
+            free(proc->tty_name);
+            proc->tty_name = NULL;
+         } else {
+            free_and_xStrdup(&proc->tty_name, name);
+         }
       } else {
          if (settings->updateProcessNames) {
             free(proc->comm);

--- a/solaris/SolarisProcess.c
+++ b/solaris/SolarisProcess.c
@@ -26,7 +26,7 @@ const ProcessFieldData Process_fields[LAST_PROCESSFIELD] = {
    [PPID] = { .name = "PPID", .title = "PPID", .description = "Parent process ID", .flags = 0, .pidColumn = true, },
    [PGRP] = { .name = "PGRP", .title = "PGRP", .description = "Process group ID", .flags = 0, .pidColumn = true, },
    [SESSION] = { .name = "SESSION", .title = "SID", .description = "Process's session ID", .flags = 0, .pidColumn = true, },
-   [TTY_NR] = { .name = "TTY_NR", .title = "    TTY ", .description = "Controlling terminal", .flags = 0, },
+   [TTY] = { .name = "TTY", .title = "TTY      ", .description = "Controlling terminal", .flags = 0, },
    [TPGID] = { .name = "TPGID", .title = "TPGID", .description = "Process ID of the fg process group of the controlling terminal", .flags = 0, .pidColumn = true, },
    [MINFLT] = { .name = "MINFLT", .title = "     MINFLT ", .description = "Number of minor faults which have not required loading a memory page from disk", .flags = 0, .defaultSortDesc = true, },
    [MAJFLT] = { .name = "MAJFLT", .title = "     MAJFLT ", .description = "Number of major faults which have required loading a memory page from disk", .flags = 0, .defaultSortDesc = true, },

--- a/unsupported/UnsupportedProcess.c
+++ b/unsupported/UnsupportedProcess.c
@@ -23,7 +23,7 @@ const ProcessFieldData Process_fields[LAST_PROCESSFIELD] = {
    [PPID] = { .name = "PPID", .title = "PPID", .description = "Parent process ID", .flags = 0, .pidColumn = true, },
    [PGRP] = { .name = "PGRP", .title = "PGRP", .description = "Process group ID", .flags = 0, .pidColumn = true, },
    [SESSION] = { .name = "SESSION", .title = "SID", .description = "Process's session ID", .flags = 0, .pidColumn = true, },
-   [TTY_NR] = { .name = "TTY_NR", .title = "    TTY ", .description = "Controlling terminal", .flags = 0, },
+   [TTY] = { .name = "TTY", .title = "TTY      ", .description = "Controlling terminal", .flags = 0, },
    [TPGID] = { .name = "TPGID", .title = "TPGID", .description = "Process ID of the fg process group of the controlling terminal", .flags = 0, .pidColumn = true, },
    [MINFLT] = { .name = "MINFLT", .title = "     MINFLT ", .description = "Number of minor faults which have not required loading a memory page from disk", .flags = 0, .defaultSortDesc = true,},
    [MAJFLT] = { .name = "MAJFLT", .title = "     MAJFLT ", .description = "Number of major faults which have required loading a memory page from disk", .flags = 0, .defaultSortDesc = true, },

--- a/unsupported/UnsupportedProcessList.c
+++ b/unsupported/UnsupportedProcessList.c
@@ -54,6 +54,7 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
    proc->pgrp = 0;
    proc->session = 0;
    proc->tty_nr = 0;
+   proc->tty_name = NULL;
    proc->tpgid = 0;
    proc->st_uid = 0;
    proc->processor = 0;


### PR DESCRIPTION
* Rename internal identifier from `TTY_NR` to just `TTY`
* Unify column header on platforms
* Use `devname(3)` on BSD derivate to show the actual terminal,
  simplifies current FreeBSD implementation.
* Use `unsigned long int` as id type, to fit `dev_t` on Linux.

Only on Solaris the terminal path is not yet resolved.

Plus some *BSD cosmetics.