### PR TITLE
netbsd: Fix display of in-use and cached memory

### DIFF
--- a/netbsd/NetBSDProcessList.c
+++ b/netbsd/NetBSDProcessList.c
@@ -102,14 +102,9 @@ static void NetBSDProcessList_scanMemoryInfo(ProcessList* pl) {
    }
 
    pl->totalMem = uvmexp.npages * pageSizeKB;
-
-   // These calculations have been taken from NetBSD's top(1)
-   // They need review for testing the correctness
-   //pl->freeMem = uvmexp.free * pageSizeKB;
-   pl->buffersMem = uvmexp.filepages * pageSizeKB;
-   pl->cachedMem = (uvmexp.anonpages + uvmexp.filepages + uvmexp.execpages) * pageSizeKB;
-   pl->usedMem = (uvmexp.npages - uvmexp.free - uvmexp.paging) * pageSizeKB + pl->buffersMem + pl->cachedMem;
-
+   pl->buffersMem = 0;
+   pl->cachedMem = (uvmexp.filepages + uvmexp.execpages) * pageSizeKB;
+   pl->usedMem = (uvmexp.active + uvmexp.wired) * pageSizeKB;
    pl->totalSwap = uvmexp.swpages * pageSizeKB;
    pl->usedSwap = uvmexp.swpginuse * pageSizeKB;
 }

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -236,7 +236,6 @@ void Platform_setMemoryValues(Meter* this) {
    long int usedMem = pl->usedMem;
    long int buffersMem = pl->buffersMem;
    long int cachedMem = pl->cachedMem;
-   usedMem -= buffersMem + cachedMem;
    this->total = pl->totalMem;
    this->values[0] = usedMem;
    this->values[1] = buffersMem;


### PR DESCRIPTION
- Only active memory counts towards the total in use.
- Memory used by the file cache is properly counted as such, and not as actively used memory.