### PR TITLE
Linux: handle offline CPUs when getting frequencies

### DIFF
--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -1825,24 +1825,24 @@ static inline double LinuxProcessList_scanCPUTime(ProcessList* super) {
 }
 
 static bool cpuIsOnline(unsigned int cpuId) {
-      /* if there's no sysfs file for the CPU node indicating online/offline status,
-       * the CPU is probably online, so assume online by default
-       */
-      bool online = 1;
-      char pathBuffer[48];
+   /* if there's no sysfs file for the CPU node indicating online/offline status,
+    * the CPU is probably online, so assume online by default
+    */
+   bool online = 1;
+   char pathBuffer[48];
 
-      xSnprintf(pathBuffer, sizeof(pathBuffer), "/sys/devices/system/cpu/cpu%u/online", cpuId);
+   xSnprintf(pathBuffer, sizeof(pathBuffer), "/sys/devices/system/cpu/cpu%u/online", cpuId);
 
-      FILE* file = fopen(pathBuffer, "r");
-      unsigned int readval;
-      if (file) {
-         if (fscanf(file, "%u", &readval) == 1) {
-            online = readval;
-         }
-         fclose(file);
+   FILE* file = fopen(pathBuffer, "r");
+   unsigned int readval;
+   if (file) {
+      if (fscanf(file, "%u", &readval) == 1) {
+         online = readval;
       }
+      fclose(file);
+   }
 
-      return online;
+   return online;
 }
 
 static int getConfiguredCPUCount(void) {

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -1829,7 +1829,7 @@ static bool cpuIsOnline(unsigned int cpuId) {
        * the CPU is probably online, so assume online by default
        */
       bool online = 1;
-      char pathBuffer[64];
+      char pathBuffer[48];
 
       xSnprintf(pathBuffer, sizeof(pathBuffer), "/sys/devices/system/cpu/cpu%u/online", cpuId);
 


### PR DESCRIPTION
Fixes: #648 

When getting frequencies from CPUFreq, the CPU nodes in sysfs are iterated from 0 to M-1 where M is the number of configured CPUs in the system and which should include offline ones as well, thus allowing for iterating through the full number of possible CPUs. The ones that are offline according to sysfs are ignored, and frequencies are fetched for up to N others where N is the number for which CPUData entries have been allocated.

When getting frequencies from `/proc/cpuinfo`, the CPU nodes and their frequencies are just taken in the order in which they appear. Offline CPUs do not seem to appear in `cpuinfo`, so they're automatically skipped. The CPU IDs from `cpuinfo` are ignored, apart from checking the output line format.

Possible issues that I can think of:

- The sysconf variable `_SC_NPROCESSORS_CONF` used for getting the total number of CPUs here (in the CPUFreq code path) isn't standard, but it seems to have been mentioned on the Linux man page `sysconf(3)` since circa 2011.
- It might not be the best idea to check the online status of every CPU node separately from sysfs. I don't know how fast or slow reading that information is, or if it has performance implications if there's a large number of CPUs or cores. It might be possible to parse e.g. `/sys/devices/system/cpu/online` for a list of online CPUs instead, which would require a bit of work to do properly but would allow for a single read.
- The `/proc/cpuinfo` code path in its form suggested here assumes that offline CPUs do not appear and that the online nodes appear in the order of their CPU IDs. The author of the previous code didn't seem to want to make that assumption, and I'm not sure if it's valid.

Any feedback is welcome!