### PR TITLE
build: add -Wno-portability to the automake init call

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@ AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])
 
 AC_CANONICAL_TARGET
-AM_INIT_AUTOMAKE([-Wall std-options subdir-objects])
+AM_INIT_AUTOMAKE([-Wall -Wno-portability std-options subdir-objects])
 
 # ----------------------------------------------------------------------
 


### PR DESCRIPTION
This allows use of the non-POSIX variable name in a patsubst
call, which culls any optimiser flags in CFLAGS, without the
annoying warning at build time.

Resolves https://github.com/htop-dev/htop/issues/662