### PR TITLE
FreeBSD: scale CPU% usage on swap time

### DIFF
--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -442,6 +442,13 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
       return;
    }
 
+   int ccpu;
+   size_t size = sizeof(ccpu);
+   if (sysctlbyname("kern.ccpu", &ccpu, &size, NULL, 0) == -1) {
+      ccpu = 0;
+   }
+   const double decayfactor = log(ccpu / kernelFScale);
+
    int count = 0;
    const struct kinfo_proc* kprocs = kvm_getprocs(fpl->kd, KERN_PROC_PROC, 0, &count);
 
@@ -504,7 +511,7 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
       proc->nlwp = kproc->ki_numthreads;
       proc->time = (kproc->ki_runtime + 5000) / 10000;
 
-      proc->percent_cpu = 100.0 * ((double)kproc->ki_pctcpu / (double)kernelFScale);
+      proc->percent_cpu = 100.0 * ((double)kproc->ki_pctcpu / (double)kernelFScale) / (1.0 - exp(kproc->ki_swtime * decayfactor));
       proc->percent_mem = 100.0 * proc->m_resident / (double)(super->totalMem);
 
       if (kproc->ki_stat == SRUN && kproc->ki_oncpu != NOCPU) {


### PR DESCRIPTION
See https://forums.freebsd.org/threads/how-does-cpu-utilization-is-calculates.12108/
and https://ess.cs.tu-dortmund.de/lockdoc-elixir/freebsd-lockdoc/lockdoc-v13.0-0.6/source/bin/ps/print.c#L650

Closes: #602