### PR TITLE
configure: check for NaN compiler support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -187,6 +187,23 @@ AC_COMPILE_IFELSE([
    AC_MSG_RESULT(no))
 CFLAGS="$old_CFLAGS"
 
+AC_MSG_CHECKING(for NaN support)
+AC_RUN_IFELSE([
+   AC_LANG_PROGRAM(
+      [[
+       #include <math.h>
+      ]],
+      [[
+       double x = NAN; return !isnan(x);
+      ]]
+   )],
+   [AC_MSG_RESULT(yes)],
+   [
+      AC_MSG_RESULT(no)
+      AC_MSG_WARN([Compiler does not respect NaN, some functionality might break; consider using '-fno-finite-math-only'])
+   ],
+   [AC_MSG_RESULT(skipped)])
+
 # ----------------------------------------------------------------------
 
 


### PR DESCRIPTION
Compilers might due to optimizations, like -ffast-math (included in
-Ofast) expect floating point variables to be never NaN and replace each
call to isnan() with false.  Htop uses the value NaN for signaling no
data available for various information.

Warn at configure time if the compiler will ignore NaN values.

Note: this can not be implemented as a compile time static assert, as
some compilers handle compile NaNs differently than runtime NaNs.