### PR TITLE
Linux: drop O_PATH usage and update process uid on change

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -963,6 +963,7 @@ void Process_init(Process* this, const Settings* settings) {
    this->show = true;
    this->updated = false;
    this->cmdlineBasenameEnd = -1;
+   this->st_uid = (uid_t)-1;
 
    if (Process_getuid == (uid_t)-1) {
       Process_getuid = getuid();

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -380,7 +380,7 @@ static bool LinuxProcessList_readStatFile(Process* process, openat_arg_t procFd,
 }
 
 
-static bool LinuxProcessList_statProcessDir(Process* process, openat_arg_t procFd) {
+static bool LinuxProcessList_updateUser(ProcessList* processList, Process* process, openat_arg_t procFd) {
    struct stat sstat;
 #ifdef HAVE_OPENAT
    int statok = fstat(procFd, &sstat);
@@ -389,7 +389,12 @@ static bool LinuxProcessList_statProcessDir(Process* process, openat_arg_t procF
 #endif
    if (statok == -1)
       return false;
-   process->st_uid = sstat.st_uid;
+
+   if (process->st_uid != sstat.st_uid) {
+      process->st_uid = sstat.st_uid;
+      process->user = UsersTable_getRef(processList->usersTable, sstat.st_uid);
+   }
+
    return true;
 }
 
@@ -1372,12 +1377,10 @@ static bool LinuxProcessList_recurseProcTree(LinuxProcessList* this, openat_arg_
       proc->percent_cpu = CLAMP(percent_cpu, 0.0F, cpus * 100.0F);
       proc->percent_mem = proc->m_resident / (double)(pl->totalMem) * 100.0;
 
+      if (! LinuxProcessList_updateUser(pl, proc, procFd))
+         goto errorReadingProcess;
+
       if (!preExisting) {
-
-         if (! LinuxProcessList_statProcessDir(proc, procFd))
-            goto errorReadingProcess;
-
-         proc->user = UsersTable_getRef(pl->usersTable, proc->st_uid);
 
          #ifdef HAVE_OPENVZ
          if (settings->flags & PROCESS_FLAG_LINUX_OPENVZ) {

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -60,12 +60,6 @@ in the source distribution for its full text.
 #endif
 
 
-// CentOS 6's kernel doesn't provide a definition of O_PATH
-// based on definition taken from uapi/asm-generic/fcnth.h in Linux kernel tree
-#ifndef O_PATH
-# define O_PATH 010000000
-#endif
-
 static long long btime = -1;
 
 static long jiffy;
@@ -1304,7 +1298,7 @@ static bool LinuxProcessList_recurseProcTree(LinuxProcessList* this, openat_arg_
       proc->isUserlandThread = proc->pid != proc->tgid;
 
 #ifdef HAVE_OPENAT
-      int procFd = openat(dirFd, entry->d_name, O_PATH | O_DIRECTORY | O_NOFOLLOW);
+      int procFd = openat(dirFd, entry->d_name, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
       if (procFd < 0)
          goto errorReadingProcess;
 #else


### PR DESCRIPTION
* O_PATH is available since Linux 2.6.39, but we are using fstat(2) on the returned file descriptor in LinuxProcessList_statProcessDir(), which is only supported since Linux 3.6.

  Fixes #534

* Always check if the user of a process changed, e.g. by using setuid(2).

