### PR TITLE
FreeBSD: improve actual processor calculation logic

### DIFF
--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -572,7 +572,11 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
       proc->percent_cpu = 100.0 * ((double)kproc->ki_pctcpu / (double)kernelFScale);
       proc->percent_mem = 100.0 * proc->m_resident / (double)(super->totalMem);
 
-      proc->processor = kproc->ki_lastcpu;
+      if (kproc->ki_stat == SRUN && kproc->ki_oncpu != NOCPU) {
+            proc->processor = kproc->ki_oncpu;
+      } else {
+            proc->processor = kproc->ki_lastcpu;
+      }
 
       proc->majflt = kproc->ki_cow;
 


### PR DESCRIPTION
Found that current htop(1) and system's top(1) calculations may be off. The reason is that FreeBSD has a bit more complicated logic which tracks actual cpu where a process is running on.

