### PR TITLE
Use PATH lookup for systemctl in systemd meter

### DIFF
--- a/linux/SystemdMeter.c
+++ b/linux/SystemdMeter.c
@@ -219,15 +219,15 @@ static void updateViaExec(void) {
          exit(1);
       dup2(fdnull, STDERR_FILENO);
       close(fdnull);
-      execl("/bin/systemctl",
-            "/bin/systemctl",
-            "show",
-            "--property=SystemState",
-            "--property=NFailedUnits",
-            "--property=NNames",
-            "--property=NJobs",
-            "--property=NInstalledJobs",
-            NULL);
+      execlp("systemctl",
+             "systemctl",
+             "show",
+             "--property=SystemState",
+             "--property=NFailedUnits",
+             "--property=NNames",
+             "--property=NJobs",
+             "--property=NInstalledJobs",
+             NULL);
       exit(127);
    }
    close(fdpair[1]);


### PR DESCRIPTION
Before this change, the systemd meter was mysteriously broken on NixOS. I figured out the problem by strace'ing htop which revealved the hardcoded `/bin/systemctl` execve. NixOS has systemctl in PATH, but not at `/bin/systemctl`, so this change makes it work on all my NixOS machines.

