### PR TITLE
Optimize RichString usage

### DIFF
--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -101,51 +101,53 @@ static void CPUMeter_updateValues(Meter* this) {
 
 static void CPUMeter_display(const Object* cast, RichString* out) {
    char buffer[50];
+   int len;
    const Meter* this = (const Meter*)cast;
+
    if (this->param > this->pl->cpuCount) {
       RichString_appendAscii(out, CRT_colors[METER_TEXT], "absent");
       return;
    }
-   xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_NORMAL]);
+   len = xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_NORMAL]);
    RichString_appendAscii(out, CRT_colors[METER_TEXT], ":");
-   RichString_appendAscii(out, CRT_colors[CPU_NORMAL], buffer);
+   RichString_appendnAscii(out, CRT_colors[CPU_NORMAL], buffer, len);
    if (this->pl->settings->detailedCPUTime) {
-      xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_KERNEL]);
+      len = xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_KERNEL]);
       RichString_appendAscii(out, CRT_colors[METER_TEXT], "sy:");
-      RichString_appendAscii(out, CRT_colors[CPU_SYSTEM], buffer);
-      xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_NICE]);
+      RichString_appendnAscii(out, CRT_colors[CPU_SYSTEM], buffer, len);
+      len = xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_NICE]);
       RichString_appendAscii(out, CRT_colors[METER_TEXT], "ni:");
-      RichString_appendAscii(out, CRT_colors[CPU_NICE_TEXT], buffer);
-      xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_IRQ]);
+      RichString_appendnAscii(out, CRT_colors[CPU_NICE_TEXT], buffer, len);
+      len = xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_IRQ]);
       RichString_appendAscii(out, CRT_colors[METER_TEXT], "hi:");
-      RichString_appendAscii(out, CRT_colors[CPU_IRQ], buffer);
-      xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_SOFTIRQ]);
+      RichString_appendnAscii(out, CRT_colors[CPU_IRQ], buffer, len);
+      len = xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_SOFTIRQ]);
       RichString_appendAscii(out, CRT_colors[METER_TEXT], "si:");
-      RichString_appendAscii(out, CRT_colors[CPU_SOFTIRQ], buffer);
+      RichString_appendnAscii(out, CRT_colors[CPU_SOFTIRQ], buffer, len);
       if (!isnan(this->values[CPU_METER_STEAL])) {
-         xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_STEAL]);
+         len = xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_STEAL]);
          RichString_appendAscii(out, CRT_colors[METER_TEXT], "st:");
-         RichString_appendAscii(out, CRT_colors[CPU_STEAL], buffer);
+         RichString_appendnAscii(out, CRT_colors[CPU_STEAL], buffer, len);
       }
       if (!isnan(this->values[CPU_METER_GUEST])) {
-         xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_GUEST]);
+         len = xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_GUEST]);
          RichString_appendAscii(out, CRT_colors[METER_TEXT], "gu:");
-         RichString_appendAscii(out, CRT_colors[CPU_GUEST], buffer);
+         RichString_appendnAscii(out, CRT_colors[CPU_GUEST], buffer, len);
       }
-      xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_IOWAIT]);
+      len = xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_IOWAIT]);
       RichString_appendAscii(out, CRT_colors[METER_TEXT], "wa:");
-      RichString_appendAscii(out, CRT_colors[CPU_IOWAIT], buffer);
+      RichString_appendnAscii(out, CRT_colors[CPU_IOWAIT], buffer, len);
    } else {
-      xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_KERNEL]);
+      len = xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_KERNEL]);
       RichString_appendAscii(out, CRT_colors[METER_TEXT], "sys:");
-      RichString_appendAscii(out, CRT_colors[CPU_SYSTEM], buffer);
-      xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_NICE]);
+      RichString_appendnAscii(out, CRT_colors[CPU_SYSTEM], buffer, len);
+      len = xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_NICE]);
       RichString_appendAscii(out, CRT_colors[METER_TEXT], "low:");
-      RichString_appendAscii(out, CRT_colors[CPU_NICE_TEXT], buffer);
+      RichString_appendnAscii(out, CRT_colors[CPU_NICE_TEXT], buffer, len);
       if (!isnan(this->values[CPU_METER_IRQ])) {
-         xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_IRQ]);
+         len = xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_IRQ]);
          RichString_appendAscii(out, CRT_colors[METER_TEXT], "vir:");
-         RichString_appendAscii(out, CRT_colors[CPU_GUEST], buffer);
+         RichString_appendnAscii(out, CRT_colors[CPU_GUEST], buffer, len);
       }
    }
 
@@ -154,14 +156,14 @@ static void CPUMeter_display(const Object* cast, RichString* out) {
       char cpuTemperatureBuffer[10];
       double cpuTemperature = this->values[CPU_METER_TEMPERATURE];
       if (isnan(cpuTemperature)) {
-         xSnprintf(cpuTemperatureBuffer, sizeof(cpuTemperatureBuffer), "N/A");
+         len = xSnprintf(cpuTemperatureBuffer, sizeof(cpuTemperatureBuffer), "N/A");
       } else if (this->pl->settings->degreeFahrenheit) {
-         xSnprintf(cpuTemperatureBuffer, sizeof(cpuTemperatureBuffer), "%5.1f%sF", cpuTemperature * 9 / 5 + 32, CRT_degreeSign);
+         len = xSnprintf(cpuTemperatureBuffer, sizeof(cpuTemperatureBuffer), "%5.1f%sF", cpuTemperature * 9 / 5 + 32, CRT_degreeSign);
       } else {
-         xSnprintf(cpuTemperatureBuffer, sizeof(cpuTemperatureBuffer), "%5.1f%sC", cpuTemperature, CRT_degreeSign);
+         len = xSnprintf(cpuTemperatureBuffer, sizeof(cpuTemperatureBuffer), "%5.1f%sC", cpuTemperature, CRT_degreeSign);
       }
       RichString_appendAscii(out, CRT_colors[METER_TEXT], "temp:");
-      RichString_appendWide(out, CRT_colors[METER_VALUE], cpuTemperatureBuffer);
+      RichString_appendnWide(out, CRT_colors[METER_VALUE], cpuTemperatureBuffer, len);
    }
    #endif
 }

--- a/DiskIOMeter.c
+++ b/DiskIOMeter.c
@@ -97,10 +97,11 @@ static void DiskIOMeter_display(ATTR_UNUSED const Object* cast, RichString* out)
    }
 
    char buffer[16];
+   int len;
 
    int color = cached_utilisation_diff > 40.0 ? METER_VALUE_NOTICE : METER_VALUE;
-   xSnprintf(buffer, sizeof(buffer), "%.1f%%", cached_utilisation_diff);
-   RichString_writeAscii(out, CRT_colors[color], buffer);
+   len = xSnprintf(buffer, sizeof(buffer), "%.1f%%", cached_utilisation_diff);
+   RichString_appendnAscii(out, CRT_colors[color], buffer, len);
 
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " read: ");
    Meter_humanUnit(buffer, cached_read_diff, sizeof(buffer));

--- a/LoadAverageMeter.c
+++ b/LoadAverageMeter.c
@@ -60,12 +60,14 @@ static void LoadAverageMeter_updateValues(Meter* this) {
 static void LoadAverageMeter_display(const Object* cast, RichString* out) {
    const Meter* this = (const Meter*)cast;
    char buffer[20];
-   xSnprintf(buffer, sizeof(buffer), "%.2f ", this->values[0]);
-   RichString_writeAscii(out, CRT_colors[LOAD_AVERAGE_ONE], buffer);
-   xSnprintf(buffer, sizeof(buffer), "%.2f ", this->values[1]);
-   RichString_appendAscii(out, CRT_colors[LOAD_AVERAGE_FIVE], buffer);
-   xSnprintf(buffer, sizeof(buffer), "%.2f ", this->values[2]);
-   RichString_appendAscii(out, CRT_colors[LOAD_AVERAGE_FIFTEEN], buffer);
+   int len;
+
+   len = xSnprintf(buffer, sizeof(buffer), "%.2f ", this->values[0]);
+   RichString_appendnAscii(out, CRT_colors[LOAD_AVERAGE_ONE], buffer, len);
+   len = xSnprintf(buffer, sizeof(buffer), "%.2f ", this->values[1]);
+   RichString_appendnAscii(out, CRT_colors[LOAD_AVERAGE_FIVE], buffer, len);
+   len = xSnprintf(buffer, sizeof(buffer), "%.2f ", this->values[2]);
+   RichString_appendnAscii(out, CRT_colors[LOAD_AVERAGE_FIFTEEN], buffer, len);
 }
 
 static void LoadMeter_updateValues(Meter* this) {
@@ -90,8 +92,10 @@ static void LoadMeter_updateValues(Meter* this) {
 static void LoadMeter_display(const Object* cast, RichString* out) {
    const Meter* this = (const Meter*)cast;
    char buffer[20];
-   xSnprintf(buffer, sizeof(buffer), "%.2f ", this->values[0]);
-   RichString_writeAscii(out, CRT_colors[LOAD], buffer);
+   int len;
+
+   len = xSnprintf(buffer, sizeof(buffer), "%.2f ", this->values[0]);
+   RichString_appendnAscii(out, CRT_colors[LOAD], buffer, len);
 }
 
 const MeterClass LoadAverageMeter_class = {

--- a/NetworkIOMeter.c
+++ b/NetworkIOMeter.c
@@ -103,6 +103,7 @@ static void NetworkIOMeter_display(ATTR_UNUSED const Object* cast, RichString* o
    }
 
    char buffer[64];
+   int len;
 
    RichString_writeAscii(out, CRT_colors[METER_TEXT], "rx: ");
    Meter_humanUnit(buffer, cached_rxb_diff, sizeof(buffer));
@@ -114,8 +115,8 @@ static void NetworkIOMeter_display(ATTR_UNUSED const Object* cast, RichString* o
    RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], buffer);
    RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], "iB/s");
 
-   xSnprintf(buffer, sizeof(buffer), " (%u/%u packets) ", cached_rxp_diff, cached_txp_diff);
-   RichString_appendAscii(out, CRT_colors[METER_TEXT], buffer);
+   len = xSnprintf(buffer, sizeof(buffer), " (%u/%u packets) ", cached_rxp_diff, cached_txp_diff);
+   RichString_appendnAscii(out, CRT_colors[METER_TEXT], buffer, len);
 }
 
 const MeterClass NetworkIOMeter_class = {

--- a/OptionItem.c
+++ b/OptionItem.c
@@ -53,7 +53,7 @@ static void NumberItem_display(const Object* cast, RichString* out) {
    } else {
       written = xSnprintf(buffer, sizeof(buffer), "%d", NumberItem_get(this));
    }
-   RichString_appendAscii(out, CRT_colors[CHECK_MARK], buffer);
+   RichString_appendnAscii(out, CRT_colors[CHECK_MARK], buffer, written);
    RichString_appendAscii(out, CRT_colors[CHECK_BOX], "]");
    for (int i = written; i < 5; i++) {
       RichString_appendAscii(out, CRT_colors[CHECK_BOX], " ");

--- a/Process.c
+++ b/Process.c
@@ -402,7 +402,7 @@ void Process_writeField(const Process* this, RichString* str, ProcessField field
       assert(0 && "Process_writeField: default key reached"); /* should never be reached */
       xSnprintf(buffer, n, "- ");
    }
-   RichString_appendWide(str, attr, buffer);
+   RichString_appendAscii(str, attr, buffer);
 }
 
 void Process_display(const Object* cast, RichString* out) {

--- a/TasksMeter.c
+++ b/TasksMeter.c
@@ -38,23 +38,24 @@ static void TasksMeter_display(const Object* cast, RichString* out) {
    const Meter* this = (const Meter*)cast;
    const Settings* settings = this->pl->settings;
    char buffer[20];
+   int len;
 
-   xSnprintf(buffer, sizeof(buffer), "%d", (int)this->values[2]);
-   RichString_writeAscii(out, CRT_colors[METER_VALUE], buffer);
+   len = xSnprintf(buffer, sizeof(buffer), "%d", (int)this->values[2]);
+   RichString_appendnAscii(out, CRT_colors[METER_VALUE], buffer, len);
 
    RichString_appendAscii(out, settings->hideUserlandThreads ? CRT_colors[METER_SHADOW] : CRT_colors[METER_TEXT], ", ");
-   xSnprintf(buffer, sizeof(buffer), "%d", (int)this->values[1]);
-   RichString_appendAscii(out, settings->hideUserlandThreads ? CRT_colors[METER_SHADOW] : CRT_colors[TASKS_RUNNING], buffer);
+   len = xSnprintf(buffer, sizeof(buffer), "%d", (int)this->values[1]);
+   RichString_appendnAscii(out, settings->hideUserlandThreads ? CRT_colors[METER_SHADOW] : CRT_colors[TASKS_RUNNING], buffer, len);
    RichString_appendAscii(out, settings->hideUserlandThreads ? CRT_colors[METER_SHADOW] : CRT_colors[METER_TEXT], " thr");
 
    RichString_appendAscii(out, settings->hideKernelThreads ? CRT_colors[METER_SHADOW] : CRT_colors[METER_TEXT], ", ");
-   xSnprintf(buffer, sizeof(buffer), "%d", (int)this->values[0]);
-   RichString_appendAscii(out, settings->hideKernelThreads ? CRT_colors[METER_SHADOW] : CRT_colors[TASKS_RUNNING], buffer);
+   len = xSnprintf(buffer, sizeof(buffer), "%d", (int)this->values[0]);
+   RichString_appendnAscii(out, settings->hideKernelThreads ? CRT_colors[METER_SHADOW] : CRT_colors[TASKS_RUNNING], buffer, len);
    RichString_appendAscii(out, settings->hideKernelThreads ? CRT_colors[METER_SHADOW] : CRT_colors[METER_TEXT], " kthr");
 
    RichString_appendAscii(out, CRT_colors[METER_TEXT], "; ");
-   xSnprintf(buffer, sizeof(buffer), "%d", (int)this->values[3]);
-   RichString_appendAscii(out, CRT_colors[TASKS_RUNNING], buffer);
+   len = xSnprintf(buffer, sizeof(buffer), "%d", (int)this->values[3]);
+   RichString_appendnAscii(out, CRT_colors[TASKS_RUNNING], buffer, len);
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " running");
 }
 

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -744,7 +744,7 @@ static void LinuxProcess_writeField(const Process* this, RichString* str, Proces
       Process_writeField(this, str, field);
       return;
    }
-   RichString_appendWide(str, attr, buffer);
+   RichString_appendAscii(str, attr, buffer);
 }
 
 static double adjustNaN(double num) {

--- a/linux/PressureStallMeter.c
+++ b/linux/PressureStallMeter.c
@@ -53,12 +53,14 @@ static void PressureStallMeter_updateValues(Meter* this) {
 static void PressureStallMeter_display(const Object* cast, RichString* out) {
    const Meter* this = (const Meter*)cast;
    char buffer[20];
-   xSnprintf(buffer, sizeof(buffer), "%5.2lf%% ", this->values[0]);
-   RichString_writeAscii(out, CRT_colors[PRESSURE_STALL_TEN], buffer);
-   xSnprintf(buffer, sizeof(buffer), "%5.2lf%% ", this->values[1]);
-   RichString_appendAscii(out, CRT_colors[PRESSURE_STALL_SIXTY], buffer);
-   xSnprintf(buffer, sizeof(buffer), "%5.2lf%% ", this->values[2]);
-   RichString_appendAscii(out, CRT_colors[PRESSURE_STALL_THREEHUNDRED], buffer);
+   int len;
+
+   len = xSnprintf(buffer, sizeof(buffer), "%5.2lf%% ", this->values[0]);
+   RichString_appendnAscii(out, CRT_colors[PRESSURE_STALL_TEN], buffer, len);
+   len = xSnprintf(buffer, sizeof(buffer), "%5.2lf%% ", this->values[1]);
+   RichString_appendnAscii(out, CRT_colors[PRESSURE_STALL_SIXTY], buffer, len);
+   len = xSnprintf(buffer, sizeof(buffer), "%5.2lf%% ", this->values[2]);
+   RichString_appendnAscii(out, CRT_colors[PRESSURE_STALL_THREEHUNDRED], buffer, len);
 }
 
 const MeterClass PressureStallCPUSomeMeter_class = {

--- a/linux/SystemdMeter.c
+++ b/linux/SystemdMeter.c
@@ -305,6 +305,7 @@ static int valueDigitColor(unsigned int value) {
 
 static void SystemdMeter_display(ATTR_UNUSED const Object* cast, RichString* out) {
    char buffer[16];
+   int len;
 
    int color = (systemState && String_eq(systemState, "running")) ? METER_VALUE_OK : METER_VALUE_ERROR;
    RichString_writeAscii(out, CRT_colors[color], systemState ? systemState : "N/A");
@@ -314,40 +315,44 @@ static void SystemdMeter_display(ATTR_UNUSED const Object* cast, RichString* out
    if (nFailedUnits == INVALID_VALUE) {
       buffer[0] = '?';
       buffer[1] = '\0';
+      len = 1;
    } else {
-      xSnprintf(buffer, sizeof(buffer), "%u", nFailedUnits);
+      len = xSnprintf(buffer, sizeof(buffer), "%u", nFailedUnits);
    }
-   RichString_appendAscii(out, zeroDigitColor(nFailedUnits), buffer);
+   RichString_appendnAscii(out, zeroDigitColor(nFailedUnits), buffer, len);
 
    RichString_appendAscii(out, CRT_colors[METER_TEXT], "/");
 
    if (nNames == INVALID_VALUE) {
       buffer[0] = '?';
       buffer[1] = '\0';
+      len = 1;
    } else {
-      xSnprintf(buffer, sizeof(buffer), "%u", nNames);
+      len = xSnprintf(buffer, sizeof(buffer), "%u", nNames);
    }
-   RichString_appendAscii(out, valueDigitColor(nNames), buffer);
+   RichString_appendnAscii(out, valueDigitColor(nNames), buffer, len);
 
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " failed) (");
 
    if (nJobs == INVALID_VALUE) {
       buffer[0] = '?';
       buffer[1] = '\0';
+      len = 1;
    } else {
-      xSnprintf(buffer, sizeof(buffer), "%u", nJobs);
+      len = xSnprintf(buffer, sizeof(buffer), "%u", nJobs);
    }
-   RichString_appendAscii(out, zeroDigitColor(nJobs), buffer);
+   RichString_appendnAscii(out, zeroDigitColor(nJobs), buffer, len);
 
    RichString_appendAscii(out, CRT_colors[METER_TEXT], "/");
 
    if (nInstalledJobs == INVALID_VALUE) {
       buffer[0] = '?';
       buffer[1] = '\0';
+      len = 1;
    } else {
-      xSnprintf(buffer, sizeof(buffer), "%u", nInstalledJobs);
+      len = xSnprintf(buffer, sizeof(buffer), "%u", nInstalledJobs);
    }
-   RichString_appendAscii(out, valueDigitColor(nInstalledJobs), buffer);
+   RichString_appendnAscii(out, valueDigitColor(nInstalledJobs), buffer, len);
 
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " jobs)");
 }

--- a/zfs/ZfsCompressedArcMeter.c
+++ b/zfs/ZfsCompressedArcMeter.c
@@ -32,12 +32,12 @@ void ZfsCompressedArcMeter_readStats(Meter* this, const ZfsArcStats* stats) {
    }
 }
 
-static void ZfsCompressedArcMeter_printRatioString(const Meter* this, char* buffer, size_t size) {
+static int ZfsCompressedArcMeter_printRatioString(const Meter* this, char* buffer, size_t size) {
    if (this->values[0] > 0) {
-      xSnprintf(buffer, size, "%.2f:1", this->total / this->values[0]);
-   } else {
-      xSnprintf(buffer, size, "N/A");
+      return xSnprintf(buffer, size, "%.2f:1", this->total / this->values[0]);
    }
+
+   return xSnprintf(buffer, size, "N/A");
 }
 
 static void ZfsCompressedArcMeter_updateValues(Meter* this) {
@@ -51,14 +51,16 @@ static void ZfsCompressedArcMeter_display(const Object* cast, RichString* out) {
 
    if (this->values[0] > 0) {
       char buffer[50];
+      int len;
+
       Meter_humanUnit(buffer, this->total, sizeof(buffer));
       RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
       RichString_appendAscii(out, CRT_colors[METER_TEXT], " Uncompressed, ");
       Meter_humanUnit(buffer, this->values[0], sizeof(buffer));
       RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
       RichString_appendAscii(out, CRT_colors[METER_TEXT], " Compressed, ");
-      ZfsCompressedArcMeter_printRatioString(this, buffer, sizeof(buffer));
-      RichString_appendAscii(out, CRT_colors[ZFS_RATIO], buffer);
+      len = ZfsCompressedArcMeter_printRatioString(this, buffer, sizeof(buffer));
+      RichString_appendnAscii(out, CRT_colors[ZFS_RATIO], buffer, len);
       RichString_appendAscii(out, CRT_colors[METER_TEXT], " Ratio");
    } else {
       RichString_writeAscii(out, CRT_colors[METER_TEXT], " ");


### PR DESCRIPTION
* Use RichString_appendnAscii where possible

  `RichString_appendnAscii()` avoids a `strlen(3)` call over `RichString_appendAscii()`.
Use the former where the length is available from a previous checked `snprintf(3)` call.

 * Process: print default buffer in ascii

   `RichString_appendWide()` is more expensive than `RichString_appendAscii()` due to the calls to `mbstowcs(3)` and `iswprint(3)`.

   Use the latter to print the process field buffer by default.

   For the following fields this theoretically can corrupt the output:
    - TTY

* LinuxProcess: print default buffer in ascii

  `RichString_appendWide()` is more expensive than `RichString_appendAscii()` due to the calls to `mbstowcs(3)` and
`iswprint(3)`.

  Use the latter to print the process field buffer by default.

  For the following fields this theoretically can corrupt the output:
    - SECATTR
    - CGROUP
    - CTID

