### PR TITLE
netbsd: Support building with libcurses

### DIFF
--- a/CRT.c
+++ b/CRT.c
@@ -885,6 +885,7 @@ void CRT_init(const Settings* settings, bool allowUnicode) {
    sigaction (SIGSYS, &act, &old_sig_handler[SIGSYS]);
    sigaction (SIGABRT, &act, &old_sig_handler[SIGABRT]);
 
+   signal(SIGINT, CRT_handleSIGTERM);
    signal(SIGTERM, CRT_handleSIGTERM);
    signal(SIGQUIT, CRT_handleSIGTERM);
 

--- a/configure.ac
+++ b/configure.ac
@@ -329,8 +329,9 @@ else
     HTOP_CHECK_SCRIPT([ncurses], [wnoutrefresh], [HAVE_LIBNCURSES], [ncurses5-config],
      HTOP_CHECK_LIB([ncurses6],  [doupdate], [HAVE_LIBNCURSES],
       HTOP_CHECK_LIB([ncurses],  [doupdate], [HAVE_LIBNCURSES],
-       AC_MSG_ERROR([can not find required library libncurses])
-   ))))
+       HTOP_CHECK_LIB([curses],  [doupdate], [HAVE_LIBNCURSES],
+        AC_MSG_ERROR([can not find required curses/ncurses library])
+   )))))
 
    AC_CHECK_HEADERS([curses.h], [],
       [AC_CHECK_HEADERS([ncurses/curses.h], [],


### PR DESCRIPTION
Right now Unicode support must be disabled, because htop peeks
into the ncurses cchar_t struct with Unicode enabled. NetBSD's cchar_t
has different contents.

Partially fixes #660