### PR TITLE
Use libunwind for printing backtrace

### DIFF
--- a/CRT.c
+++ b/CRT.c
@@ -21,12 +21,20 @@ in the source distribution for its full text.
 #include "ProvideCurses.h"
 #include "XUtils.h"
 
-#ifdef HAVE_EXECINFO_H
-#include <execinfo.h>
-#endif
-
 #if !defined(NDEBUG) && defined(HAVE_MEMFD_CREATE)
 #include <sys/mman.h>
+#endif
+
+#if defined(HAVE_LIBUNWIND_H) && defined(HAVE_LIBUNWIND)
+# define PRINT_BACKTRACE
+# define UNW_LOCAL_ONLY
+# include <libunwind.h>
+# if defined(HAVE_DLADDR)
+#  include <dlfcn.h>
+# endif
+#elif defined(HAVE_EXECINFO_H)
+# define PRINT_BACKTRACE
+# include <execinfo.h>
 #endif
 
 
@@ -1006,6 +1014,59 @@ void CRT_setColors(int colorScheme) {
    CRT_colors = CRT_colorSchemes[colorScheme];
 }
 
+#ifdef PRINT_BACKTRACE
+static void print_backtrace(void) {
+#if defined(HAVE_LIBUNWIND_H) && defined(HAVE_LIBUNWIND)
+   unw_context_t context;
+   unw_getcontext(&context);
+
+   unw_cursor_t cursor;
+   unw_init_local(&cursor, &context);
+
+   unsigned int item = 0;
+
+   while (unw_step(&cursor) > 0) {
+      unw_word_t pc;
+      unw_get_reg(&cursor, UNW_REG_IP, &pc);
+      if (pc == 0)
+         break;
+
+      char symbolName[256] = "?";
+      unw_word_t offset = 0;
+      unw_get_proc_name(&cursor, symbolName, sizeof(symbolName), &offset);
+
+      unw_proc_info_t pip;
+      pip.unwind_info = NULL;
+
+      const char* fname = "?";
+      const void* ptr = 0;
+      if (unw_get_proc_info(&cursor, &pip) == 0) {
+         ptr = (const void*)(pip.start_ip + offset);
+
+         #ifdef HAVE_DLADDR
+         Dl_info dlinfo;
+         if (dladdr(ptr, &dlinfo) && dlinfo.dli_fname && *dlinfo.dli_fname)
+            fname = dlinfo.dli_fname;
+         #endif
+      }
+
+      const char* frame = "";
+      if (unw_is_signal_frame(&cursor) > 0)
+         frame = "{signal frame}";
+
+      fprintf(stderr, "%2u: %#14lx  %s  (%s+%#lx)  [%p]%s%s\n", item++, pc, fname, symbolName, offset, ptr, frame ? "  " : "", frame);
+   }
+#elif defined(HAVE_EXECINFO_H)
+   void* backtraceArray[256];
+
+   size_t size = backtrace(backtraceArray, ARRAYSIZE(backtraceArray));
+   backtrace_symbols_fd(backtraceArray, size, STDERR_FILENO);
+#else
+#error No implementation for print_backtrace()!
+#endif
+}
+#endif
+
 void CRT_handleSIGSEGV(int signal) {
    CRT_done();
 
@@ -1020,7 +1081,7 @@ void CRT_handleSIGSEGV(int signal) {
       "  - Likely steps to reproduce (How did it happen?)\n"
    );
 
-#ifdef HAVE_EXECINFO_H
+#ifdef PRINT_BACKTRACE
    fprintf(stderr, "  - Backtrace of the issue (see below)\n");
 #endif
 
@@ -1046,16 +1107,14 @@ void CRT_handleSIGSEGV(int signal) {
    Settings_write(CRT_crashSettings, true);
    fprintf(stderr, "\n\n");
 
-#ifdef HAVE_EXECINFO_H
+#ifdef PRINT_BACKTRACE
    fprintf(stderr,
       "Backtrace information:\n"
       "----------------------\n"
    );
 
-   void* backtraceArray[256];
+   print_backtrace();
 
-   size_t size = backtrace(backtraceArray, ARRAYSIZE(backtraceArray));
-   backtrace_symbols_fd(backtraceArray, size, STDERR_FILENO);
    fprintf(stderr,
       "\n"
       "To make the above information more practical to work with, "

--- a/configure.ac
+++ b/configure.ac
@@ -253,6 +253,7 @@ AC_SEARCH_LIBS([clock_gettime], [rt])
 
 AC_CHECK_FUNCS([ \
     clock_gettime \
+    dladdr \
     faccessat \
     fstatat \
     host_get_clock_service \
@@ -260,9 +261,6 @@ AC_CHECK_FUNCS([ \
     openat \
     readlinkat \
    ])
-
-# Add -lexecinfo if needed
-AC_SEARCH_LIBS([backtrace], [execinfo])
 
 if test "$my_htop_platform" = darwin; then
    AC_CHECK_FUNCS([mach_timebase_info])
@@ -409,6 +407,36 @@ if test "x$enable_affinity" = xyes; then
 fi
 
 
+AC_ARG_ENABLE([unwind],
+              [AS_HELP_STRING([--enable-unwind],
+              [enable unwind support for printing backtraces; requires libunwind @<:@default=check@:>@])],
+              [],
+              [enable_unwind=check])
+case "$enable_unwind" in
+   check)
+      enable_unwind=yes
+      if test "$enable_static" = yes; then
+         AC_CHECK_LIB([lzma], [lzma_index_buffer_decode])
+      fi
+      AC_CHECK_LIB([unwind], [backtrace], [], [enable_unwind=no])
+      AC_CHECK_HEADERS([libunwind.h], [], [enable_unwind=no])
+      ;;
+   no)
+      ;;
+   yes)
+      AC_CHECK_LIB([unwind], [backtrace], [], [AC_MSG_ERROR([can not find required library libunwind])])
+      AC_CHECK_HEADERS([libunwind.h], [], [AC_MSG_ERROR([can not find require header file libunwind.h])])
+      ;;
+   *)
+      AC_MSG_ERROR([bad value '$enable_unwind' for --enable-unwind])
+      ;;
+esac
+if test "x$enable_unwind" = xno; then
+   # Fall back to backtrace(3) and add -lexecinfo if needed
+   AC_SEARCH_LIBS([backtrace], [execinfo])
+fi
+
+
 AC_ARG_ENABLE([hwloc],
               [AS_HELP_STRING([--enable-hwloc],
               [enable hwloc support for CPU affinity; disables affinity support; requires libhwloc @<:@default=no@:>@])],
@@ -425,6 +453,7 @@ case "$enable_hwloc" in
       AC_MSG_ERROR([bad value '$enable_hwloc' for --enable-hwloc])
       ;;
 esac
+
 
 AC_ARG_WITH([os-release],
             [AS_HELP_STRING([--with-os-release=FILE],
@@ -715,6 +744,7 @@ AC_MSG_RESULT([
   (Linux) capabilities:      $enable_capabilities
   unicode:                   $enable_unicode
   affinity:                  $enable_affinity
+  unwind:                    $enable_unwind
   hwloc:                     $enable_hwloc
   debug:                     $enable_debug
   static:                    $enable_static


### PR DESCRIPTION
On Linux:
```
---
0x7fe2a58be140: (funlockfile+0x50)
0x7fe2a570fce1: (gsignal+0x141)
0x7fe2a56f9537: (abort+0x123)
0x7fe2a56f940f: -- unable to obtain symbol name
0x7fe2a5708662: (__assert_fail+0x42)
      0x540500: (ProcessList_scan+0xd30)
      0x4e756a: (CommandLine_run+0x74a)
      0x5053b3: (main+0x13)
0x7fe2a56fad0a: (__libc_start_main+0xea)
      0x427aaa: (_start+0x2a)
---
```

and FreeBSD:
```
---
   0x8004e5e00: -- unable to obtain symbol name
   0x8004e53cf: -- unable to obtain symbol name
0x7ffffffff003: -- unable to obtain symbol name
   0x800684f29: -- unable to obtain symbol name
   0x8005b2f81: -- unable to obtain symbol name
      0x366221: (ProcessList_scan+0xe51)
      0x304dd1: (CommandLine_run+0x761)
      0x3259a3: (main+0x13)
      0x270190: (_start+0x100)
   0x8003ce008: -- unable to obtain symbol name
---
```