### PR TITLE
RFC: Drop setting accountGuestInCPUMeter

### DIFF
--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -115,7 +115,6 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    Panel_add(super, (Object*) CheckItem_newByRef("Detailed CPU time (System/IO-Wait/Hard-IRQ/Soft-IRQ/Steal/Guest)", &(settings->detailedCPUTime)));
    Panel_add(super, (Object*) CheckItem_newByRef("Count CPUs from 1 instead of 0", &(settings->countCPUsFromOne)));
    Panel_add(super, (Object*) CheckItem_newByRef("Update process names on every refresh", &(settings->updateProcessNames)));
-   Panel_add(super, (Object*) CheckItem_newByRef("Add guest time in CPU meter percentage", &(settings->accountGuestInCPUMeter)));
    Panel_add(super, (Object*) CheckItem_newByRef("Also show CPU percentage numerically", &(settings->showCPUUsage)));
    Panel_add(super, (Object*) CheckItem_newByRef("Also show CPU frequency", &(settings->showCPUFrequency)));
    #ifdef BUILD_WITH_CPU_TEMP

--- a/Settings.c
+++ b/Settings.c
@@ -213,8 +213,6 @@ static bool Settings_read(Settings* this, const char* fileName, unsigned int ini
       #endif
       } else if (String_eq(option[0], "update_process_names")) {
          this->updateProcessNames = atoi(option[1]);
-      } else if (String_eq(option[0], "account_guest_in_cpu_meter")) {
-         this->accountGuestInCPUMeter = atoi(option[1]);
       } else if (String_eq(option[0], "delay")) {
          this->delay = CLAMP(atoi(option[1]), 1, 255);
       } else if (String_eq(option[0], "color_scheme")) {
@@ -320,7 +318,6 @@ int Settings_write(const Settings* this) {
    fprintf(fd, "degree_fahrenheit=%d\n", (int) this->degreeFahrenheit);
    #endif
    fprintf(fd, "update_process_names=%d\n", (int) this->updateProcessNames);
-   fprintf(fd, "account_guest_in_cpu_meter=%d\n", (int) this->accountGuestInCPUMeter);
    fprintf(fd, "color_scheme=%d\n", (int) this->colorScheme);
    fprintf(fd, "enable_mouse=%d\n", (int) this->enableMouse);
    fprintf(fd, "delay=%d\n", (int) this->delay);

--- a/Settings.h
+++ b/Settings.h
@@ -62,7 +62,6 @@ typedef struct Settings_ {
    bool stripExeFromCmdline;
    bool showMergedCommand;
    bool updateProcessNames;
-   bool accountGuestInCPUMeter;
    bool headerMargin;
    bool enableMouse;
    int hideFunctionBar;  // 0 - off, 1 - on ESC until next input, 2 - permanently

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -261,11 +261,7 @@ double Platform_setCPUValues(Meter* this, unsigned int cpu) {
       v[CPU_METER_GUEST]   = cpuData->guestPeriod / total * 100.0;
       v[CPU_METER_IOWAIT]  = cpuData->ioWaitPeriod / total * 100.0;
       this->curItems = 8;
-      if (this->pl->settings->accountGuestInCPUMeter) {
-         percent = v[0] + v[1] + v[2] + v[3] + v[4] + v[5] + v[6];
-      } else {
-         percent = v[0] + v[1] + v[2] + v[3] + v[4];
-      }
+      percent = v[0] + v[1] + v[2] + v[3] + v[4] + v[5] + v[6];
    } else {
       v[2] = cpuData->systemAllPeriod / total * 100.0;
       v[3] = (cpuData->stealPeriod + cpuData->guestPeriod) / total * 100.0;


### PR DESCRIPTION
Introduced in 8ace29c267ba.

This setting affects only Linux.
In the source data /proc/stat from the kernel, the Guest and Guest-Nice
parts are already included in User and Nice.
Htop accounts for that by subtracting them accordingly:
https://github.com/htop-dev/htop/blob/feec16cbb53dabc6a52ef2f69a6a13798be82617/linux/LinuxProcessList.c#L1787-L1789

With the setting accountGuestInCPUMeter disabled these Guest and Guest-
Nice and the Steal CPU share percentage utilizations are not counted
towards the total CPU utilization, but only if detailedCPUTime is
simultaneously enabled.
This is kind of unintuitive and only has the limited affect on the
summed total CPU utilization in a CPU Bar Meter:
[||||||||| X.X%]

Drop this setting and always count the hypervisor related shares Steal
and Guest to the total percentage sum.