### PR TITLE
Linux: add reset to heuristic

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -1161,7 +1161,7 @@ static int skipPotentialPath(const char* cmdline, int end) {
 void Process_updateCmdline(Process* this, const char* cmdline, int basenameStart, int basenameEnd) {
    assert(basenameStart >= 0);
    assert((cmdline && basenameStart < (int)strlen(cmdline)) || (!cmdline && basenameStart == 0));
-   assert(basenameEnd >= 0);
+   assert((basenameEnd > basenameStart) || (basenameEnd == 0 && basenameStart == 0));
    assert((cmdline && basenameEnd <= (int)strlen(cmdline)) || (!cmdline && basenameEnd == 0));
 
    if (!this->cmdline && !cmdline)

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -1123,6 +1123,13 @@ static bool LinuxProcessList_readCmdlineFile(Process* process, openat_arg_t proc
             }
          }
       }
+
+      /* Some command lines are hard to parse, like
+       *   file.so [kdeinit5] file local:/run/user/1000/klauncherdqbouY.1.slave-socket local:/run/user/1000/kded5TwsDAx.1.slave-socket
+       * Reset if start is behind end.
+       */
+      if (tokenStart >= tokenEnd)
+         tokenStart = tokenEnd = 0;
    }
 
    if (tokenEnd == 0) {


### PR DESCRIPTION
On hard to parse command lines tokenStart might be computed to be bigger
than tokenEnd.
Reset both values in such cases.