### PR TITLE
Read settings after applying defaults

### DIFF
--- a/Settings.c
+++ b/Settings.c
@@ -131,12 +131,13 @@ static bool Settings_read(Settings* this, const char* fileName, unsigned int ini
       return false;
 
    bool didReadMeters = false;
-   bool didReadFields = false;
+   bool didReadAny = false;
    for (;;) {
       char* line = String_readLine(fd);
       if (!line) {
          break;
       }
+      didReadAny = true;
       size_t nOptions;
       char** option = String_split(line, '=', &nOptions);
       free (line);
@@ -146,7 +147,6 @@ static bool Settings_read(Settings* this, const char* fileName, unsigned int ini
       }
       if (String_eq(option[0], "fields")) {
          readFields(this->fields, &(this->flags), option[1]);
-         didReadFields = true;
       } else if (String_eq(option[0], "sort_key")) {
          // This "+1" is for compatibility with the older enum format.
          this->sortKey = atoi(option[1]) + 1;
@@ -253,7 +253,7 @@ static bool Settings_read(Settings* this, const char* fileName, unsigned int ini
    if (!didReadMeters) {
       Settings_defaultMeters(this, initialCpuCount);
    }
-   return didReadFields;
+   return didReadAny;
 }
 
 static void writeFields(FILE* fd, const ProcessField* fields, const char* name) {
@@ -370,13 +370,13 @@ Settings* Settings_new(unsigned int initialCpuCount) {
    this->treeDirection = 1;
    this->shadowOtherUsers = false;
    this->showThreadNames = false;
-   this->hideKernelThreads = false;
+   this->hideKernelThreads = true;
    this->hideUserlandThreads = false;
    this->treeView = false;
    this->allBranchesCollapsed = false;
    this->highlightBaseName = false;
    this->highlightDeletedExe = true;
-   this->highlightMegabytes = false;
+   this->highlightMegabytes = true;
    this->detailedCPUTime = false;
    this->countCPUsFromOne = false;
    this->showCPUUsage = true;
@@ -394,6 +394,7 @@ Settings* Settings_new(unsigned int initialCpuCount) {
    this->stripExeFromCmdline = true;
    this->showMergedCommand = false;
    this->hideFunctionBar = 0;
+   this->headerMargin = true;
    #ifdef HAVE_LIBHWLOC
    this->topologyAffinity = false;
    #endif
@@ -462,17 +463,7 @@ Settings* Settings_new(unsigned int initialCpuCount) {
    }
    if (!ok) {
       this->changed = true;
-      ok = Settings_read(this, SYSCONFDIR "/htoprc", initialCpuCount);
-   }
-   if (!ok) {
-      Settings_defaultMeters(this, initialCpuCount);
-      this->hideKernelThreads = true;
-      this->highlightMegabytes = true;
-      this->highlightThreads = true;
-      this->findCommInCmdline = true;
-      this->stripExeFromCmdline = true;
-      this->showMergedCommand = false;
-      this->headerMargin = true;
+      Settings_read(this, SYSCONFDIR "/htoprc", initialCpuCount);
    }
    return this;
 }


### PR DESCRIPTION
Default settings are used as a base and only settings specified in `htoprc` are
applied on top of it. This patch removes the special case for applying some
defaults  when the config does not contain a `meters` key. All defaults are set
before any attempt to read settings, so only keys actually present in the config
file are overridden.