### PR TITLE
netbsd: Support curses libraries without ncurses mouse support

### DIFF
--- a/CRT.c
+++ b/CRT.c
@@ -836,7 +836,9 @@ void CRT_init(const Settings* settings, bool allowUnicode) {
    nonl();
    intrflush(stdscr, false);
    keypad(stdscr, true);
+#ifdef HAVE_GETMOUSE
    mouseinterval(0);
+#endif
    curs_set(0);
 
    if (has_colors()) {
@@ -910,10 +912,12 @@ void CRT_init(const Settings* settings, bool allowUnicode) {
 #endif
       CRT_treeStrAscii;
 
+#ifdef HAVE_GETMOUSE
 #if NCURSES_MOUSE_VERSION > 1
    mousemask(BUTTON1_RELEASED | BUTTON4_PRESSED | BUTTON5_PRESSED, NULL);
 #else
    mousemask(BUTTON1_RELEASED, NULL);
+#endif
 #endif
 
    CRT_degreeSign = initDegreeSign();

--- a/CommandLine.c
+++ b/CommandLine.c
@@ -186,7 +186,9 @@ static CommandLineSettings parseArguments(const char* program, int argc, char** 
             flags.useColors = false;
             break;
          case 'M':
+#ifdef HAVE_GETMOUSE
             flags.enableMouse = false;
+#endif
             break;
          case 'U':
             flags.allowUnicode = false;
@@ -304,8 +306,10 @@ int CommandLine_run(const char* name, int argc, char** argv) {
       settings->delay = flags.delay;
    if (!flags.useColors)
       settings->colorScheme = COLORSCHEME_MONOCHROME;
+#ifdef HAVE_GETMOUSE
    if (!flags.enableMouse)
       settings->enableMouse = false;
+#endif
    if (flags.treeView)
       settings->treeView = true;
    if (flags.highlightChanges)

--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -131,7 +131,9 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
                                                  &(settings->showCPUTemperature)));
    Panel_add(super, (Object*) CheckItem_newByRef("- Show temperature in degree Fahrenheit instead of Celsius", &(settings->degreeFahrenheit)));
    #endif
+   #ifdef HAVE_GETMOUSE
    Panel_add(super, (Object*) CheckItem_newByRef("Enable the mouse", &(settings->enableMouse)));
+   #endif
    Panel_add(super, (Object*) NumberItem_newByRef("Update interval (in seconds)", &(settings->delay), -1, 1, 255));
    Panel_add(super, (Object*) CheckItem_newByRef("Highlight new and old processes", &(settings->highlightChanges)));
    Panel_add(super, (Object*) NumberItem_newByRef("- Highlight time (in seconds)", &(settings->highlightDelaySecs), 0, 1, 24 * 60 * 60));

--- a/InfoScreen.c
+++ b/InfoScreen.c
@@ -106,6 +106,7 @@ void InfoScreen_run(InfoScreen* this) {
          }
       }
 
+#ifdef HAVE_GETMOUSE
       if (ch == KEY_MOUSE) {
          MEVENT mevent;
          int ok = getmouse(&mevent);
@@ -127,6 +128,7 @@ void InfoScreen_run(InfoScreen* this) {
             #endif
          }
       }
+#endif
 
       if (this->inc->active) {
          IncSet_handleKey(this->inc, ch, panel, IncSet_getListItemValue, this->lines);

--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -172,6 +172,7 @@ void ScreenManager_run(ScreenManager* this, Panel** lastFocus, int* lastKey) {
       ch = getch();
 
       HandlerResult result = IGNORED;
+#ifdef HAVE_GETMOUSE
       if (ch == KEY_MOUSE && this->settings->enableMouse) {
          ch = ERR;
          MEVENT mevent;
@@ -212,6 +213,7 @@ void ScreenManager_run(ScreenManager* this, Panel** lastFocus, int* lastKey) {
             }
          }
       }
+#endif
       if (ch == ERR) {
          if (sortTimeout > 0)
             sortTimeout--;

--- a/Settings.c
+++ b/Settings.c
@@ -224,8 +224,10 @@ static bool Settings_read(Settings* this, const char* fileName, unsigned int ini
          if (this->colorScheme < 0 || this->colorScheme >= LAST_COLORSCHEME) {
             this->colorScheme = 0;
          }
+      #ifdef HAVE_GETMOUSE
       } else if (String_eq(option[0], "enable_mouse")) {
          this->enableMouse = atoi(option[1]);
+      #endif
       } else if (String_eq(option[0], "left_meters")) {
          Settings_readMeters(this, option[1], 0);
          didReadMeters = true;
@@ -332,7 +334,9 @@ int Settings_write(const Settings* this, bool onCrash) {
    fprintf(fd, "update_process_names=%d\n", (int) this->updateProcessNames);
    fprintf(fd, "account_guest_in_cpu_meter=%d\n", (int) this->accountGuestInCPUMeter);
    fprintf(fd, "color_scheme=%d\n", (int) this->colorScheme);
+   #ifdef HAVE_GETMOUSE
    fprintf(fd, "enable_mouse=%d\n", (int) this->enableMouse);
+   #endif
    fprintf(fd, "delay=%d\n", (int) this->delay);
    fprintf(fd, "left_meters="); writeMeters(this, fd, 0);
    fprintf(fd, "left_meter_modes="); writeMeterModes(this, fd, 0);
@@ -437,7 +441,9 @@ Settings* Settings_new(unsigned int initialCpuCount) {
       }
    }
    this->colorScheme = 0;
+#ifdef HAVE_GETMOUSE
    this->enableMouse = true;
+#endif
    this->changed = false;
    this->delay = DEFAULT_DELAY;
    bool ok = false;

--- a/Settings.h
+++ b/Settings.h
@@ -65,7 +65,9 @@ typedef struct Settings_ {
    bool updateProcessNames;
    bool accountGuestInCPUMeter;
    bool headerMargin;
+   #ifdef HAVE_GETMOUSE
    bool enableMouse;
+   #endif
    int hideFunctionBar;  // 0 - off, 1 - on ESC until next input, 2 - permanently
    #ifdef HAVE_LIBHWLOC
    bool topologyAffinity;

--- a/configure.ac
+++ b/configure.ac
@@ -352,6 +352,7 @@ if test "$my_htop_platform" = "solaris"; then
    AC_DEFINE([ERR], [(-1)], [Predefine ncurses macro.])
 fi
 AC_CHECK_FUNCS( [set_escdelay] )
+AC_CHECK_FUNCS( [getmouse] )
 
 
 AC_ARG_ENABLE([hwloc],


### PR DESCRIPTION
This adds a configure check for the ncurses getmouse() function
and disables mouse-related code paths when mouse support is
not present in the curses library.

This is necessary for stable versions of NetBSD's libcurses, the
development version has stub mouse functions for compatibility
with ncurses.