### PR TITLE
Darwin: obtain CPU data using Intel Power Gadget

### DIFF
--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -117,11 +117,17 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    Panel_add(super, (Object*) CheckItem_newByRef("Update process names on every refresh", &(settings->updateProcessNames)));
    Panel_add(super, (Object*) CheckItem_newByRef("Add guest time in CPU meter percentage", &(settings->accountGuestInCPUMeter)));
    Panel_add(super, (Object*) CheckItem_newByRef("Also show CPU percentage numerically", &(settings->showCPUUsage)));
+   #if !defined(HTOP_DARWIN)
    Panel_add(super, (Object*) CheckItem_newByRef("Also show CPU frequency", &(settings->showCPUFrequency)));
+   #elif defined(HAVE_POWER_GADGET)
+   Panel_add(super, (Object*) CheckItem_newByRef("Also show CPU frequency (requires Intel Power Gadget)", &(settings->showCPUFrequency)));
+   #endif
    #ifdef BUILD_WITH_CPU_TEMP
    Panel_add(super, (Object*) CheckItem_newByRef(
    #if defined(HTOP_LINUX)
                                                  "Also show CPU temperature (requires libsensors)",
+   #elif defined(HTOP_DARWIN) && defined(HAVE_POWER_GADGET)
+                                                 "Also show CPU temperature (requires Intel Power Gadget)",
    #elif defined(HTOP_FREEBSD)
                                                  "Also show CPU temperature",
    #else

--- a/configure.ac
+++ b/configure.ac
@@ -299,6 +299,33 @@ if test "$enable_static" = yes; then
    AC_SEARCH_LIBS([Gpm_GetEvent], [gpm])
 fi
 
+AC_ARG_ENABLE([power-gadget],
+              [AS_HELP_STRING([--enable-power-gadget],
+                              [enable Intel Power Gadget support for obtaining CPU frequencies @<:@default=no@:>@])],
+              [],
+              [enable_power_gadget=no])
+case "$enable_power_gadget" in
+   no)
+      ;;
+   yes)
+      if test "$my_htop_platform" != darwin; then
+         AC_MSG_ERROR([the Intel Power Gadget is only supported on macOS])
+      fi
+
+      AC_COMPILE_IFELSE([
+         AC_LANG_PROGRAM(
+         [[#include <IntelPowerGadget/PowerGadgetLib.h>]],
+         [[PG_Initialize();]])],
+         [
+         AC_DEFINE([HAVE_POWER_GADGET], [1], [Using Intel Power Gadget for CPU frequencies])
+         LIBS="$LIBS -weak_framework IntelPowerGadget"
+         ],
+         [AC_MSG_ERROR([can not use IntelPowerGadget])], [-framework IntelPowerGadget])
+      ;;
+   *)
+      AC_MSG_ERROR([bad value '$enable_power_gadget' for --enable-power-gadget])
+      ;;
+esac
 
 AC_ARG_ENABLE([hwloc],
               [AS_HELP_STRING([--enable-hwloc],
@@ -509,7 +536,7 @@ case "$enable_sensors" in
       AC_MSG_ERROR([bad value '$enable_sensors' for --enable-sensors])
       ;;
 esac
-if test "$enable_sensors" = yes || test "$my_htop_platform" = freebsd; then
+if test "$enable_sensors" = yes || test "$my_htop_platform" = freebsd || test "$enable_power_gadget" = yes; then
    AC_DEFINE([BUILD_WITH_CPU_TEMP], [1], [Define if CPU temperature option should be enabled.])
 fi
 

--- a/darwin/DarwinProcessList.h
+++ b/darwin/DarwinProcessList.h
@@ -25,6 +25,14 @@ typedef struct DarwinProcessList_ {
    uint64_t user_threads;
    uint64_t global_diff;
 
+#ifdef HAVE_POWER_GADGET
+   bool initialized_power_gadget;
+   int cpu_count;
+   double *cpu_freqs;
+   double *cpu_temps;
+   uint64_t *cpu_samples;
+#endif
+
    ZfsArcStats zfs;
 } DarwinProcessList;
 

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -231,8 +231,14 @@ double Platform_setCPUValues(Meter* mtr, unsigned int cpu) {
    /* Convert to percent and return */
    total = mtr->values[CPU_METER_NICE] + mtr->values[CPU_METER_NORMAL] + mtr->values[CPU_METER_KERNEL];
 
+#ifdef HAVE_POWER_GADGET
+   // cpu is indexed from 1, but the array from 0
+   mtr->values[CPU_METER_FREQUENCY] = dpl->cpu_freqs[cpu - 1];
+   mtr->values[CPU_METER_TEMPERATURE] = dpl->cpu_temps[cpu - 1];
+#else
    mtr->values[CPU_METER_FREQUENCY] = NAN;
    mtr->values[CPU_METER_TEMPERATURE] = NAN;
+#endif
 
    return CLAMP(total, 0.0, 100.0);
 }


### PR DESCRIPTION
The [Intel Power Gadget](https://software.intel.com/content/www/us/en/develop/articles/intel-power-gadget.html) is a proprietary framework and driver from Intel, which allows user-space processes to query the CPU.  This PR adds support for using it for obtaining CPU frequencies and temperatures using it. Since the library might not be available at runtime, I've made the build system link against it weakly.

I've never contributed to `htop` before, and I'm not sure what your standards are, but I thought I'd post it here.