### PR TITLE
Merging all the points related to calculating time in one place

### DIFF
--- a/ClockMeter.c
+++ b/ClockMeter.c
@@ -20,9 +20,10 @@ static const int ClockMeter_attributes[] = {
 };
 
 static void ClockMeter_updateValues(Meter* this) {
-   time_t t = time(NULL);
+   const ProcessList* pl = this->pl;
+
    struct tm result;
-   const struct tm* lt = localtime_r(&t, &result);
+   const struct tm* lt = localtime_r(&pl->timestamp.tv_sec, &result);
    this->values[0] = lt->tm_hour * 60 + lt->tm_min;
    strftime(this->txtBuffer, sizeof(this->txtBuffer), "%H:%M:%S", lt);
 }

--- a/ClockMeter.c
+++ b/ClockMeter.c
@@ -23,7 +23,7 @@ static void ClockMeter_updateValues(Meter* this) {
    const ProcessList* pl = this->pl;
 
    struct tm result;
-   const struct tm* lt = localtime_r(&pl->timestamp.tv_sec, &result);
+   const struct tm* lt = localtime_r(&pl->realtime.tv_sec, &result);
    this->values[0] = lt->tm_hour * 60 + lt->tm_min;
    strftime(this->txtBuffer, sizeof(this->txtBuffer), "%H:%M:%S", lt);
 }

--- a/Compat.c
+++ b/Compat.c
@@ -11,17 +11,11 @@ in the source distribution for its full text.
 
 #include <errno.h>
 #include <fcntl.h> // IWYU pragma: keep
-#include <time.h>
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h> // IWYU pragma: keep
 
 #include "XUtils.h" // IWYU pragma: keep
-
-#ifdef HAVE_HOST_GET_CLOCK_SERVICE
-#include <mach/clock.h>
-#include <mach/mach.h>
-#endif
 
 
 int Compat_faccessat(int dirfd,
@@ -122,32 +116,4 @@ ssize_t Compat_readlinkat(int dirfd,
    return readlink(path, buf, bufsize);
 
 #endif
-}
-
-int Compat_clock_monotonic_gettime(struct timespec *tp) {
-
-#if defined(HAVE_CLOCK_GETTIME)
-
-   return clock_gettime(CLOCK_MONOTONIC, tp);
-
-#elif defined(HAVE_HOST_GET_CLOCK_SERVICE)
-
-   clock_serv_t cclock;
-   mach_timespec_t mts;
-
-   host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock);
-   clock_get_time(cclock, &mts);
-   mach_port_deallocate(mach_task_self(), cclock);
-
-   tp->tv_sec = mts.tv_sec;
-   tp->tv_nsec = mts.tv_nsec;
-
-   return 0;
-
-#else
-
-#error No Compat_clock_monotonic_gettime() implementation!
-
-#endif
-
 }

--- a/Compat.h
+++ b/Compat.h
@@ -56,6 +56,4 @@ ssize_t Compat_readlinkat(int dirfd,
                           char* buf,
                           size_t bufsize);
 
-int Compat_clock_monotonic_gettime(struct timespec *tp);
-
 #endif /* HEADER_Compat */

--- a/DateMeter.c
+++ b/DateMeter.c
@@ -23,7 +23,7 @@ static void DateMeter_updateValues(Meter* this) {
    const ProcessList* pl = this->pl;
 
    struct tm result;
-   const struct tm* lt = localtime_r(&pl->timestamp.tv_sec, &result);
+   const struct tm* lt = localtime_r(&pl->realtime.tv_sec, &result);
    this->values[0] = lt->tm_yday;
    int year = lt->tm_year + 1900;
    if (((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0)) {

--- a/DateMeter.c
+++ b/DateMeter.c
@@ -20,9 +20,10 @@ static const int DateMeter_attributes[] = {
 };
 
 static void DateMeter_updateValues(Meter* this) {
-   time_t t = time(NULL);
+   const ProcessList* pl = this->pl;
+
    struct tm result;
-   const struct tm* lt = localtime_r(&t, &result);
+   const struct tm* lt = localtime_r(&pl->timestamp.tv_sec, &result);
    this->values[0] = lt->tm_yday;
    int year = lt->tm_year + 1900;
    if (((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0)) {

--- a/DateTimeMeter.c
+++ b/DateTimeMeter.c
@@ -20,9 +20,10 @@ static const int DateTimeMeter_attributes[] = {
 };
 
 static void DateTimeMeter_updateValues(Meter* this) {
-   time_t t = time(NULL);
+   const ProcessList* pl = this->pl;
+
    struct tm result;
-   const struct tm* lt = localtime_r(&t, &result);
+   const struct tm* lt = localtime_r(&pl->realtime.tv_sec, &result);
    int year = lt->tm_year + 1900;
    if (((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0)) {
       this->total = 366;

--- a/DiskIOMeter.c
+++ b/DiskIOMeter.c
@@ -34,7 +34,7 @@ static void DiskIOMeter_updateValues(Meter* this) {
    const ProcessList* pl = this->pl;
 
    static uint64_t cached_last_update;
-   uint64_t passedTimeInMs = pl->timestampMs - cached_last_update;
+   uint64_t passedTimeInMs = pl->realtimeMs - cached_last_update;
 
    /* update only every 500ms */
    if (passedTimeInMs > 500) {
@@ -43,7 +43,7 @@ static void DiskIOMeter_updateValues(Meter* this) {
       static uint64_t cached_msTimeSpend_total;
       uint64_t diff;
 
-      cached_last_update = pl->timestampMs;
+      cached_last_update = pl->realtimeMs;
 
       DiskIOData data;
 

--- a/DiskIOMeter.c
+++ b/DiskIOMeter.c
@@ -31,12 +31,10 @@ static uint32_t cached_write_diff;
 static double cached_utilisation_diff;
 
 static void DiskIOMeter_updateValues(Meter* this) {
-   static uint64_t cached_last_update;
+   const ProcessList* pl = this->pl;
 
-   struct timeval tv;
-   gettimeofday(&tv, NULL);
-   uint64_t timeInMilliSeconds = (uint64_t)tv.tv_sec * 1000 + (uint64_t)tv.tv_usec / 1000;
-   uint64_t passedTimeInMs = timeInMilliSeconds - cached_last_update;
+   static uint64_t cached_last_update;
+   uint64_t passedTimeInMs = pl->timestampMs - cached_last_update;
 
    /* update only every 500ms */
    if (passedTimeInMs > 500) {
@@ -45,7 +43,7 @@ static void DiskIOMeter_updateValues(Meter* this) {
       static uint64_t cached_msTimeSpend_total;
       uint64_t diff;
 
-      cached_last_update = timeInMilliSeconds;
+      cached_last_update = pl->timestampMs;
 
       DiskIOData data;
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -134,6 +134,7 @@ myhtopheaders = \
 # -----
 
 linux_platform_headers = \
+	generic/gettime.h \
 	generic/hostname.h \
 	generic/uname.h \
 	linux/HugePageMeter.h \
@@ -154,6 +155,7 @@ linux_platform_headers = \
 	zfs/ZfsCompressedArcMeter.h
 
 linux_platform_sources = \
+	generic/gettime.c \
 	generic/hostname.c \
 	generic/uname.c \
 	linux/HugePageMeter.c \
@@ -184,6 +186,7 @@ freebsd_platform_headers = \
 	freebsd/FreeBSDProcess.h \
 	freebsd/Platform.h \
 	freebsd/ProcessField.h \
+	generic/gettime.h \
 	generic/hostname.h \
 	generic/openzfs_sysctl.h \
 	generic/uname.h \
@@ -195,6 +198,7 @@ freebsd_platform_sources = \
 	freebsd/Platform.c \
 	freebsd/FreeBSDProcessList.c \
 	freebsd/FreeBSDProcess.c \
+	generic/gettime.c \
 	generic/hostname.c \
 	generic/openzfs_sysctl.c \
 	generic/uname.c \
@@ -215,6 +219,7 @@ dragonflybsd_platform_headers = \
 	dragonflybsd/DragonFlyBSDProcess.h \
 	dragonflybsd/Platform.h \
 	dragonflybsd/ProcessField.h \
+	generic/gettime.h \
 	generic/hostname.h \
 	generic/uname.h
 
@@ -222,6 +227,7 @@ dragonflybsd_platform_sources = \
 	dragonflybsd/DragonFlyBSDProcessList.c \
 	dragonflybsd/DragonFlyBSDProcess.c \
 	dragonflybsd/Platform.c \
+	generic/gettime.c \
 	generic/hostname.c \
 	generic/uname.c
 
@@ -235,6 +241,7 @@ endif
 # -------
 
 openbsd_platform_headers = \
+	generic/gettime.h \
 	generic/hostname.h \
 	generic/uname.h \
 	openbsd/OpenBSDProcessList.h \
@@ -243,6 +250,7 @@ openbsd_platform_headers = \
 	openbsd/ProcessField.h
 
 openbsd_platform_sources = \
+	generic/gettime.c \
 	generic/hostname.c \
 	generic/uname.c \
 	openbsd/OpenBSDProcessList.c \
@@ -263,6 +271,7 @@ darwin_platform_headers = \
 	darwin/DarwinProcessList.h \
 	darwin/Platform.h \
 	darwin/ProcessField.h \
+	generic/gettime.h \
 	generic/hostname.h \
 	generic/openzfs_sysctl.h \
 	generic/uname.h \
@@ -274,6 +283,7 @@ darwin_platform_sources = \
 	darwin/Platform.c \
 	darwin/DarwinProcess.c \
 	darwin/DarwinProcessList.c \
+	generic/gettime.c \
 	generic/hostname.c \
 	generic/openzfs_sysctl.c \
 	generic/uname.c \
@@ -291,6 +301,7 @@ endif
 # -------
 
 solaris_platform_headers = \
+	generic/gettime.h \
 	generic/hostname.h \
 	generic/uname.h \
 	solaris/ProcessField.h \
@@ -302,6 +313,7 @@ solaris_platform_headers = \
 	zfs/ZfsCompressedArcMeter.h
 
 solaris_platform_sources = \
+	generic/gettime.c \
 	generic/hostname.c \
 	generic/uname.c \
 	solaris/Platform.c \
@@ -320,12 +332,14 @@ endif
 # -----------
 
 unsupported_platform_headers = \
+	generic/gettime.h \
 	unsupported/Platform.h \
 	unsupported/ProcessField.h \
 	unsupported/UnsupportedProcess.h \
 	unsupported/UnsupportedProcessList.h
 
 unsupported_platform_sources = \
+	generic/gettime.c \
 	unsupported/Platform.c \
 	unsupported/UnsupportedProcess.c \
 	unsupported/UnsupportedProcessList.c

--- a/Meter.c
+++ b/Meter.c
@@ -314,10 +314,10 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
    x += captionLen;
    w -= captionLen;
 
-   if (!timercmp(&pl->timestamp, &(data->time), <)) {
+   if (!timercmp(&pl->realtime, &(data->time), <)) {
       int globalDelay = this->pl->settings->delay;
       struct timeval delay = { .tv_sec = globalDelay / 10, .tv_usec = (globalDelay - ((globalDelay / 10) * 10)) * 100000 };
-      timeradd(&pl->timestamp, &delay, &(data->time));
+      timeradd(&pl->realtime, &delay, &(data->time));
 
       for (int i = 0; i < nValues - 1; i++)
          data->values[i] = data->values[i + 1];

--- a/Meter.c
+++ b/Meter.c
@@ -18,6 +18,7 @@ in the source distribution for its full text.
 #include "CRT.h"
 #include "Macros.h"
 #include "Object.h"
+#include "Platform.h"
 #include "ProvideCurses.h"
 #include "RichString.h"
 #include "Settings.h"
@@ -286,6 +287,7 @@ static const char* const GraphMeterMode_dotsAscii[] = {
 };
 
 static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
+   const ProcessList* pl = this->pl;
 
    if (!this->drawData) {
       this->drawData = xCalloc(1, sizeof(GraphData));
@@ -312,12 +314,10 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
    x += captionLen;
    w -= captionLen;
 
-   struct timeval now;
-   gettimeofday(&now, NULL);
-   if (!timercmp(&now, &(data->time), <)) {
+   if (!timercmp(&pl->timestamp, &(data->time), <)) {
       int globalDelay = this->pl->settings->delay;
       struct timeval delay = { .tv_sec = globalDelay / 10, .tv_usec = (globalDelay - ((globalDelay / 10) * 10)) * 100000 };
-      timeradd(&now, &delay, &(data->time));
+      timeradd(&pl->timestamp, &delay, &(data->time));
 
       for (int i = 0; i < nValues - 1; i++)
          data->values[i] = data->values[i + 1];

--- a/NetworkIOMeter.c
+++ b/NetworkIOMeter.c
@@ -28,7 +28,7 @@ static void NetworkIOMeter_updateValues(Meter* this) {
    const ProcessList* pl = this->pl;
    static uint64_t cached_last_update = 0;
 
-   uint64_t passedTimeInMs = pl->timestampMs - cached_last_update;
+   uint64_t passedTimeInMs = pl->realtimeMs - cached_last_update;
 
    /* update only every 500ms */
    if (passedTimeInMs > 500) {
@@ -38,7 +38,7 @@ static void NetworkIOMeter_updateValues(Meter* this) {
       static uint64_t cached_txp_total;
       uint64_t diff;
 
-      cached_last_update = pl->timestampMs;
+      cached_last_update = pl->realtimeMs;
 
       NetworkIOData data;
       hasData = Platform_getNetworkIO(&data);

--- a/NetworkIOMeter.c
+++ b/NetworkIOMeter.c
@@ -25,12 +25,10 @@ static uint32_t cached_txb_diff;
 static uint32_t cached_txp_diff;
 
 static void NetworkIOMeter_updateValues(Meter* this) {
+   const ProcessList* pl = this->pl;
    static uint64_t cached_last_update = 0;
 
-   struct timeval tv;
-   gettimeofday(&tv, NULL);
-   uint64_t timeInMilliSeconds = (uint64_t)tv.tv_sec * 1000 + (uint64_t)tv.tv_usec / 1000;
-   uint64_t passedTimeInMs = timeInMilliSeconds - cached_last_update;
+   uint64_t passedTimeInMs = pl->timestampMs - cached_last_update;
 
    /* update only every 500ms */
    if (passedTimeInMs > 500) {
@@ -40,7 +38,7 @@ static void NetworkIOMeter_updateValues(Meter* this) {
       static uint64_t cached_txp_total;
       uint64_t diff;
 
-      cached_last_update = timeInMilliSeconds;
+      cached_last_update = pl->timestampMs;
 
       NetworkIOData data;
       hasData = Platform_getNetworkIO(&data);

--- a/Process.c
+++ b/Process.c
@@ -467,14 +467,14 @@ void Process_toggleTag(Process* this) {
 
 bool Process_isNew(const Process* this) {
    assert(this->processList);
-   if (this->processList->scanTs >= this->seenTs) {
-      return this->processList->scanTs - this->seenTs <= 1000 * this->processList->settings->highlightDelaySecs;
+   if (this->processList->monotonicMs >= this->seenStampMs) {
+      return this->processList->monotonicMs - this->seenStampMs <= 1000 * (uint64_t)this->processList->settings->highlightDelaySecs;
    }
    return false;
 }
 
 bool Process_isTomb(const Process* this) {
-    return this->tombTs > 0;
+    return this->tombStampMs > 0;
 }
 
 bool Process_setPriority(Process* this, int priority) {

--- a/Process.h
+++ b/Process.h
@@ -174,8 +174,8 @@ typedef struct Process_ {
    /*
     * Internal time counts for showing new and exited processes.
     */
-   time_t seenTs;
-   time_t tombTs;
+   uint64_t seenStampMs;
+   uint64_t tombStampMs;
 
    /*
     * Internal state for tree-mode.

--- a/ProcessList.h
+++ b/ProcessList.h
@@ -48,6 +48,9 @@ typedef struct ProcessList_ {
    Hashtable* displayTreeSet;
    Hashtable* draftingTreeSet;
 
+   struct timeval timestamp;  /* time of the current sample */
+   uint64_t timestampMs;      /* current time in milliseconds */
+
    Panel* panel;
    int following;
    uid_t userId;

--- a/ProcessList.h
+++ b/ProcessList.h
@@ -48,8 +48,9 @@ typedef struct ProcessList_ {
    Hashtable* displayTreeSet;
    Hashtable* draftingTreeSet;
 
-   struct timeval timestamp;  /* time of the current sample */
-   uint64_t timestampMs;      /* current time in milliseconds */
+   struct timeval realtime;   /* time of the current sample */
+   uint64_t realtimeMs;       /* current time in milliseconds */
+   uint64_t monotonicMs;      /* same, but from monotonic clock */
 
    Panel* panel;
    int following;
@@ -79,8 +80,6 @@ typedef struct ProcessList_ {
    memory_t cachedSwap;
 
    unsigned int cpuCount;
-
-   time_t scanTs;
 } ProcessList;
 
 ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidMatchList, uid_t userId);

--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -15,6 +15,7 @@ in the source distribution for its full text.
 #include "CRT.h"
 #include "FunctionBar.h"
 #include "Object.h"
+#include "Platform.h"
 #include "ProcessList.h"
 #include "ProvideCurses.h"
 #include "XUtils.h"
@@ -92,9 +93,8 @@ void ScreenManager_resize(ScreenManager* this, int x1, int y1, int x2, int y2) {
 static void checkRecalculation(ScreenManager* this, double* oldTime, int* sortTimeout, bool* redraw, bool* rescan, bool* timedOut) {
    ProcessList* pl = this->header->pl;
 
-   struct timeval tv;
-   gettimeofday(&tv, NULL);
-   double newTime = ((double)tv.tv_sec * 10) + ((double)tv.tv_usec / 100000);
+   Platform_gettime_realtime(&pl->realtime, &pl->realtimeMs);
+   double newTime = ((double)pl->realtime.tv_sec * 10) + ((double)pl->realtime.tv_usec / 100000);
 
    *timedOut = (newTime - *oldTime > this->settings->delay);
    *rescan |= *timedOut;

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -37,6 +37,10 @@ in the source distribution for its full text.
 #include "zfs/ZfsArcMeter.h"
 #include "zfs/ZfsCompressedArcMeter.h"
 
+#ifdef HAVE_HOST_GET_CLOCK_SERVICE
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
 #ifdef HAVE_MACH_MACH_TIME_H
 #include <mach/mach_time.h>
 #endif
@@ -404,4 +408,24 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
 
    CFRelease(list);
    CFRelease(power_sources);
+}
+
+void Platform_gettime_monotonic(uint64_t* msec) {
+
+#ifdef HAVE_HOST_GET_CLOCK_SERVICE
+
+   clock_serv_t cclock;
+   mach_timespec_t mts;
+
+   host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock);
+   clock_get_time(cclock, &mts);
+   mach_port_deallocate(mach_task_self(), cclock);
+
+   *msec = ((uint64_t)mts.tv_sec * 1000) + ((uint64_t)mts.tv_nsec / 1000000);
+
+#else
+
+   Generic_gettime_monotomic(msec);
+
+#endif
 }

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -19,6 +19,7 @@ in the source distribution for its full text.
 #include "NetworkIOMeter.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
+#include "generic/gettime.h"
 #include "generic/hostname.h"
 #include "generic/uname.h"
 
@@ -84,5 +85,11 @@ static inline void Platform_longOptionsUsage(ATTR_UNUSED const char* name) { }
 static inline bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
    return false;
 }
+
+static inline void Platform_gettime_realtime(struct timeval* tv, uint64_t* msec) {
+    Generic_gettime_realtime(tv, msec);
+}
+
+void Platform_gettime_monotonic(uint64_t* msec);
 
 #endif

--- a/dragonflybsd/Platform.h
+++ b/dragonflybsd/Platform.h
@@ -17,6 +17,7 @@ in the source distribution for its full text.
 #include "NetworkIOMeter.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
+#include "generic/gettime.h"
 #include "generic/hostname.h"
 #include "generic/uname.h"
 
@@ -73,6 +74,14 @@ static inline void Platform_longOptionsUsage(ATTR_UNUSED const char* name) { }
 
 static inline bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
    return false;
+}
+
+static inline void Platform_gettime_realtime(struct timeval* tv, uint64_t* msec) {
+    Generic_gettime_realtime(tv, msec);
+}
+
+static inline void Platform_gettime_monotonic(uint64_t* msec) {
+    Generic_gettime_monotonic(msec);
 }
 
 #endif

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -18,6 +18,7 @@ in the source distribution for its full text.
 #include "Process.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
+#include "generic/gettime.h"
 #include "generic/hostname.h"
 #include "generic/uname.h"
 
@@ -78,6 +79,14 @@ static inline void Platform_longOptionsUsage(ATTR_UNUSED const char* name) { }
 
 static inline bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
    return false;
+}
+
+static inline void Platform_gettime_realtime(struct timeval* tv, uint64_t* msec) {
+    Generic_gettime_realtime(tv, msec);
+}
+
+static inline void Platform_gettime_monotonic(uint64_t* msec) {
+    Generic_gettime_monotonic(msec);
 }
 
 #endif

--- a/generic/gettime.c
+++ b/generic/gettime.c
@@ -1,0 +1,57 @@
+/*
+htop - generic/gettime.c
+(C) 2021 htop dev team
+Released under the GNU GPLv2, see the COPYING file
+in the source distribution for its full text.
+*/
+#include "config.h"  // IWYU pragma: keep
+
+#include <string.h>
+#include <time.h>
+
+#include "generic/gettime.h"
+
+
+void Generic_gettime_realtime(struct timeval* tvp, uint64_t* msec) {
+
+#if defined(HAVE_CLOCK_GETTIME)
+
+   struct timespec ts;
+   if (clock_gettime(CLOCK_REALTIME, &ts) == 0) {
+      tvp->tv_sec = ts.tv_sec;
+      tvp->tv_usec = ts.tv_nsec / 1000;
+      *msec = ((uint64_t)ts.tv_sec * 1000) + ((uint64_t)ts.tv_nsec / 1000000);
+   } else {
+      memset(tvp, 0, sizeof(struct timeval));
+      *msec = 0;
+   }
+
+#else	/* lower resolution gettimeofday(2) is always available */
+
+   struct timeval tv;
+   if (gettimeofday(&tv, NULL) == 0) {
+      *tsp = tv; /* struct copy */
+      *msec = ((uint64_t)tv.tv_sec * 1000) + ((uint64_t)tv.tv_usec / 1000);
+   } else {
+      memset(tvp, 0, sizeof(struct timeval));
+      *msec = 0;
+   }
+
+#endif
+}
+
+void Generic_gettime_monotonic(uint64_t* msec) {
+#if defined(HAVE_CLOCK_GETTIME)
+
+   struct timespec ts;
+   if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0)
+      *msec = ((uint64_t)ts.tv_sec * 1000) + ((uint64_t)ts.tv_nsec / 1000000);
+   else
+      *msec = 0;
+
+#else
+
+# error "No monotonic clock available"
+
+#endif
+}

--- a/generic/gettime.h
+++ b/generic/gettime.h
@@ -1,0 +1,19 @@
+#ifndef HEADER_gettime
+#define HEADER_gettime
+/*
+htop - generic/gettime.h
+(C) 2021 htop dev team
+Released under the GNU GPLv2, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include <stdint.h>
+#include <sys/time.h>
+#include <sys/types.h>
+
+
+void Generic_gettime_realtime(struct timeval* ts, uint64_t* msec);
+
+void Generic_gettime_monotonic(uint64_t* msec);
+
+#endif

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -189,13 +189,6 @@ static void LinuxProcessList_updateCPUcount(ProcessList* super, FILE* stream) {
    }
 }
 
-static void LinuxProcessList_updateTime(LinuxProcessList* this) {
-   ProcessList* pl = &(this->super);
-
-   gettimeofday(&pl->timestamp, NULL);
-   pl->timestampMs = (uint64_t)&pl->timestamp.tv_sec * 1000 + (uint64_t)pl->timestamp.tv_usec / 1000;
-}
-
 ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidMatchList, uid_t userId) {
    LinuxProcessList* this = xCalloc(1, sizeof(LinuxProcessList));
    ProcessList* pl = &(this->super);
@@ -1975,7 +1968,6 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
    LinuxProcessList* this = (LinuxProcessList*) super;
    const Settings* settings = super->settings;
 
-   LinuxProcessList_updateTime(this);
    LinuxProcessList_scanMemoryInfo(super);
    LinuxProcessList_scanHugePages(this);
    LinuxProcessList_scanZfsArcstats(this);
@@ -2005,5 +1997,5 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
    openat_arg_t rootFd = "";
 #endif
 
-   LinuxProcessList_recurseProcTree(this, rootFd, PROCDIR, NULL, period, super->timestampMs);
+   LinuxProcessList_recurseProcTree(this, rootFd, PROCDIR, NULL, period, super->realtimeMs);
 }

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -19,6 +19,7 @@ in the source distribution for its full text.
 #include "Process.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
+#include "generic/gettime.h"
 #include "generic/hostname.h"
 #include "generic/uname.h"
 
@@ -92,5 +93,13 @@ static inline void Platform_getRelease(char** string) {
 void Platform_longOptionsUsage(const char* name);
 
 bool Platform_getLongOption(int opt, int argc, char** argv);
+
+static inline void Platform_gettime_realtime(struct timeval* tv, uint64_t* msec) {
+    Generic_gettime_realtime(tv, msec);
+}
+
+static inline void Platform_gettime_monotonic(uint64_t* msec) {
+    Generic_gettime_monotonic(msec);
+}
 
 #endif

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -19,6 +19,7 @@ in the source distribution for its full text.
 #include "Process.h"
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
+#include "generic/gettime.h"
 #include "generic/hostname.h"
 #include "generic/uname.h"
 
@@ -76,6 +77,14 @@ static inline void Platform_longOptionsUsage(ATTR_UNUSED const char* name) { }
 
 static inline bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
    return false;
+}
+
+static inline void Platform_gettime_realtime(struct timeval* tv, uint64_t* msec) {
+    Generic_gettime_realtime(tv, msec);
+}
+
+static inline void Platform_gettime_monotonic(uint64_t* msec) {
+    Generic_gettime_monotonic(msec);
 }
 
 #endif

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -26,6 +26,7 @@ in the source distribution for its full text.
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
 
+#include "generic/gettime.h"
 #include "generic/hostname.h"
 #include "generic/uname.h"
 
@@ -99,6 +100,14 @@ static inline void Platform_longOptionsUsage(ATTR_UNUSED const char* name) { }
 
 static inline bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
    return false;
+}
+
+static inline void Platform_gettime_realtime(struct timeval* tv, uint64_t* msec) {
+    Generic_gettime_realtime(tv, msec);
+}
+
+static inline void Platform_gettime_monotonic(uint64_t* msec) {
+    Generic_gettime_monotonic(msec);
 }
 
 #endif

--- a/unsupported/Platform.h
+++ b/unsupported/Platform.h
@@ -15,6 +15,7 @@ in the source distribution for its full text.
 #include "ProcessLocksScreen.h"
 #include "SignalsPanel.h"
 #include "UnsupportedProcess.h"
+#include "generic/gettime.h"
 
 
 extern const SignalItem Platform_signals[];
@@ -67,6 +68,14 @@ static inline void Platform_longOptionsUsage(ATTR_UNUSED const char* name) { }
 
 static inline bool Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {
    return false;
+}
+
+static inline void Platform_gettime_realtime(struct timeval* tv, uint64_t* msec) {
+    Generic_gettime_realtime(tv, msec);
+}
+
+static inline void Platform_gettime_monotonic(uint64_t* msec) {
+    Generic_gettime_monotonic(msec);
 }
 
 #endif


### PR DESCRIPTION
The end goal is to consolidate all the points in htop that can only work in
live-only mode today, so that will be able to inject PCP archive mode and have
a chance at it working.
The biggest problem we've got at this moment is all the places that are
independently asking the kernel to 'give me the time right now'.
Each of those needs to be audited and ultimately changed to allow platforms to
manage their own idea of time.
So, all the calls to gettimeofday(2) and time(2) are potential problems.
Ultimately I want to get these down to just one or two.