### PR TITLE
TasksMeter: save some float casts

### DIFF
--- a/TasksMeter.c
+++ b/TasksMeter.c
@@ -31,7 +31,7 @@ static void TasksMeter_updateValues(Meter* this) {
    this->values[3] = MINIMUM(pl->runningTasks, pl->activeCPUs);
    this->total     = pl->totalTasks;
 
-   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%d/%d", (int) this->values[3], (int) this->total);
+   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%u/%u", MINIMUM(pl->runningTasks, pl->activeCPUs), pl->totalTasks);
 }
 
 static void TasksMeter_display(const Object* cast, RichString* out) {


### PR DESCRIPTION
Split from #714.
This actually make compiled code (x86-64) slightly smaller.