### PR TITLE
netbsd: Add battery support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -216,6 +216,7 @@ fi
 
 if test "$my_htop_platform" = netbsd; then
    AC_SEARCH_LIBS([kvm_open], [kvm], [], [AC_MSG_ERROR([can not find required function kvm_open()])])
+   AC_SEARCH_LIBS([prop_dictionary_get], [prop], [], [AC_MSG_ERROR([can not find required function prop_dictionary_get()])])
 fi
 
 if test "$my_htop_platform" = openbsd; then

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -410,7 +410,7 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
          totalCapacity += maxCharge;
       }
 
-      if (isACAdapter) {
+      if (isACAdapter && *isOnAC != AC_PRESENT) {
          *isOnAC = isConnected ? AC_PRESENT : AC_ABSENT;
       }
    }

--- a/netbsd/README.md
+++ b/netbsd/README.md
@@ -27,7 +27,6 @@ What needs improvement
 
 * Kernel and userspace threads are not displayed or counted -
   maybe look at NetBSD top(1).
-* Battery display - use envsys(4).
 * Support for compiling using libcurses's Unicode support.
 * Support for fstat(1) (view open files, like lsof(8) on Linux).
 * Support for ktrace(1) (like strace(1) on Linux).


### PR DESCRIPTION
This uses proplib and sysmon_envsys to determine the total charge
percentage of any number of connected batteries as well as the
AC adapter state. Should work with ACPI and non-ACPI systems.


![netbsd-battery](https://user-images.githubusercontent.com/29542929/127031663-c88727ba-78b6-4481-a95e-55fc4fb04a99.png)
