### PR TITLE
Limit deleted library check

### DIFF
--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -1354,7 +1354,8 @@ static bool LinuxProcessList_recurseProcTree(LinuxProcessList* this, openat_arg_
       {
          bool prev = proc->usesDeletedLib;
 
-         if ((lp->m_lrs == 0 && (settings->flags & PROCESS_FLAG_LINUX_LRS_FIX)) || settings->highlightDeletedExe) {
+         if ((lp->m_lrs == 0 && (settings->flags & PROCESS_FLAG_LINUX_LRS_FIX)) ||
+             (settings->highlightDeletedExe && !proc->procExeDeleted && !proc->isKernelThread && !proc->isUserlandThread)) {
             // Check if we really should recalculate the M_LRS value for this process
             uint64_t passedTimeInMs = pl->realtimeMs - lp->last_mlrs_calctime;
 
@@ -1365,8 +1366,8 @@ static bool LinuxProcessList_recurseProcTree(LinuxProcessList* this, openat_arg_
                LinuxProcessList_readMaps(lp, procFd, settings->flags & PROCESS_FLAG_LINUX_LRS_FIX, settings->highlightDeletedExe);
             }
          } else {
-            /* reset if setting got disabled */
-            proc->usesDeletedLib = false;
+            /* Copy from process structure in threads and reset if setting got disabled */
+            proc->usesDeletedLib = (proc->isUserlandThread && parent) ? parent->usesDeletedLib : false;
          }
 
          proc->mergedCommand.exeChanged |= prev ^ proc->usesDeletedLib;


### PR DESCRIPTION
Reading and parsing `/proc/<pid>/maps` is quite expensive.

Do not check for deleted libraries if the main binary has been deleted;
in this case the deleted binary takes precedence.

Do not check in threads.  The check is void for kernel threads and user-
land threads can just inherit the state from the main process structure.