### PR TITLE
Process print rework

### DIFF
--- a/Process.h
+++ b/Process.h
@@ -245,27 +245,32 @@ static inline bool Process_isChildOf(const Process* this, pid_t pid) {
 #define ONE_M (ONE_K * ONE_K)
 #define ONE_G (ONE_M * ONE_K)
 #define ONE_T (1ULL * ONE_G * ONE_K)
+#define ONE_P (1ULL * ONE_T * ONE_K)
 
 #define ONE_DECIMAL_K 1000UL
 #define ONE_DECIMAL_M (ONE_DECIMAL_K * ONE_DECIMAL_K)
 #define ONE_DECIMAL_G (ONE_DECIMAL_M * ONE_DECIMAL_K)
 #define ONE_DECIMAL_T (1ULL * ONE_DECIMAL_G * ONE_DECIMAL_K)
+#define ONE_DECIMAL_P (1ULL * ONE_DECIMAL_T * ONE_DECIMAL_K)
 
 void Process_setupColumnWidths(void);
 
-/* Takes number in kilo units (base 1024) */
-void Process_humanNumber(RichString* str, unsigned long long number, bool coloring);
+/* Takes number in bytes (base 1024). Prints 6 columns. */
+void Process_printBytes(RichString* str, unsigned long long number, bool coloring);
 
-/* Takes number in bare units (base 1000) */
-void Process_colorNumber(RichString* str, unsigned long long number, bool coloring);
+/* Takes number in kilo bytes (base 1024). Prints 6 columns. */
+void Process_printKBytes(RichString* str, unsigned long long number, bool coloring);
 
-/* Takes number in hundredths of a seconds */
-void Process_printTime(RichString* str, unsigned long long totalHundredths);
+/* Takes number as count (base 1000). Prints 12 columns. */
+void Process_printCount(RichString* str, unsigned long long number, bool coloring);
+
+/* Takes time in hundredths of a seconds. Prints 9 columns. */
+void Process_printTime(RichString* str, unsigned long long totalHundredths, bool coloring);
+
+/* Takes rate in bare unit (base 1024) per second. Prints 12 columns. */
+void Process_printRate(RichString* str, double rate, bool coloring);
 
 void Process_fillStarttimeBuffer(Process* this);
-
-/* Takes number in bare units (base 1024) */
-void Process_outputRate(RichString* str, char* buffer, size_t n, double rate, int coloring);
 
 void Process_printLeftAlignedField(RichString* str, int attr, const char* content, unsigned int width);
 

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -81,7 +81,7 @@ const ProcessFieldData Process_fields[LAST_PROCESSFIELD] = {
    [RBYTES] = { .name = "RBYTES", .title = " IO_R ", .description = "Bytes of read(2) I/O for the process", .flags = PROCESS_FLAG_IO, .defaultSortDesc = true, },
    [WBYTES] = { .name = "WBYTES", .title = " IO_W ", .description = "Bytes of write(2) I/O for the process", .flags = PROCESS_FLAG_IO, .defaultSortDesc = true, },
    [CNCLWB] = { .name = "CNCLWB", .title = " IO_C ", .description = "Bytes of cancelled write(2) I/O", .flags = PROCESS_FLAG_IO, .defaultSortDesc = true, },
-   [IO_READ_RATE] = { .name = "IO_READ_RATE", .title = " DISK READ ", .description = "The I/O rate of read(2) in bytes per second for the process", .flags = PROCESS_FLAG_IO, .defaultSortDesc = true, },
+   [IO_READ_RATE] = { .name = "IO_READ_RATE", .title = " DISK READ  ", .description = "The I/O rate of read(2) in bytes per second for the process", .flags = PROCESS_FLAG_IO, .defaultSortDesc = true, },
    [IO_WRITE_RATE] = { .name = "IO_WRITE_RATE", .title = " DISK WRITE ", .description = "The I/O rate of write(2) in bytes per second for the process", .flags = PROCESS_FLAG_IO, .defaultSortDesc = true, },
    [IO_RATE] = { .name = "IO_RATE", .title = "   DISK R/W ", .description = "Total I/O rate in bytes per second", .flags = PROCESS_FLAG_IO, .defaultSortDesc = true, },
    [CGROUP] = { .name = "CGROUP", .title = "    CGROUP ", .description = "Which cgroup the process is in", .flags = PROCESS_FLAG_LINUX_CGROUP, },
@@ -611,19 +611,19 @@ static void LinuxProcess_writeField(const Process* this, RichString* str, Proces
    switch (field) {
    case CMINFLT: Process_printCount(str, lp->cminflt, coloring); return;
    case CMAJFLT: Process_printCount(str, lp->cmajflt, coloring); return;
-   case M_DRS: Process_printKBytes(str, lp->m_drs * pageSizeKB, coloring); return;
-   case M_DT: Process_printKBytes(str, lp->m_dt * pageSizeKB, coloring); return;
+   case M_DRS: Process_printBytes(str, lp->m_drs * pageSize, coloring); return;
+   case M_DT: Process_printBytes(str, lp->m_dt * pageSize, coloring); return;
    case M_LRS:
       if (lp->m_lrs) {
-         Process_printKBytes(str, lp->m_lrs * pageSizeKB, coloring);
+         Process_printBytes(str, lp->m_lrs * pageSize, coloring);
          return;
       }
 
       attr = CRT_colors[PROCESS_SHADOW];
       xSnprintf(buffer, n, "  N/A ");
       break;
-   case M_TRS: Process_printKBytes(str, lp->m_trs * pageSizeKB, coloring); return;
-   case M_SHARE: Process_printKBytes(str, lp->m_share * pageSizeKB, coloring); return;
+   case M_TRS: Process_printBytes(str, lp->m_trs * pageSize, coloring); return;
+   case M_SHARE: Process_printBytes(str, lp->m_share * pageSize, coloring); return;
    case M_PSS: Process_printKBytes(str, lp->m_pss, coloring); return;
    case M_SWAP: Process_printKBytes(str, lp->m_swap, coloring); return;
    case M_PSSWP: Process_printKBytes(str, lp->m_psswp, coloring); return;
@@ -631,13 +631,13 @@ static void LinuxProcess_writeField(const Process* this, RichString* str, Proces
    case STIME: Process_printTime(str, lp->stime, coloring); return;
    case CUTIME: Process_printTime(str, lp->cutime, coloring); return;
    case CSTIME: Process_printTime(str, lp->cstime, coloring); return;
-   case RCHAR:  Process_printKBytes(str, lp->io_rchar, coloring); return;
-   case WCHAR:  Process_printKBytes(str, lp->io_wchar, coloring); return;
+   case RCHAR:  Process_printBytes(str, lp->io_rchar, coloring); return;
+   case WCHAR:  Process_printBytes(str, lp->io_wchar, coloring); return;
    case SYSCR:  Process_printCount(str, lp->io_syscr, coloring); return;
    case SYSCW:  Process_printCount(str, lp->io_syscw, coloring); return;
-   case RBYTES: Process_printKBytes(str, lp->io_read_bytes, coloring); return;
-   case WBYTES: Process_printKBytes(str, lp->io_write_bytes, coloring); return;
-   case CNCLWB: Process_printKBytes(str, lp->io_cancelled_write_bytes, coloring); return;
+   case RBYTES: Process_printBytes(str, lp->io_read_bytes, coloring); return;
+   case WBYTES: Process_printBytes(str, lp->io_write_bytes, coloring); return;
+   case CNCLWB: Process_printBytes(str, lp->io_cancelled_write_bytes, coloring); return;
    case IO_READ_RATE:  Process_printRate(str, lp->io_rate_read_bps, coloring); return;
    case IO_WRITE_RATE: Process_printRate(str, lp->io_rate_write_bps, coloring); return;
    case IO_RATE: {

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -609,37 +609,37 @@ static void LinuxProcess_writeField(const Process* this, RichString* str, Proces
    int attr = CRT_colors[DEFAULT_COLOR];
    size_t n = sizeof(buffer) - 1;
    switch (field) {
-   case CMINFLT: Process_colorNumber(str, lp->cminflt, coloring); return;
-   case CMAJFLT: Process_colorNumber(str, lp->cmajflt, coloring); return;
-   case M_DRS: Process_humanNumber(str, lp->m_drs * pageSizeKB, coloring); return;
-   case M_DT: Process_humanNumber(str, lp->m_dt * pageSizeKB, coloring); return;
+   case CMINFLT: Process_printCount(str, lp->cminflt, coloring); return;
+   case CMAJFLT: Process_printCount(str, lp->cmajflt, coloring); return;
+   case M_DRS: Process_printKBytes(str, lp->m_drs * pageSizeKB, coloring); return;
+   case M_DT: Process_printKBytes(str, lp->m_dt * pageSizeKB, coloring); return;
    case M_LRS:
       if (lp->m_lrs) {
-         Process_humanNumber(str, lp->m_lrs * pageSizeKB, coloring);
+         Process_printKBytes(str, lp->m_lrs * pageSizeKB, coloring);
          return;
       }
 
       attr = CRT_colors[PROCESS_SHADOW];
       xSnprintf(buffer, n, "  N/A ");
       break;
-   case M_TRS: Process_humanNumber(str, lp->m_trs * pageSizeKB, coloring); return;
-   case M_SHARE: Process_humanNumber(str, lp->m_share * pageSizeKB, coloring); return;
-   case M_PSS: Process_humanNumber(str, lp->m_pss, coloring); return;
-   case M_SWAP: Process_humanNumber(str, lp->m_swap, coloring); return;
-   case M_PSSWP: Process_humanNumber(str, lp->m_psswp, coloring); return;
-   case UTIME: Process_printTime(str, lp->utime); return;
-   case STIME: Process_printTime(str, lp->stime); return;
-   case CUTIME: Process_printTime(str, lp->cutime); return;
-   case CSTIME: Process_printTime(str, lp->cstime); return;
-   case RCHAR:  Process_humanNumber(str, lp->io_rchar, coloring); return;
-   case WCHAR:  Process_humanNumber(str, lp->io_wchar, coloring); return;
-   case SYSCR:  Process_colorNumber(str, lp->io_syscr, coloring); return;
-   case SYSCW:  Process_colorNumber(str, lp->io_syscw, coloring); return;
-   case RBYTES: Process_humanNumber(str, lp->io_read_bytes, coloring); return;
-   case WBYTES: Process_humanNumber(str, lp->io_write_bytes, coloring); return;
-   case CNCLWB: Process_humanNumber(str, lp->io_cancelled_write_bytes, coloring); return;
-   case IO_READ_RATE:  Process_outputRate(str, buffer, n, lp->io_rate_read_bps, coloring); return;
-   case IO_WRITE_RATE: Process_outputRate(str, buffer, n, lp->io_rate_write_bps, coloring); return;
+   case M_TRS: Process_printKBytes(str, lp->m_trs * pageSizeKB, coloring); return;
+   case M_SHARE: Process_printKBytes(str, lp->m_share * pageSizeKB, coloring); return;
+   case M_PSS: Process_printKBytes(str, lp->m_pss, coloring); return;
+   case M_SWAP: Process_printKBytes(str, lp->m_swap, coloring); return;
+   case M_PSSWP: Process_printKBytes(str, lp->m_psswp, coloring); return;
+   case UTIME: Process_printTime(str, lp->utime, coloring); return;
+   case STIME: Process_printTime(str, lp->stime, coloring); return;
+   case CUTIME: Process_printTime(str, lp->cutime, coloring); return;
+   case CSTIME: Process_printTime(str, lp->cstime, coloring); return;
+   case RCHAR:  Process_printKBytes(str, lp->io_rchar, coloring); return;
+   case WCHAR:  Process_printKBytes(str, lp->io_wchar, coloring); return;
+   case SYSCR:  Process_printCount(str, lp->io_syscr, coloring); return;
+   case SYSCW:  Process_printCount(str, lp->io_syscw, coloring); return;
+   case RBYTES: Process_printKBytes(str, lp->io_read_bytes, coloring); return;
+   case WBYTES: Process_printKBytes(str, lp->io_write_bytes, coloring); return;
+   case CNCLWB: Process_printKBytes(str, lp->io_cancelled_write_bytes, coloring); return;
+   case IO_READ_RATE:  Process_printRate(str, lp->io_rate_read_bps, coloring); return;
+   case IO_WRITE_RATE: Process_printRate(str, lp->io_rate_write_bps, coloring); return;
    case IO_RATE: {
       double totalRate;
       if (!isnan(lp->io_rate_read_bps) && !isnan(lp->io_rate_write_bps))
@@ -650,7 +650,7 @@ static void LinuxProcess_writeField(const Process* this, RichString* str, Proces
          totalRate = lp->io_rate_write_bps;
       else
          totalRate = NAN;
-      Process_outputRate(str, buffer, n, totalRate, coloring); return;
+      Process_printRate(str, totalRate, coloring); return;
    }
    #ifdef HAVE_OPENVZ
    case CTID: xSnprintf(buffer, n, "%-8s ", lp->ctid ? lp->ctid : ""); break;

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -82,10 +82,10 @@ typedef struct LinuxProcess_ {
    long m_lrs;
    long m_dt;
 
-   /* Data read (in kilobytes) */
+   /* Data read (in bytes) */
    unsigned long long io_rchar;
 
-   /* Data written (in kilobytes) */
+   /* Data written (in bytes) */
    unsigned long long io_wchar;
 
    /* Number of read(2) syscalls */
@@ -94,20 +94,24 @@ typedef struct LinuxProcess_ {
    /* Number of write(2) syscalls */
    unsigned long long io_syscw;
 
-   /* Storage data read (in kilobytes) */
+   /* Storage data read (in bytes) */
    unsigned long long io_read_bytes;
 
-   /* Storage data written (in kilobytes) */
+   /* Storage data written (in bytes) */
    unsigned long long io_write_bytes;
 
-   /* Storage data cancelled (in kilobytes) */
+   /* Storage data cancelled (in bytes) */
    unsigned long long io_cancelled_write_bytes;
 
-   /* Point in time of last io scan (in seconds elapsed since the Epoch) */
-   unsigned long long io_last_scan_time;
+   /* Point in time of last io scan (in milliseconds elapsed since the Epoch) */
+   unsigned long long io_last_scan_time_ms;
 
+   /* Storage data read (in bytes per second) */
    double io_rate_read_bps;
+
+   /* Storage data written (in bytes per second) */
    double io_rate_write_bps;
+
    #ifdef HAVE_OPENVZ
    char* ctid;
    pid_t vpid;


### PR DESCRIPTION
Make functions formatting data for a process field column less error
prone, unify interfaces and improve some internals.

* Process_printBytes
  - rename from Process_humanNumber
  - take number in bytes, not kilobytes
  - handle petabytes
  - increase buffer to avoid crashes when the passed value is
    ~ ULLONG_MAX

* Process_printKBytes
  - add wrapper for Process_printBytes taking kilobytes keeping -1 as
  special value

* Process_printCount
  - rename from Process_colorNumber

* Process_printTime
  - add coloring parameter as other print functions
  - improve coloring and formatting for larger times

* Process_printRate
  - rename from Process_outputRate
  - use local buffer instead of passed one; this function prints to the
    RichString after all

 Linux: update IO fields

- fix header width of IO_READ_RATE

- save data in bytes (not kilobytes) to better compute rate

- fix rate data: multiply with 1000 to compensate time difference in
  milliseconds

- rename unit less variable now into realtimeMs

- use Process_printBytes(..., data * pageSize, ...) instead of
  Process_printKBytes(..., data * pageSizeKB, ...) to avoid wrapper


