### PR TITLE
Rework CPU counting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: ./configure --enable-werror --enable-linux-affinity --disable-unicode --disable-sensors
+      run: ./configure --enable-werror --enable-affinity --disable-unicode --disable-sensors
     - name: Enable compatibility modes
       run: |
         sed -i 's/#define HAVE_FSTATAT 1/#undef HAVE_FSTATAT/g' config.h
@@ -26,7 +26,7 @@ jobs:
     - name: Build
       run: make -k
     - name: Distcheck
-      run: make distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-werror --enable-linux-affinity --disable-unicode --disable-sensors"
+      run: make distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-werror --enable-affinity --disable-unicode --disable-sensors"
 
   build-ubuntu-latest-minimal-clang:
     runs-on: ubuntu-latest
@@ -44,11 +44,11 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: ./configure --enable-werror --enable-linux-affinity --disable-unicode --disable-sensors
+      run: ./configure --enable-werror --enable-affinity --disable-unicode --disable-sensors
     - name: Build
       run: make -k
     - name: Distcheck
-      run: make distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-werror --enable-linux-affinity --disable-unicode --disable-sensors"
+      run: make distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-werror --enable-affinity --disable-unicode --disable-sensors"
 
   build-ubuntu-latest-full-featured-gcc:
     runs-on: ubuntu-latest

--- a/Action.c
+++ b/Action.c
@@ -302,7 +302,7 @@ static Htop_Reaction actionSetAffinity(State* st) {
    if (Settings_isReadonly())
       return HTOP_OK;
 
-   if (st->pl->cpuCount == 1)
+   if (st->pl->activeCPUs == 1)
       return HTOP_OK;
 
 #if (defined(HAVE_LIBHWLOC) || defined(HAVE_LINUX_AFFINITY))

--- a/Action.c
+++ b/Action.c
@@ -34,7 +34,7 @@ in the source distribution for its full text.
 #include "Vector.h"
 #include "XUtils.h"
 
-#if (defined(HAVE_LIBHWLOC) || defined(HAVE_LINUX_AFFINITY))
+#if (defined(HAVE_LIBHWLOC) || defined(HAVE_AFFINITY))
 #include "Affinity.h"
 #include "AffinityPanel.h"
 #endif
@@ -305,7 +305,7 @@ static Htop_Reaction actionSetAffinity(State* st) {
    if (st->pl->activeCPUs == 1)
       return HTOP_OK;
 
-#if (defined(HAVE_LIBHWLOC) || defined(HAVE_LINUX_AFFINITY))
+#if (defined(HAVE_LIBHWLOC) || defined(HAVE_AFFINITY))
    const Process* p = (const Process*) Panel_getSelected((Panel*)st->mainPanel);
    if (!p)
       return HTOP_OK;
@@ -328,8 +328,11 @@ static Htop_Reaction actionSetAffinity(State* st) {
       Affinity_delete(affinity2);
    }
    Object_delete(affinityPanel);
-#endif
    return HTOP_REFRESH | HTOP_REDRAW_BAR | HTOP_UPDATE_PANELHDR;
+#else
+   return HTOP_OK;
+#endif
+
 }
 
 static Htop_Reaction actionKill(State* st) {
@@ -484,7 +487,7 @@ static const struct {
    { .key = "   F9 k: ", .roInactive = true,  .info = "kill process/tagged processes" },
    { .key = "   F7 ]: ", .roInactive = true,  .info = "higher priority (root only)" },
    { .key = "   F8 [: ", .roInactive = false, .info = "lower priority (+ nice)" },
-#if (defined(HAVE_LIBHWLOC) || defined(HAVE_LINUX_AFFINITY))
+#if (defined(HAVE_LIBHWLOC) || defined(HAVE_AFFINITY))
    { .key = "      a: ", .roInactive = true, .info = "set CPU affinity" },
 #endif
    { .key = "      e: ", .roInactive = false, .info = "show process environment" },

--- a/Affinity.c
+++ b/Affinity.c
@@ -22,7 +22,7 @@ in the source distribution for its full text.
 #else
 #define HTOP_HWLOC_CPUBIND_FLAG HWLOC_CPUBIND_PROCESS
 #endif
-#elif defined(HAVE_LINUX_AFFINITY)
+#elif defined(HAVE_AFFINITY)
 #include <sched.h>
 #endif
 
@@ -84,7 +84,7 @@ bool Affinity_set(Process* proc, Arg arg) {
    return ok;
 }
 
-#elif defined(HAVE_LINUX_AFFINITY)
+#elif defined(HAVE_AFFINITY)
 
 Affinity* Affinity_get(const Process* proc, ProcessList* pl) {
    cpu_set_t cpuset;

--- a/Affinity.c
+++ b/Affinity.c
@@ -59,7 +59,7 @@ Affinity* Affinity_get(const Process* proc, ProcessList* pl) {
    if (ok) {
       affinity = Affinity_new(pl);
       if (hwloc_bitmap_last(cpuset) == -1) {
-         for (unsigned int i = 0; i < pl->cpuCount; i++) {
+         for (unsigned int i = 0; i < pl->existingCPUs; i++) {
             Affinity_add(affinity, i);
          }
       } else {
@@ -93,7 +93,7 @@ Affinity* Affinity_get(const Process* proc, ProcessList* pl) {
       return NULL;
 
    Affinity* affinity = Affinity_new(pl);
-   for (unsigned int i = 0; i < pl->cpuCount; i++) {
+   for (unsigned int i = 0; i < pl->existingCPUs; i++) {
       if (CPU_ISSET(i, &cpuset)) {
          Affinity_add(affinity, i);
       }

--- a/Affinity.h
+++ b/Affinity.h
@@ -12,7 +12,7 @@ in the source distribution for its full text.
 
 #include "ProcessList.h"
 
-#if defined(HAVE_LIBHWLOC) || defined(HAVE_LINUX_AFFINITY)
+#if defined(HAVE_LIBHWLOC) || defined(HAVE_AFFINITY)
 #include <stdbool.h>
 
 #include "Object.h"
@@ -20,8 +20,8 @@ in the source distribution for its full text.
 #endif
 
 
-#if defined(HAVE_LIBHWLOC) && defined(HAVE_LINUX_AFFINITY)
-#error hwloc and linux affinity are mutual exclusive.
+#if defined(HAVE_LIBHWLOC) && defined(HAVE_AFFINITY)
+#error hwloc and affinity support are mutual exclusive.
 #endif
 
 
@@ -38,12 +38,12 @@ void Affinity_delete(Affinity* this);
 
 void Affinity_add(Affinity* this, unsigned int id);
 
-#if defined(HAVE_LIBHWLOC) || defined(HAVE_LINUX_AFFINITY)
+#if defined(HAVE_LIBHWLOC) || defined(HAVE_AFFINITY)
 
 Affinity* Affinity_get(const Process* proc, ProcessList* pl);
 
 bool Affinity_set(Process* proc, Arg arg);
 
-#endif /* HAVE_LIBHWLOC || HAVE_LINUX_AFFINITY */
+#endif /* HAVE_LIBHWLOC || HAVE_AFFINITY */
 
 #endif

--- a/AffinityPanel.c
+++ b/AffinityPanel.c
@@ -383,7 +383,8 @@ Panel* AffinityPanel_new(ProcessList* pl, const Affinity* affinity, int* width) 
    Panel_setHeader(super, "Use CPUs:");
 
    unsigned int curCpu = 0;
-   for (unsigned int i = 0; i < pl->cpuCount; i++) {
+   for (unsigned int i = 0; i < pl->existingCPUs; i++) {
+      /* TODO: skip offline CPUs */
       char number[16];
       xSnprintf(number, 9, "CPU %d", Settings_cpuId(pl->settings, i));
       unsigned cpu_width = 4 + strlen(number);
@@ -427,7 +428,8 @@ Affinity* AffinityPanel_getAffinity(Panel* super, ProcessList* pl) {
    Affinity_add(affinity, i);
    hwloc_bitmap_foreach_end();
    #else
-   for (unsigned int i = 0; i < this->pl->cpuCount; i++) {
+   for (unsigned int i = 0; i < this->pl->existingCPUs; i++) {
+      /* TODO: skip offline CPUs */
       const MaskItem* item = (const MaskItem*)Vector_get(this->cpuids, i);
       if (item->value) {
          Affinity_add(affinity, item->cpu);

--- a/AffinityPanel.c
+++ b/AffinityPanel.c
@@ -384,7 +384,9 @@ Panel* AffinityPanel_new(ProcessList* pl, const Affinity* affinity, int* width) 
 
    unsigned int curCpu = 0;
    for (unsigned int i = 0; i < pl->existingCPUs; i++) {
-      /* TODO: skip offline CPUs */
+      if (!ProcessList_isCPUonline(this->pl, i))
+         continue;
+
       char number[16];
       xSnprintf(number, 9, "CPU %d", Settings_cpuId(pl->settings, i));
       unsigned cpu_width = 4 + strlen(number);
@@ -428,8 +430,7 @@ Affinity* AffinityPanel_getAffinity(Panel* super, ProcessList* pl) {
    Affinity_add(affinity, i);
    hwloc_bitmap_foreach_end();
    #else
-   for (unsigned int i = 0; i < this->pl->existingCPUs; i++) {
-      /* TODO: skip offline CPUs */
+   for (int i = 0; i < Vector_size(this->cpuids); i++) {
       const MaskItem* item = (const MaskItem*)Vector_get(this->cpuids, i);
       if (item->value) {
          Affinity_add(affinity, item->cpu);

--- a/AvailableMetersPanel.c
+++ b/AvailableMetersPanel.c
@@ -94,9 +94,9 @@ const PanelClass AvailableMetersPanel_class = {
 
 // Handle (&CPUMeter_class) entries in the AvailableMetersPanel
 static void AvailableMetersPanel_addCPUMeters(Panel* super, const MeterClass* type, const ProcessList* pl) {
-   if (pl->cpuCount > 1) {
+   if (pl->existingCPUs > 1) {
       Panel_add(super, (Object*) ListItem_new("CPU average", 0));
-      for (unsigned int i = 1; i <= pl->cpuCount; i++) {
+      for (unsigned int i = 1; i <= pl->existingCPUs; i++) {
          char buffer[50];
          xSnprintf(buffer, sizeof(buffer), "%s %d", type->uiName, Settings_cpuId(pl->settings, i - 1));
          Panel_add(super, (Object*) ListItem_new(buffer, i));

--- a/CommandLine.c
+++ b/CommandLine.c
@@ -295,7 +295,7 @@ int CommandLine_run(const char* name, int argc, char** argv) {
    Hashtable* dm = DynamicMeters_new();
    ProcessList* pl = ProcessList_new(ut, dm, flags.pidMatchList, flags.userId);
 
-   Settings* settings = Settings_new(pl->cpuCount);
+   Settings* settings = Settings_new(pl->activeCPUs);
    pl->settings = settings;
 
    Header* header = Header_new(pl, settings, 2);

--- a/LoadAverageMeter.c
+++ b/LoadAverageMeter.c
@@ -47,12 +47,12 @@ static void LoadAverageMeter_updateValues(Meter* this) {
    if (this->values[0] < 1.0) {
       this->curAttributes = OK_attributes;
       this->total = 1.0;
-   } else if (this->values[0] < this->pl->cpuCount) {
+   } else if (this->values[0] < this->pl->activeCPUs) {
       this->curAttributes = Medium_attributes;
-      this->total = this->pl->cpuCount;
+      this->total = this->pl->activeCPUs;
    } else {
       this->curAttributes = High_attributes;
-      this->total = 2 * this->pl->cpuCount;
+      this->total = 2 * this->pl->activeCPUs;
    }
 
    xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%.2f/%.2f/%.2f", this->values[0], this->values[1], this->values[2]);
@@ -79,12 +79,12 @@ static void LoadMeter_updateValues(Meter* this) {
    if (this->values[0] < 1.0) {
       this->curAttributes = OK_attributes;
       this->total = 1.0;
-   } else if (this->values[0] < this->pl->cpuCount) {
+   } else if (this->values[0] < this->pl->activeCPUs) {
       this->curAttributes = Medium_attributes;
-      this->total = this->pl->cpuCount;
+      this->total = this->pl->activeCPUs;
    } else {
       this->curAttributes = High_attributes;
-      this->total = 2 * this->pl->cpuCount;
+      this->total = 2 * this->pl->activeCPUs;
    }
 
    xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%.2f", this->values[0]);

--- a/Process.c
+++ b/Process.c
@@ -821,7 +821,7 @@ void Process_writeField(const Process* this, RichString* str, ProcessField field
    case PERCENT_NORM_CPU: {
       float cpuPercentage = this->percent_cpu;
       if (field == PERCENT_NORM_CPU) {
-         cpuPercentage /= this->processList->cpuCount;
+         cpuPercentage /= this->processList->activeCPUs;
       }
       if (cpuPercentage > 999.9F) {
          xSnprintf(buffer, n, "%4u ", (unsigned int)cpuPercentage);

--- a/ProcessList.c
+++ b/ProcessList.c
@@ -34,7 +34,8 @@ ProcessList* ProcessList_init(ProcessList* this, const ObjectClass* klass, Users
    this->userId = userId;
 
    // set later by platform-specific code
-   this->cpuCount = 0;
+   this->activeCPUs = 0;
+   this->existingCPUs = 0;
    this->monotonicMs = 0;
 
    // always maintain valid realtime timestamps

--- a/ProcessList.h
+++ b/ProcessList.h
@@ -87,9 +87,11 @@ typedef struct ProcessList_ {
    unsigned int existingCPUs;
 } ProcessList;
 
+/* Implemented by platforms */
 ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* dynamicMeters, Hashtable* pidMatchList, uid_t userId);
 void ProcessList_delete(ProcessList* pl);
 void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate);
+bool ProcessList_isCPUonline(const ProcessList* super, unsigned int id);
 
 
 ProcessList* ProcessList_init(ProcessList* this, const ObjectClass* klass, UsersTable* usersTable, Hashtable* dynamicMeters, Hashtable* pidMatchList, uid_t userId);

--- a/ProcessList.h
+++ b/ProcessList.h
@@ -83,7 +83,8 @@ typedef struct ProcessList_ {
    memory_t usedSwap;
    memory_t cachedSwap;
 
-   unsigned int cpuCount;
+   unsigned int activeCPUs;
+   unsigned int existingCPUs;
 } ProcessList;
 
 ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* dynamicMeters, Hashtable* pidMatchList, uid_t userId);

--- a/README
+++ b/README
@@ -80,8 +80,11 @@ To install on the local system run `make install`. By default `make install` ins
     enable Performance Co-Pilot support via a new pcp-htop utility
     dependency: *libpcp*
     default: *no*
+  * `--enable-affinity`:
+    enable `sched_setaffinity(2)` and `sched_getaffinity(2)` for affinity support; conflicts with hwloc
+    default: *check*
   * `--enable-hwloc`:
-    enable hwloc support for CPU affinity; disables Linux affinity
+    enable hwloc support for CPU affinity; disables affinity support
     dependency: *libhwloc*
     default: *no*
   * `--enable-static`:
@@ -113,9 +116,6 @@ To install on the local system run `make install`. By default `make install` ins
   * `--enable-ancient-vserver`:
     enable ancient VServer support (implies `--enable-vserver`)
     default: *no*
-   * `--enable-linux-affinity`:
-    enable Linux `sched_setaffinity(2)` and `sched_getaffinity(2)` for affinity support; conflicts with hwloc
-    default: *check*
   * `--enable-delayacct`:
     enable Linux delay accounting support
     dependencies: *pkg-config*(build-time), *libnl-3* and *libnl-genl-3*

--- a/TasksMeter.c
+++ b/TasksMeter.c
@@ -28,7 +28,7 @@ static void TasksMeter_updateValues(Meter* this) {
    this->values[0] = pl->kernelThreads;
    this->values[1] = pl->userlandThreads;
    this->values[2] = pl->totalTasks - pl->kernelThreads - pl->userlandThreads;
-   this->values[3] = MINIMUM(pl->runningTasks, pl->cpuCount);
+   this->values[3] = MINIMUM(pl->runningTasks, pl->activeCPUs);
    this->total     = pl->totalTasks;
 
    xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%d/%d", (int) this->values[3], (int) this->total);

--- a/UptimeMeter.c
+++ b/UptimeMeter.c
@@ -19,7 +19,7 @@ static const int UptimeMeter_attributes[] = {
 
 static void UptimeMeter_updateValues(Meter* this) {
    int totalseconds = Platform_getUptime();
-   if (totalseconds == -1) {
+   if (totalseconds <= 0) {
       xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "(unknown)");
       return;
    }

--- a/configure.ac
+++ b/configure.ac
@@ -355,9 +355,44 @@ AC_CHECK_FUNCS( [set_escdelay] )
 AC_CHECK_FUNCS( [getmouse] )
 
 
+AC_ARG_ENABLE([affinity],
+              [AS_HELP_STRING([--enable-affinity],
+                              [enable sched_setaffinity and sched_getaffinity for affinity support, conflicts with hwloc @<:@default=check@:>@])],
+              [],
+              [enable_affinity=check])
+if test "x$enable_affinity" = xcheck; then
+   if test "x$enable_hwloc" = xyes; then
+      enable_affinity=no
+   else
+      AC_MSG_CHECKING([for usable sched_setaffinity])
+      AC_RUN_IFELSE([
+         AC_LANG_PROGRAM([[
+            #include <sched.h>
+            #include <errno.h>
+            static cpu_set_t cpuset;
+         ]], [[
+            CPU_ZERO(&cpuset);
+            sched_setaffinity(0, sizeof(cpu_set_t), &cpuset);
+            if (errno == ENOSYS) return 1;
+         ]])],
+      [enable_affinity=yes
+         AC_MSG_RESULT([yes])],
+      [enable_affinity=no
+         AC_MSG_RESULT([no])],
+      [AC_MSG_RESULT([yes (assumed while cross compiling)])])
+   fi
+fi
+if test "x$enable_affinity" = xyes; then
+   if test "x$enable_hwloc" = xyes; then
+      AC_MSG_ERROR([--enable-hwloc and --enable-affinity are mutual exclusive. Specify at most one of them.])
+   fi
+   AC_DEFINE([HAVE_AFFINITY], [1], [Define if sched_setaffinity and sched_getaffinity are to be used.])
+fi
+
+
 AC_ARG_ENABLE([hwloc],
               [AS_HELP_STRING([--enable-hwloc],
-              [enable hwloc support for CPU affinity; disables Linux affinity; requires libhwloc @<:@default=no@:>@])],
+              [enable hwloc support for CPU affinity; disables affinity support; requires libhwloc @<:@default=no@:>@])],
               [],
               [enable_hwloc=no])
 case "$enable_hwloc" in
@@ -430,41 +465,6 @@ AC_ARG_ENABLE([ancient_vserver],
 if test "x$enable_ancient_vserver" = xyes; then
     AC_DEFINE([HAVE_VSERVER], [1], [Define if VServer support enabled.])
     AC_DEFINE([HAVE_ANCIENT_VSERVER], [1], [Define if ancient vserver support enabled.])
-fi
-
-
-AC_ARG_ENABLE([linux_affinity],
-              [AS_HELP_STRING([--enable-linux-affinity],
-                              [enable Linux sched_setaffinity and sched_getaffinity for affinity support, conflicts with hwloc @<:@default=check@:>@])],
-              [],
-              [enable_linux_affinity=check])
-if test "x$enable_linux_affinity" = xcheck; then
-   if test "x$enable_hwloc" = xyes; then
-      enable_linux_affinity=no
-   else
-      AC_MSG_CHECKING([for usable sched_setaffinity])
-      AC_RUN_IFELSE([
-         AC_LANG_PROGRAM([[
-            #include <sched.h>
-            #include <errno.h>
-            static cpu_set_t cpuset;
-         ]], [[
-            CPU_ZERO(&cpuset);
-            sched_setaffinity(0, sizeof(cpu_set_t), &cpuset);
-            if (errno == ENOSYS) return 1;
-         ]])],
-      [enable_linux_affinity=yes
-         AC_MSG_RESULT([yes])],
-      [enable_linux_affinity=no
-         AC_MSG_RESULT([no])],
-      [AC_MSG_RESULT([yes (assumed while cross compiling)])])
-   fi
-fi
-if test "x$enable_linux_affinity" = xyes; then
-   if test "x$enable_hwloc" = xyes; then
-      AC_MSG_ERROR([--enable-hwloc and --enable-linux-affinity are mutual exclusive. Specify at most one of them.])
-   fi
-   AC_DEFINE([HAVE_LINUX_AFFINITY], [1], [Define if Linux sched_setaffinity and sched_getaffinity are to be used.])
 fi
 
 
@@ -688,11 +688,11 @@ AC_MSG_RESULT([
   (Linux) openvz:            $enable_openvz
   (Linux) vserver:           $enable_vserver
   (Linux) ancient vserver:   $enable_ancient_vserver
-  (Linux) affinity:          $enable_linux_affinity
   (Linux) delay accounting:  $enable_delayacct
   (Linux) sensors:           $enable_sensors
   (Linux) capabilities:      $enable_capabilities
   unicode:                   $enable_unicode
+  affinity:                  $enable_affinity
   hwloc:                     $enable_hwloc
   debug:                     $enable_debug
   static:                    $enable_static

--- a/darwin/DarwinProcessList.c
+++ b/darwin/DarwinProcessList.c
@@ -236,3 +236,12 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
 
    free(ps);
 }
+
+bool ProcessList_isCPUonline(const ProcessList* super, unsigned int id) {
+   assert(id < super->existingCPUs);
+
+   // TODO: support offline CPUs and hot swapping
+   (void) super; (void) id;
+
+   return true;
+}

--- a/darwin/DarwinProcessList.h
+++ b/darwin/DarwinProcessList.h
@@ -34,4 +34,6 @@ void ProcessList_delete(ProcessList* this);
 
 void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate);
 
+bool ProcessList_isCPUonline(const ProcessList* super, unsigned int id);
+
 #endif

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -186,21 +186,21 @@ int Platform_getMaxPid() {
 
 static double Platform_setCPUAverageValues(Meter* mtr) {
    const ProcessList* dpl = mtr->pl;
-   unsigned int cpus = dpl->cpuCount;
+   unsigned int activeCPUs = dpl->activeCPUs;
    double sumNice = 0.0;
    double sumNormal = 0.0;
    double sumKernel = 0.0;
    double sumPercent = 0.0;
-   for (unsigned int i = 1; i <= cpus; i++) {
+   for (unsigned int i = 1; i <= dpl->existingCPUs; i++) {
       sumPercent += Platform_setCPUValues(mtr, i);
       sumNice    += mtr->values[CPU_METER_NICE];
       sumNormal  += mtr->values[CPU_METER_NORMAL];
       sumKernel  += mtr->values[CPU_METER_KERNEL];
    }
-   mtr->values[CPU_METER_NICE]   = sumNice   / cpus;
-   mtr->values[CPU_METER_NORMAL] = sumNormal / cpus;
-   mtr->values[CPU_METER_KERNEL] = sumKernel / cpus;
-   return sumPercent / cpus;
+   mtr->values[CPU_METER_NICE]   = sumNice   / activeCPUs;
+   mtr->values[CPU_METER_NORMAL] = sumNormal / activeCPUs;
+   mtr->values[CPU_METER_KERNEL] = sumKernel / activeCPUs;
+   return sumPercent / activeCPUs;
 }
 
 double Platform_setCPUValues(Meter* mtr, unsigned int cpu) {

--- a/dragonflybsd/DragonFlyBSDProcessList.c
+++ b/dragonflybsd/DragonFlyBSDProcessList.c
@@ -95,13 +95,15 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* dynamicMeters, H
       sysctl(MIB_kern_cp_times, 2, dfpl->cp_times_o, &len, NULL, 0);
    }
 
-   pl->cpuCount = MAXIMUM(cpus, 1);
+   pl->existingCPUs = MAXIMUM(cpus, 1);
+   // TODO: support offline CPUs and hot swapping
+   pl->activeCPUs = pl->existingCPUs;
 
    if (cpus == 1 ) {
       dfpl->cpus = xRealloc(dfpl->cpus, sizeof(CPUData));
    } else {
       // on smp we need CPUs + 1 to store averages too (as kernel kindly provides that as well)
-      dfpl->cpus = xRealloc(dfpl->cpus, (pl->cpuCount + 1) * sizeof(CPUData));
+      dfpl->cpus = xRealloc(dfpl->cpus, (pl->existingCPUs + 1) * sizeof(CPUData));
    }
 
    len = sizeof(kernelFScale);
@@ -140,8 +142,8 @@ void ProcessList_delete(ProcessList* this) {
 static inline void DragonFlyBSDProcessList_scanCPUTime(ProcessList* pl) {
    const DragonFlyBSDProcessList* dfpl = (DragonFlyBSDProcessList*) pl;
 
-   unsigned int cpus   = pl->cpuCount;   // actual CPU count
-   unsigned int maxcpu = cpus;           // max iteration (in case we have average + smp)
+   unsigned int cpus   = pl->existingCPUs;  // actual CPU count
+   unsigned int maxcpu = cpus;              // max iteration (in case we have average + smp)
    int cp_times_offset;
 
    assert(cpus > 0);

--- a/dragonflybsd/DragonFlyBSDProcessList.c
+++ b/dragonflybsd/DragonFlyBSDProcessList.c
@@ -443,8 +443,6 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
       Process* proc = ProcessList_getProcess(super, kproc->kp_ktaddr ? (pid_t)kproc->kp_ktaddr : kproc->kp_pid, &preExisting, DragonFlyBSDProcess_new);
       DragonFlyBSDProcess* dfp = (DragonFlyBSDProcess*) proc;
 
-      proc->show = ! ((hideKernelThreads && Process_isKernelThread(proc)) || (hideUserlandThreads && Process_isUserlandThread(proc)));
-
       if (!preExisting) {
          dfp->jid = kproc->kp_jailid;
          if (kproc->kp_ktaddr && kproc->kp_flags & P_SYSTEM) {
@@ -597,6 +595,7 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
       if (proc->state == 'R')
          super->runningTasks++;
 
+      proc->show = ! ((hideKernelThreads && Process_isKernelThread(proc)) || (hideUserlandThreads && Process_isUserlandThread(proc)));
       proc->updated = true;
    }
 }

--- a/dragonflybsd/DragonFlyBSDProcessList.c
+++ b/dragonflybsd/DragonFlyBSDProcessList.c
@@ -432,7 +432,6 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
 
    int count = 0;
 
-   // TODO Kernel Threads seem to be skipped, need to figure out the correct flag
    const struct kinfo_proc* kprocs = kvm_getprocs(dfpl->kd, KERN_PROC_ALL | (!hideUserlandThreads ? KERN_PROC_FLAG_LWP : 0), 0, &count);
 
    for (int i = 0; i < count; i++) {

--- a/dragonflybsd/DragonFlyBSDProcessList.c
+++ b/dragonflybsd/DragonFlyBSDProcessList.c
@@ -601,3 +601,12 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
       proc->updated = true;
    }
 }
+
+bool ProcessList_isCPUonline(const ProcessList* super, unsigned int id) {
+   assert(id < super->existingCPUs);
+
+   // TODO: support offline CPUs and hot swapping
+   (void) super; (void) id;
+
+   return true;
+}

--- a/dragonflybsd/DragonFlyBSDProcessList.h
+++ b/dragonflybsd/DragonFlyBSDProcessList.h
@@ -59,4 +59,6 @@ void ProcessList_delete(ProcessList* this);
 
 void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate);
 
+bool ProcessList_isCPUonline(const ProcessList* super, unsigned int id);
+
 #endif

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -159,7 +159,7 @@ int Platform_getMaxPid() {
 
 double Platform_setCPUValues(Meter* this, unsigned int cpu) {
    const DragonFlyBSDProcessList* fpl = (const DragonFlyBSDProcessList*) this->pl;
-   unsigned int cpus = this->pl->cpuCount;
+   unsigned int cpus = this->pl->activeCPUs;
    const CPUData* cpuData;
 
    if (cpus == 1) {

--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -495,8 +495,6 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
       Process* proc = ProcessList_getProcess(super, kproc->ki_pid, &preExisting, FreeBSDProcess_new);
       FreeBSDProcess* fp = (FreeBSDProcess*) proc;
 
-      proc->show = ! ((hideKernelThreads && Process_isKernelThread(proc)) || (hideUserlandThreads && Process_isUserlandThread(proc)));
-
       if (!preExisting) {
          fp->jid = kproc->ki_jid;
          proc->pid = kproc->ki_pid;
@@ -591,6 +589,8 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
 
       if (Process_isKernelThread(proc))
          super->kernelThreads++;
+
+      proc->show = ! ((hideKernelThreads && Process_isKernelThread(proc)) || (hideUserlandThreads && Process_isUserlandThread(proc)));
 
       super->totalTasks++;
       if (proc->state == 'R')

--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -380,16 +380,15 @@ static inline void FreeBSDProcessList_scanMemoryInfo(ProcessList* pl) {
 }
 
 static void FreeBSDProcessList_updateExe(const struct kinfo_proc* kproc, Process* proc) {
-   const int mib[] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, kproc->ki_pid };
-   char buffer[2048];
-   size_t size = sizeof(buffer);
-   if (sysctl(mib, 4, buffer, &size, NULL, 0) != 0) {
+   if (Process_isKernelThread(proc)) {
       Process_updateExe(proc, NULL);
       return;
    }
 
-   /* Kernel threads return an empty buffer */
-   if (buffer[0] == '\0') {
+   const int mib[] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, kproc->ki_pid };
+   char buffer[2048];
+   size_t size = sizeof(buffer);
+   if (sysctl(mib, 4, buffer, &size, NULL, 0) != 0) {
       Process_updateExe(proc, NULL);
       return;
    }

--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -498,7 +498,7 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
       if (!preExisting) {
          fp->jid = kproc->ki_jid;
          proc->pid = kproc->ki_pid;
-         proc->isKernelThread = kproc->ki_pid != 0 && kproc->ki_pid != 1 && (kproc->ki_flag & P_SYSTEM);
+         proc->isKernelThread = kproc->ki_pid != 1 && (kproc->ki_flag & P_SYSTEM);
          proc->isUserlandThread = false;
          proc->ppid = kproc->ki_ppid;
          proc->tpgid = kproc->ki_tpgid;

--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -599,3 +599,12 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
       proc->updated = true;
    }
 }
+
+bool ProcessList_isCPUonline(const ProcessList* super, unsigned int id) {
+   assert(id < super->existingCPUs);
+
+   // TODO: support offline CPUs and hot swapping
+   (void) super; (void) id;
+
+   return true;
+}

--- a/freebsd/FreeBSDProcessList.h
+++ b/freebsd/FreeBSDProcessList.h
@@ -53,4 +53,6 @@ void ProcessList_delete(ProcessList* this);
 
 void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate);
 
+bool ProcessList_isCPUonline(const ProcessList* super, unsigned int id);
+
 #endif

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -181,7 +181,7 @@ int Platform_getMaxPid() {
 
 double Platform_setCPUValues(Meter* this, unsigned int cpu) {
    const FreeBSDProcessList* fpl = (const FreeBSDProcessList*) this->pl;
-   unsigned int cpus = this->pl->cpuCount;
+   unsigned int cpus = this->pl->activeCPUs;
    const CPUData* cpuData;
 
    if (cpus == 1) {

--- a/linux/LibSensors.h
+++ b/linux/LibSensors.h
@@ -8,9 +8,10 @@
 #include "linux/LinuxProcessList.h"
 
 
-int LibSensors_init(FILE* input);
+int LibSensors_init(void);
 void LibSensors_cleanup(void);
+int LibSensors_reload(void);
 
-void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int cpuCount);
+void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, unsigned int activeCPUs);
 
 #endif /* HEADER_LibSensors */

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -2081,3 +2081,10 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
 
    LinuxProcessList_recurseProcTree(this, rootFd, PROCDIR, NULL, period);
 }
+
+bool ProcessList_isCPUonline(const ProcessList* super, unsigned int id) {
+   assert(id < super->existingCPUs);
+
+   const LinuxProcessList* this = (const LinuxProcessList*) super;
+   return this->cpuData[id + 1].online;
+}

--- a/linux/LinuxProcessList.h
+++ b/linux/LinuxProcessList.h
@@ -120,4 +120,6 @@ void ProcessList_delete(ProcessList* pl);
 
 void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate);
 
+bool ProcessList_isCPUonline(const ProcessList* super, unsigned int id);
+
 #endif

--- a/linux/LinuxProcessList.h
+++ b/linux/LinuxProcessList.h
@@ -53,6 +53,8 @@ typedef struct CPUData_ {
    #ifdef HAVE_SENSORS_SENSORS_H
    double temperature;
    #endif
+
+   bool online;
 } CPUData;
 
 typedef struct TtyDriver_ {
@@ -65,7 +67,8 @@ typedef struct TtyDriver_ {
 typedef struct LinuxProcessList_ {
    ProcessList super;
 
-   CPUData* cpus;
+   CPUData* cpuData;
+
    TtyDriver* ttyDrivers;
    bool haveSmapsRollup;
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -246,10 +246,16 @@ int Platform_getMaxPid() {
 
 double Platform_setCPUValues(Meter* this, unsigned int cpu) {
    const LinuxProcessList* pl = (const LinuxProcessList*) this->pl;
-   const CPUData* cpuData = &(pl->cpus[cpu]);
+   const CPUData* cpuData = &(pl->cpuData[cpu]);
    double total = (double) ( cpuData->totalPeriod == 0 ? 1 : cpuData->totalPeriod);
    double percent;
    double* v = this->values;
+
+   if (!cpuData->online) {
+      this->curItems = 0;
+      return NAN;
+   }
+
    v[CPU_METER_NICE] = cpuData->nicePeriod / total * 100.0;
    v[CPU_METER_NORMAL] = cpuData->userPeriod / total * 100.0;
    if (this->pl->settings->detailedCPUTime) {
@@ -1000,7 +1006,7 @@ void Platform_init(void) {
    }
 
 #ifdef HAVE_SENSORS_SENSORS_H
-   LibSensors_init(NULL);
+   LibSensors_init();
 #endif
 }
 

--- a/openbsd/OpenBSDProcessList.c
+++ b/openbsd/OpenBSDProcessList.c
@@ -173,7 +173,7 @@ static void OpenBSDProcessList_scanMemoryInfo(ProcessList* pl) {
 }
 
 static void OpenBSDProcessList_updateCwd(const struct kinfo_proc* kproc, Process* proc) {
-   const int mib[] = { CTL_KERN, KERN_PROC_CWD, kproc->ki_pid };
+   const int mib[] = { CTL_KERN, KERN_PROC_CWD, kproc->p_pid };
    char buffer[2048];
    size_t size = sizeof(buffer);
    if (sysctl(mib, 3, buffer, &size, NULL, 0) != 0) {

--- a/openbsd/OpenBSDProcessList.c
+++ b/openbsd/OpenBSDProcessList.c
@@ -447,3 +447,16 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
 
    OpenBSDProcessList_scanProcs(opl);
 }
+
+bool ProcessList_isCPUonline(const ProcessList* super, unsigned int id) {
+   assert(id < super->existingCPUs);
+
+   const OpenBSDProcessList* opl = (const OpenBSDProcessList*) super;
+
+   for (unsigned int i = 0; i < super->activeCPUs; i++) {
+      if (opl->cpus[i].cpuIndex == id)
+         return true;
+   }
+
+   return false;
+}

--- a/openbsd/OpenBSDProcessList.c
+++ b/openbsd/OpenBSDProcessList.c
@@ -36,12 +36,66 @@ static long fscale;
 static int pageSize;
 static int pageSizeKB;
 
-ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* dynamicMeters, Hashtable* pidMatchList, uid_t userId) {
+static void OpenBSDProcessList_updateCPUcount(ProcessList* super) {
+   OpenBSDProcessList* opl = (OpenBSDProcessList*) super;
    const int nmib[] = { CTL_HW, HW_NCPU };
    const int mib[] = { CTL_HW, HW_NCPUONLINE };
-   const int fmib[] = { CTL_KERN, KERN_FSCALE };
    int r;
-   unsigned int cpu_index_c = 0;
+   unsigned int value;
+   size_t size;
+   bool change = false;
+
+   size = sizeof(value);
+   r = sysctl(mib, 2, &value, &size, NULL, 0);
+   if (r < 0 || value < 1) {
+      value = 1;
+   }
+
+   if (value != super->activeCPUs) {
+      super->activeCPUs = value;
+      change = true;
+   }
+
+   size = sizeof(value);
+   r = sysctl(nmib, 2, &value, &size, NULL, 0);
+   if (r < 0 || value < 1) {
+      value = super->activeCPUs;
+   }
+
+   if (value != super->existingCPUs) {
+      opl->cpuData = xReallocArray(opl->cpuData, value + 1, sizeof(CPUData));
+      super->existingCPUs = value;
+      change = true;
+   }
+
+   if (change) {
+      CPUData* dAvg = &opl->cpuData[0];
+      memset(dAvg, '\0', sizeof(CPUData));
+      dAvg->totalTime = 1;
+      dAvg->totalPeriod = 1;
+      dAvg->online = true;
+
+      for (unsigned int i = 0; i < super->existingCPUs; i++) {
+         CPUData* d = &opl->cpuData[i + 1];
+         memset(d, '\0', sizeof(CPUData));
+         d->totalTime = 1;
+         d->totalPeriod = 1;
+
+         const int ncmib[] = { CTL_KERN, KERN_CPUSTATS, i };
+         struct cpustats cpu_stats;
+
+         size = sizeof(cpu_stats);
+         if (sysctl(ncmib, 3, &cpu_stats, &size, NULL, 0) < 0) {
+            CRT_fatalError("ncmib sysctl call failed");
+         }
+         d->online = (cpu_stats.cs_flags & CPUSTATS_ONLINE);
+      }
+   }
+}
+
+
+ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* dynamicMeters, Hashtable* pidMatchList, uid_t userId) {
+   const int fmib[] = { CTL_KERN, KERN_FSCALE };
    size_t size;
    char errbuf[_POSIX2_LINE_MAX];
 
@@ -49,20 +103,7 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* dynamicMeters, H
    ProcessList* pl = (ProcessList*) opl;
    ProcessList_init(pl, Class(OpenBSDProcess), usersTable, dynamicMeters, pidMatchList, userId);
 
-   // TODO: test offline CPUs and hot swapping
-
-   size = sizeof(pl->activeCPUs);
-   r = sysctl(mib, 2, &pl->activeCPUs, &size, NULL, 0);
-   if (r < 0 || pl->activeCPUs < 1) {
-      pl->activeCPUs = 1;
-   }
-   opl->cpus = xCalloc(pl->activeCPUs + 1, sizeof(CPUData));
-
-   size = sizeof(int);
-   r = sysctl(nmib, 2, &pl->existingCPUs, &size, NULL, 0);
-   if (r < 0) {
-      pl->existingCPUs = pl->activeCPUs;
-   }
+   OpenBSDProcessList_updateCPUcount(pl);
 
    size = sizeof(fscale);
    if (sysctl(fmib, 2, &fscale, &size, NULL, 0) < 0) {
@@ -73,35 +114,12 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* dynamicMeters, H
       CRT_fatalError("pagesize sysconf call failed");
    pageSizeKB = pageSize / ONE_K;
 
-   for (unsigned int i = 0; i <= pl->activeCPUs; i++) {
-      CPUData* d = opl->cpus + i;
-      d->totalTime = 1;
-      d->totalPeriod = 1;
-   }
-
    opl->kd = kvm_openfiles(NULL, NULL, NULL, KVM_NO_FILES, errbuf);
    if (opl->kd == NULL) {
       CRT_fatalError("kvm_openfiles() failed");
    }
 
    opl->cpuSpeed = -1;
-
-   for (unsigned int i = 0; i < pl->existingCPUs; i++) {
-      const int ncmib[] = { CTL_KERN, KERN_CPUSTATS, i };
-      struct cpustats cpu_stats;
-
-      size = sizeof(cpu_stats);
-      if (sysctl(ncmib, 3, &cpu_stats, &size, NULL, 0) < 0) {
-         CRT_fatalError("ncmib sysctl call failed");
-      }
-      if (cpu_stats.cs_flags & CPUSTATS_ONLINE) {
-         opl->cpus[cpu_index_c].cpuIndex = i;
-         cpu_index_c++;
-      }
-
-      if (cpu_index_c == pl->activeCPUs)
-         break;
-   }
 
    return pl;
 }
@@ -113,7 +131,7 @@ void ProcessList_delete(ProcessList* this) {
       kvm_close(opl->kd);
    }
 
-   free(opl->cpus);
+   free(opl->cpuData);
 
    ProcessList_done(this);
    free(this);
@@ -275,8 +293,6 @@ static void OpenBSDProcessList_scanProcs(OpenBSDProcessList* this) {
       Process* proc = ProcessList_getProcess(&this->super, (kproc->p_tid == -1) ? kproc->p_pid : kproc->p_tid, &preExisting, OpenBSDProcess_new);
       OpenBSDProcess* fp = (OpenBSDProcess*) proc;
 
-      proc->show = ! ((hideKernelThreads && Process_isKernelThread(proc)) || (hideUserlandThreads && Process_isUserlandThread(proc)));
-
       if (!preExisting) {
          proc->ppid = kproc->p_ppid;
          proc->tpgid = kproc->p_tpgid;
@@ -348,11 +364,13 @@ static void OpenBSDProcessList_scanProcs(OpenBSDProcessList* this) {
       if (proc->state == 'R') {
          this->super.runningTasks++;
       }
+
+      proc->show = ! ((hideKernelThreads && Process_isKernelThread(proc)) || (hideUserlandThreads && Process_isUserlandThread(proc)));
       proc->updated = true;
    }
 }
 
-static void getKernelCPUTimes(int cpuId, u_int64_t* times) {
+static void getKernelCPUTimes(unsigned int cpuId, u_int64_t* times) {
    const int mib[] = { CTL_KERN, KERN_CPTIME2, cpuId };
    size_t length = sizeof(*times) * CPUSTATES;
    if (sysctl(mib, 3, times, &length, NULL, 0) == -1 || length != sizeof(*times) * CPUSTATES) {
@@ -401,9 +419,14 @@ static void OpenBSDProcessList_scanCPUTime(OpenBSDProcessList* this) {
    u_int64_t kernelTimes[CPUSTATES] = {0};
    u_int64_t avg[CPUSTATES] = {0};
 
-   for (unsigned int i = 0; i < this->super.activeCPUs; i++) {
-      getKernelCPUTimes(this->cpus[i].cpuIndex, kernelTimes);
-      CPUData* cpu = this->cpus + i + 1;
+   for (unsigned int i = 0; i < this->super.existingCPUs; i++) {
+      CPUData* cpu = &this->cpuData[i + 1];
+
+      if (!cpu->online) {
+         continue;
+      }
+
+      getKernelCPUTimes(i, kernelTimes);
       kernelCPUTimesToHtop(kernelTimes, cpu);
 
       avg[CP_USER] += cpu->userTime;
@@ -420,7 +443,7 @@ static void OpenBSDProcessList_scanCPUTime(OpenBSDProcessList* this) {
       avg[i] /= this->super.activeCPUs;
    }
 
-   kernelCPUTimesToHtop(avg, this->cpus);
+   kernelCPUTimesToHtop(avg, &this->cpuData[0]);
 
    {
       const int mib[] = { CTL_HW, HW_CPUSPEED };
@@ -437,6 +460,7 @@ static void OpenBSDProcessList_scanCPUTime(OpenBSDProcessList* this) {
 void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
    OpenBSDProcessList* opl = (OpenBSDProcessList*) super;
 
+   OpenBSDProcessList_updateCPUcount(super);
    OpenBSDProcessList_scanMemoryInfo(super);
    OpenBSDProcessList_scanCPUTime(opl);
 
@@ -452,11 +476,5 @@ bool ProcessList_isCPUonline(const ProcessList* super, unsigned int id) {
    assert(id < super->existingCPUs);
 
    const OpenBSDProcessList* opl = (const OpenBSDProcessList*) super;
-
-   for (unsigned int i = 0; i < super->activeCPUs; i++) {
-      if (opl->cpus[i].cpuIndex == id)
-         return true;
-   }
-
-   return false;
+   return opl->cpuData[id + 1].online;
 }

--- a/openbsd/OpenBSDProcessList.h
+++ b/openbsd/OpenBSDProcessList.h
@@ -36,7 +36,7 @@ typedef struct CPUData_ {
    unsigned long long int intrPeriod;
    unsigned long long int idlePeriod;
 
-   int cpuIndex;
+   unsigned int cpuIndex;
 } CPUData;
 
 typedef struct OpenBSDProcessList_ {

--- a/openbsd/OpenBSDProcessList.h
+++ b/openbsd/OpenBSDProcessList.h
@@ -36,14 +36,14 @@ typedef struct CPUData_ {
    unsigned long long int intrPeriod;
    unsigned long long int idlePeriod;
 
-   unsigned int cpuIndex;
+   bool online;
 } CPUData;
 
 typedef struct OpenBSDProcessList_ {
    ProcessList super;
    kvm_t* kd;
 
-   CPUData* cpus;
+   CPUData* cpuData;
    int cpuSpeed;
 
 } OpenBSDProcessList;

--- a/openbsd/OpenBSDProcessList.h
+++ b/openbsd/OpenBSDProcessList.h
@@ -55,4 +55,6 @@ void ProcessList_delete(ProcessList* this);
 
 void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate);
 
+bool ProcessList_isCPUonline(const ProcessList* super, unsigned int id);
+
 #endif

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -169,19 +169,12 @@ int Platform_getMaxPid() {
 
 double Platform_setCPUValues(Meter* this, unsigned int cpu) {
    const OpenBSDProcessList* pl = (const OpenBSDProcessList*) this->pl;
-   const CPUData* cpuData = NULL;
+   const CPUData* cpuData = &(pl->cpuData[cpu]);
    double total;
    double totalPercent;
    double* v = this->values;
 
-   for (unsigned int i = 0; i < pl->super.activeCPUs; i++) {
-      if (pl->cpus[i].cpuIndex == cpu) {
-         cpuData = &(pl->cpus[i]);
-         break;
-      }
-   }
-
-   if (!cpuData) {
+   if (!cpuData->online) {
       this->curItems = 0;
       return NAN;
    }

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -169,10 +169,24 @@ int Platform_getMaxPid() {
 
 double Platform_setCPUValues(Meter* this, unsigned int cpu) {
    const OpenBSDProcessList* pl = (const OpenBSDProcessList*) this->pl;
-   const CPUData* cpuData = &(pl->cpus[cpu]);
-   double total = cpuData->totalPeriod == 0 ? 1 : cpuData->totalPeriod;
+   const CPUData* cpuData = NULL;
+   double total;
    double totalPercent;
    double* v = this->values;
+
+   for (unsigned int i = 0; i < pl->super.activeCPUs; i++) {
+      if (pl->cpus[i].cpuIndex == cpu) {
+         cpuData = &(pl->cpus[i]);
+         break;
+      }
+   }
+
+   if (!cpuData) {
+      this->curItems = 0;
+      return NAN;
+   }
+
+   total = cpuData->totalPeriod == 0 ? 1 : cpuData->totalPeriod;
 
    v[CPU_METER_NICE] = cpuData->nicePeriod / total * 100.0;
    v[CPU_METER_NORMAL] = cpuData->userPeriod / total * 100.0;

--- a/pcp/PCPProcessList.c
+++ b/pcp/PCPProcessList.c
@@ -675,3 +675,12 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
    double period = (this->timestamp - sample) * 100;
    PCPProcessList_updateProcesses(this, period, &timestamp);
 }
+
+bool ProcessList_isCPUonline(const ProcessList* super, unsigned int id) {
+   assert(id < super->existingCPUs);
+
+   // TODO: support offline CPUs and hot swapping
+   (void) super; (void) id;
+
+   return true;
+}

--- a/pcp/PCPProcessList.c
+++ b/pcp/PCPProcessList.c
@@ -33,10 +33,13 @@ static int PCPProcessList_computeCPUcount(void) {
 static void PCPProcessList_updateCPUcount(PCPProcessList* this) {
    ProcessList* pl = &(this->super);
    unsigned int cpus = PCPProcessList_computeCPUcount();
-   if (cpus == pl->cpuCount)
+   if (cpus == pl->existingCPUs)
       return;
 
-   pl->cpuCount = cpus;
+   pl->existingCPUs = cpus;
+   // TODO: support offline CPUs and hot swapping
+   pl->activeCPUs = pl->existingCPUs;
+
    free(this->percpu);
    free(this->values);
 
@@ -79,7 +82,7 @@ void ProcessList_delete(ProcessList* pl) {
    PCPProcessList* this = (PCPProcessList*) pl;
    ProcessList_done(pl);
    free(this->values);
-   for (unsigned int i = 0; i < pl->cpuCount; i++)
+   for (unsigned int i = 0; i < pl->existingCPUs; i++)
       free(this->percpu[i]);
    free(this->percpu);
    free(this->cpu);
@@ -371,7 +374,7 @@ static bool PCPProcessList_updateProcesses(PCPProcessList* this, double period, 
 
       float percent_cpu = (pp->utime + pp->stime - lasttimes) / period * 100.0;
       proc->percent_cpu = isnan(percent_cpu) ?
-                          0.0 : CLAMP(percent_cpu, 0.0, pl->cpuCount * 100.0);
+                          0.0 : CLAMP(percent_cpu, 0.0, pl->activeCPUs * 100.0);
       proc->percent_mem = proc->m_resident / (double)pl->totalMem * 100.0;
 
       PCPProcessList_updateUsername(proc, pid, offset, pl->usersTable);
@@ -539,7 +542,7 @@ static void PCPProcessList_updateAllCPUTime(PCPProcessList* this, Metric metric,
 
 static void PCPProcessList_updatePerCPUTime(PCPProcessList* this, Metric metric, CPUMetric cpumetric)
 {
-   int cpus = this->super.cpuCount;
+   int cpus = this->super.existingCPUs;
    if (Metric_values(metric, this->values, cpus, PM_TYPE_U64) == NULL)
       memset(this->values, 0, cpus * sizeof(pmAtomValue));
    for (int i = 0; i < cpus; i++)
@@ -548,7 +551,7 @@ static void PCPProcessList_updatePerCPUTime(PCPProcessList* this, Metric metric,
 
 static void PCPProcessList_updatePerCPUReal(PCPProcessList* this, Metric metric, CPUMetric cpumetric)
 {
-   int cpus = this->super.cpuCount;
+   int cpus = this->super.existingCPUs;
    if (Metric_values(metric, this->values, cpus, PM_TYPE_DOUBLE) == NULL)
       memset(this->values, 0, cpus * sizeof(pmAtomValue));
    for (int i = 0; i < cpus; i++)
@@ -608,7 +611,7 @@ static void PCPProcessList_updateHeader(ProcessList* super, const Settings* sett
    PCPProcessList_updateAllCPUTime(this, PCP_CPU_GUEST, CPU_GUEST_TIME);
    PCPProcessList_deriveCPUTime(this->cpu);
 
-   for (unsigned int i = 0; i < super->cpuCount; i++)
+   for (unsigned int i = 0; i < super->existingCPUs; i++)
       PCPProcessList_backupCPUTime(this->percpu[i]);
    PCPProcessList_updatePerCPUTime(this, PCP_PERCPU_USER, CPU_USER_TIME);
    PCPProcessList_updatePerCPUTime(this, PCP_PERCPU_NICE, CPU_NICE_TIME);
@@ -619,7 +622,7 @@ static void PCPProcessList_updateHeader(ProcessList* super, const Settings* sett
    PCPProcessList_updatePerCPUTime(this, PCP_PERCPU_SOFTIRQ, CPU_SOFTIRQ_TIME);
    PCPProcessList_updatePerCPUTime(this, PCP_PERCPU_STEAL, CPU_STEAL_TIME);
    PCPProcessList_updatePerCPUTime(this, PCP_PERCPU_GUEST, CPU_GUEST_TIME);
-   for (unsigned int i = 0; i < super->cpuCount; i++)
+   for (unsigned int i = 0; i < super->existingCPUs; i++)
       PCPProcessList_deriveCPUTime(this->percpu[i]);
 
    if (settings->showCPUFrequency)

--- a/pcp/PCPProcessList.h
+++ b/pcp/PCPProcessList.h
@@ -69,4 +69,6 @@ void ProcessList_delete(ProcessList* pl);
 
 void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate);
 
+bool ProcessList_isCPUonline(const ProcessList* super, unsigned int id);
+
 #endif

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -184,7 +184,7 @@ int Platform_getMaxPid() {
 
 double Platform_setCPUValues(Meter* this, unsigned int cpu) {
    const SolarisProcessList* spl = (const SolarisProcessList*) this->pl;
-   unsigned int cpus = this->pl->activeCPUs;
+   unsigned int cpus = this->pl->existingCPUs;
    const CPUData* cpuData = NULL;
 
    if (cpus == 1) {
@@ -192,6 +192,11 @@ double Platform_setCPUValues(Meter* this, unsigned int cpu) {
       cpuData = &(spl->cpus[0]);
    } else {
       cpuData = &(spl->cpus[cpu]);
+   }
+
+   if (!cpuData->online) {
+      this->curItems = 0;
+      return NAN;
    }
 
    double percent;

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -184,7 +184,7 @@ int Platform_getMaxPid() {
 
 double Platform_setCPUValues(Meter* this, unsigned int cpu) {
    const SolarisProcessList* spl = (const SolarisProcessList*) this->pl;
-   unsigned int cpus = this->pl->cpuCount;
+   unsigned int cpus = this->pl->activeCPUs;
    const CPUData* cpuData = NULL;
 
    if (cpus == 1) {

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -59,20 +59,24 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* dynamicMeters, H
       CRT_fatalError("Cannot get pagesize by sysconf(_SC_PAGESIZE)");
    pageSizeKB = pageSize / 1024;
 
-   pl->cpuCount = sysconf(_SC_NPROCESSORS_ONLN);
-   if (pl->cpuCount == (unsigned int)-1)
+   pl->activeCPUs = sysconf(_SC_NPROCESSORS_ONLN);
+   if (pl->activeCPUs == (unsigned int)-1)
       CRT_fatalError("Cannot get CPU count by sysconf(_SC_NPROCESSORS_ONLN)");
-   else if (pl->cpuCount == 1)
+   else if (pl->activeCPUs == 1)
       spl->cpus = xRealloc(spl->cpus, sizeof(CPUData));
    else
-      spl->cpus = xRealloc(spl->cpus, (pl->cpuCount + 1) * sizeof(CPUData));
+      spl->cpus = xRealloc(spl->cpus, (pl->activeCPUs + 1) * sizeof(CPUData));
+
+   /* TODO: support offline CPUs and hot swapping
+    * pl->existingCPUs = sysconf(_SC_NPROCESSORS_CONF) */
+   pl->existingCPUs = pl->activeCPUs;
 
    return pl;
 }
 
 static inline void SolarisProcessList_scanCPUTime(ProcessList* pl) {
    const SolarisProcessList* spl = (SolarisProcessList*) pl;
-   unsigned int cpus = pl->cpuCount;
+   unsigned int cpus = pl->existingCPUs;
    kstat_t* cpuinfo = NULL;
    kstat_named_t* idletime = NULL;
    kstat_named_t* intrtime = NULL;

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -495,3 +495,12 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
    super->kernelThreads = 1;
    proc_walk(&SolarisProcessList_walkproc, super, PR_WALK_LWP);
 }
+
+bool ProcessList_isCPUonline(const ProcessList* super, unsigned int id) {
+   assert(id < super->existingCPUs);
+
+   // TODO: support offline CPUs and hot swapping
+   (void) super; (void) id;
+
+   return true;
+}

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -47,36 +47,70 @@ static char* SolarisProcessList_readZoneName(kstat_ctl_t* kd, SolarisProcess* sp
    return zname;
 }
 
+static void SolarisProcessList_updateCPUcount(ProcessList* super) {
+   SolarisProcessList* spl = (SolarisProcessList*) super;
+   long int s;
+   bool change = false;
+
+   s = sysconf(_SC_NPROCESSORS_CONF);
+   if (s < 1)
+      CRT_fatalError("Cannot get exisitng CPU count by sysconf(_SC_NPROCESSORS_CONF)");
+
+   if (s != super->existingCPUs) {
+      if (s == 1) {
+         spl->cpus = xRealloc(spl->cpus, sizeof(CPUData));
+         spl->cpus[0].online = true;
+      } else {
+         spl->cpus = xReallocArray(spl->cpus, s + 1, sizeof(CPUData));
+         for (int i = 0; i < s + 1; i++) {
+            spl->cpus[i].online = false;
+         }
+      }
+
+      change = true;
+      super->existingCPUs = s;
+   }
+
+   s = sysconf(_SC_NPROCESSORS_ONLN);
+   if (s < 1)
+      CRT_fatalError("Cannot get active CPU count by sysconf(_SC_NPROCESSORS_ONLN)");
+
+   if (s != super->activeCPUs) {
+      change = true;
+      super->activeCPUs = s;
+   }
+
+   if (change) {
+      kstat_close(spl->kd);
+      spl->kd = kstat_open();
+      if (!spl->kd)
+         CRT_fatalError("Cannot open kstat handle");
+   }
+}
+
 ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* dynamicMeters, Hashtable* pidMatchList, uid_t userId) {
    SolarisProcessList* spl = xCalloc(1, sizeof(SolarisProcessList));
    ProcessList* pl = (ProcessList*) spl;
    ProcessList_init(pl, Class(SolarisProcess), usersTable, dynamicMeters, pidMatchList, userId);
 
    spl->kd = kstat_open();
+   if (!spl->kd)
+      CRT_fatalError("Cannot open kstat handle");
 
    pageSize = sysconf(_SC_PAGESIZE);
    if (pageSize == -1)
       CRT_fatalError("Cannot get pagesize by sysconf(_SC_PAGESIZE)");
    pageSizeKB = pageSize / 1024;
 
-   pl->activeCPUs = sysconf(_SC_NPROCESSORS_ONLN);
-   if (pl->activeCPUs == (unsigned int)-1)
-      CRT_fatalError("Cannot get CPU count by sysconf(_SC_NPROCESSORS_ONLN)");
-   else if (pl->activeCPUs == 1)
-      spl->cpus = xRealloc(spl->cpus, sizeof(CPUData));
-   else
-      spl->cpus = xRealloc(spl->cpus, (pl->activeCPUs + 1) * sizeof(CPUData));
-
-   /* TODO: support offline CPUs and hot swapping
-    * pl->existingCPUs = sysconf(_SC_NPROCESSORS_CONF) */
-   pl->existingCPUs = pl->activeCPUs;
+   SolarisProcessList_updateCPUcount(pl);
 
    return pl;
 }
 
 static inline void SolarisProcessList_scanCPUTime(ProcessList* pl) {
    const SolarisProcessList* spl = (SolarisProcessList*) pl;
-   unsigned int cpus = pl->existingCPUs;
+   unsigned int activeCPUs = pl->activeCPUs;
+   unsigned int existingCPUs = pl->existingCPUs;
    kstat_t* cpuinfo = NULL;
    kstat_named_t* idletime = NULL;
    kstat_named_t* intrtime = NULL;
@@ -89,43 +123,44 @@ static inline void SolarisProcessList_scanCPUTime(ProcessList* pl) {
    double userbuf = 0;
    int arrskip = 0;
 
-   assert(cpus > 0);
+   assert(existingCPUs > 0);
+   assert(spl->kd);
 
-   if (cpus > 1) {
+   if (existingCPUs > 1) {
       // Store values for the stats loop one extra element up in the array
       // to leave room for the average to be calculated afterwards
       arrskip++;
    }
 
    // Calculate per-CPU statistics first
-   for (unsigned int i = 0; i < cpus; i++) {
-      if (spl->kd != NULL) {
-         if ((cpuinfo = kstat_lookup_wrapper(spl->kd, "cpu", i, "sys")) != NULL) {
-            if (kstat_read(spl->kd, cpuinfo, NULL) != -1) {
-               idletime = kstat_data_lookup_wrapper(cpuinfo, "cpu_nsec_idle");
-               intrtime = kstat_data_lookup_wrapper(cpuinfo, "cpu_nsec_intr");
-               krnltime = kstat_data_lookup_wrapper(cpuinfo, "cpu_nsec_kernel");
-               usertime = kstat_data_lookup_wrapper(cpuinfo, "cpu_nsec_user");
-            }
+   for (unsigned int i = 0; i < existingCPUs; i++) {
+      CPUData* cpuData = &(spl->cpus[i + arrskip]);
+
+      if ((cpuinfo = kstat_lookup_wrapper(spl->kd, "cpu", i, "sys")) != NULL) {
+         cpuData->online = true;
+         if (kstat_read(spl->kd, cpuinfo, NULL) != -1) {
+            idletime = kstat_data_lookup_wrapper(cpuinfo, "cpu_nsec_idle");
+            intrtime = kstat_data_lookup_wrapper(cpuinfo, "cpu_nsec_intr");
+            krnltime = kstat_data_lookup_wrapper(cpuinfo, "cpu_nsec_kernel");
+            usertime = kstat_data_lookup_wrapper(cpuinfo, "cpu_nsec_user");
          }
+      } else {
+         cpuData->online = false;
+         continue;
       }
 
       assert( (idletime != NULL) && (intrtime != NULL)
            && (krnltime != NULL) && (usertime != NULL) );
 
       if (pl->settings->showCPUFrequency) {
-         if (spl->kd != NULL) {
-            if ((cpuinfo = kstat_lookup_wrapper(spl->kd, "cpu_info", i, NULL)) != NULL) {
-               if (kstat_read(spl->kd, cpuinfo, NULL) != -1) {
-                  cpu_freq = kstat_data_lookup_wrapper(cpuinfo, "current_clock_Hz");
-               }
+         if ((cpuinfo = kstat_lookup_wrapper(spl->kd, "cpu_info", i, NULL)) != NULL) {
+            if (kstat_read(spl->kd, cpuinfo, NULL) != -1) {
+               cpu_freq = kstat_data_lookup_wrapper(cpuinfo, "current_clock_Hz");
             }
          }
 
          assert( cpu_freq != NULL );
       }
-
-      CPUData* cpuData = &(spl->cpus[i + arrskip]);
 
       uint64_t totaltime = (idletime->value.ui64 - cpuData->lidle)
                          + (intrtime->value.ui64 - cpuData->lintr)
@@ -147,7 +182,7 @@ static inline void SolarisProcessList_scanCPUTime(ProcessList* pl) {
       // Add frequency in MHz
       cpuData->frequency        = pl->settings->showCPUFrequency ? (double)cpu_freq->value.ui64 / 1E6 : NAN;
       // Accumulate the current percentages into buffers for later average calculation
-      if (cpus > 1) {
+      if (existingCPUs > 1) {
          userbuf               += cpuData->userPercent;
          krnlbuf               += cpuData->systemPercent;
          intrbuf               += cpuData->irqPercent;
@@ -155,14 +190,14 @@ static inline void SolarisProcessList_scanCPUTime(ProcessList* pl) {
       }
    }
 
-   if (cpus > 1) {
+   if (existingCPUs > 1) {
       CPUData* cpuData          = &(spl->cpus[0]);
-      cpuData->userPercent      = userbuf / cpus;
+      cpuData->userPercent      = userbuf / activeCPUs;
       cpuData->nicePercent      = (double)0.0; // Not implemented on Solaris
-      cpuData->systemPercent    = krnlbuf / cpus;
-      cpuData->irqPercent       = intrbuf / cpus;
+      cpuData->systemPercent    = krnlbuf / activeCPUs;
+      cpuData->irqPercent       = intrbuf / activeCPUs;
       cpuData->systemAllPercent = cpuData->systemPercent + cpuData->irqPercent;
-      cpuData->idlePercent      = idlebuf / cpus;
+      cpuData->idlePercent      = idlebuf / activeCPUs;
    }
 }
 
@@ -483,6 +518,7 @@ static int SolarisProcessList_walkproc(psinfo_t* _psinfo, lwpsinfo_t* _lwpsinfo,
 }
 
 void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
+   SolarisProcessList_updateCPUcount(super);
    SolarisProcessList_scanCPUTime(super);
    SolarisProcessList_scanMemoryInfo(super);
    SolarisProcessList_scanZfsArcstats(super);
@@ -499,8 +535,7 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
 bool ProcessList_isCPUonline(const ProcessList* super, unsigned int id) {
    assert(id < super->existingCPUs);
 
-   // TODO: support offline CPUs and hot swapping
-   (void) super; (void) id;
+   const SolarisProcessList* spl = (const SolarisProcessList*) super;
 
-   return true;
+   return (super->existingCPUs == 1) ? true : spl->cpus[id + 1].online;
 }

--- a/solaris/SolarisProcessList.h
+++ b/solaris/SolarisProcessList.h
@@ -59,4 +59,6 @@ void ProcessList_delete(ProcessList* pl);
 
 void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate);
 
+bool ProcessList_isCPUonline(const ProcessList* super, unsigned int id);
+
 #endif

--- a/solaris/SolarisProcessList.h
+++ b/solaris/SolarisProcessList.h
@@ -44,6 +44,7 @@ typedef struct CPUData_ {
    uint64_t lkrnl;
    uint64_t lintr;
    uint64_t lidle;
+   bool online;
 } CPUData;
 
 typedef struct SolarisProcessList_ {

--- a/unsupported/UnsupportedProcessList.c
+++ b/unsupported/UnsupportedProcessList.c
@@ -18,7 +18,8 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* dynamicMeters, H
    ProcessList* this = xCalloc(1, sizeof(ProcessList));
    ProcessList_init(this, Class(Process), usersTable, dynamicMeters, pidMatchList, userId);
 
-   this->cpuCount = 1;
+   this->existingCPUs = 1;
+   this->activeCPUs = 1;
 
    return this;
 }

--- a/unsupported/UnsupportedProcessList.c
+++ b/unsupported/UnsupportedProcessList.c
@@ -89,3 +89,11 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
    if (!preExisting)
       ProcessList_add(super, proc);
 }
+
+bool ProcessList_isCPUonline(const ProcessList* super, unsigned int id) {
+   assert(id < super->existingCPUs);
+
+   (void) super; (void) id;
+
+   return true;
+}

--- a/unsupported/UnsupportedProcessList.h
+++ b/unsupported/UnsupportedProcessList.h
@@ -16,4 +16,6 @@ void ProcessList_delete(ProcessList* this);
 
 void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate);
 
+bool ProcessList_isCPUonline(const ProcessList* super, unsigned int id);
+
 #endif


### PR DESCRIPTION
Currently htop does not support offline CPUs and hot-swapping, e.g. via
    `echo 0 > /sys/devices/system/cpu/cpu2/online`

Split the current single `cpuCount` variable into `activeCPUs` and `existingCPUs`.

Supersedes: #650
Related: #580

/cc @mwahlroos @sthen 

@natoscott please take a look at the PCP code

TODO:

- [x] Check on Darwin
- [x] Check on DragonFlyBSD
- [x] Check on FreeBSD
- [x] Check on NetBSD (#603)
- [x] Check on OpenBSD
- [x] Check on Solaris
- [x] Check with PCP
- [x] Hide offline CPUs in affinity panel