### PR TITLE
Fix macOS CPU time calculations

### DIFF
--- a/darwin/DarwinProcess.c
+++ b/darwin/DarwinProcess.c
@@ -278,8 +278,8 @@ static uint64_t machTicksToNanoseconds(uint64_t schedulerTicks) {
 
 // Converts nanoseconds to hundreths of a second (centiseconds) as needed by the "time" field of the Process struct.
 static long long int nanosecondsToCentiseconds(uint64_t nanoseconds) {
-   uint64_t centiseconds_per_second = 100;
-   uint64_t nanoseconds_per_second = 1e9;
+   const uint64_t centiseconds_per_second = 100;
+   const uint64_t nanoseconds_per_second = 1e9;
    return nanoseconds / nanoseconds_per_second * centiseconds_per_second;
 }
 
@@ -344,7 +344,7 @@ void DarwinProcess_setFromKInfoProc(Process* proc, const struct kinfo_proc* ps, 
    proc->updated = true;
 }
 
-void DarwinProcess_setFromLibprocPidinfo(DarwinProcess* proc, DarwinProcessList* dpl, double time_interval_ns) {
+void DarwinProcess_setFromLibprocPidinfo(DarwinProcess* proc, DarwinProcessList* dpl, double timeIntervalNS) {
    struct proc_taskinfo pti;
 
    if (sizeof(pti) == proc_pidinfo(proc->super.pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti))) {
@@ -355,9 +355,9 @@ void DarwinProcess_setFromLibprocPidinfo(DarwinProcess* proc, DarwinProcessList*
 
       uint64_t total_current_time_ns = user_time_ns + system_time_ns;
 
-      if (total_existing_time_ns && 1E-6 < time_interval_ns) {
+      if (total_existing_time_ns && 1E-6 < timeIntervalNS) {
          uint64_t total_time_diff_ns = total_current_time_ns - total_existing_time_ns;
-         proc->super.percent_cpu = ((double)total_time_diff_ns / time_interval_ns) * 100.0;
+         proc->super.percent_cpu = ((double)total_time_diff_ns / timeIntervalNS) * 100.0;
       } else {
          proc->super.percent_cpu = 0.0;
       }

--- a/darwin/DarwinProcess.h
+++ b/darwin/DarwinProcess.h
@@ -31,7 +31,7 @@ void Process_delete(Object* cast);
 
 void DarwinProcess_setFromKInfoProc(Process* proc, const struct kinfo_proc* ps, bool exists);
 
-void DarwinProcess_setFromLibprocPidinfo(DarwinProcess* proc, DarwinProcessList* dpl, double time_interval_ns);
+void DarwinProcess_setFromLibprocPidinfo(DarwinProcess* proc, DarwinProcessList* dpl, double timeIntervalNS);
 
 /*
  * Scan threads for process state information.

--- a/darwin/DarwinProcess.h
+++ b/darwin/DarwinProcess.h
@@ -31,7 +31,7 @@ void Process_delete(Object* cast);
 
 void DarwinProcess_setFromKInfoProc(Process* proc, const struct kinfo_proc* ps, bool exists);
 
-void DarwinProcess_setFromLibprocPidinfo(DarwinProcess* proc, DarwinProcessList* dpl, double time_interval);
+void DarwinProcess_setFromLibprocPidinfo(DarwinProcess* proc, DarwinProcessList* dpl, double time_interval_ns);
 
 /*
  * Scan threads for process state information.

--- a/darwin/DarwinProcessList.c
+++ b/darwin/DarwinProcessList.c
@@ -160,9 +160,11 @@ void ProcessList_delete(ProcessList* this) {
    free(this);
 }
 
-static double ticksToNanoseconds(const double ticks) {
+// Converts "scheduler ticks" to nanoseconds.
+// See `sysconf(_SC_CLK_TCK)`, as used to define the `Platform_clockTicksPerSec` constant.
+static double schedulerTicksToNanoseconds(const double ticks) {
    const double nanos_per_sec = 1e9;
-   return (ticks / Platform_timebaseToNS) * (nanos_per_sec / (double) Platform_clockTicksPerSec);
+   return ticks * (nanos_per_sec / (double) Platform_clockTicksPerSec);
 }
 
 void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
@@ -192,7 +194,7 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
       }
    }
 
-   const double time_interval = ticksToNanoseconds(dpl->global_diff) / (double) dpl->super.activeCPUs;
+   const double time_interval_ns = schedulerTicksToNanoseconds(dpl->global_diff) / (double) dpl->super.activeCPUs;
 
    /* Clear the thread counts */
    super->kernelThreads = 0;
@@ -213,7 +215,7 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
       proc = (DarwinProcess*)ProcessList_getProcess(super, ps[i].kp_proc.p_pid, &preExisting, DarwinProcess_new);
 
       DarwinProcess_setFromKInfoProc(&proc->super, &ps[i], preExisting);
-      DarwinProcess_setFromLibprocPidinfo(proc, dpl, time_interval);
+      DarwinProcess_setFromLibprocPidinfo(proc, dpl, time_interval_ns);
 
       if (proc->super.st_uid != ps[i].kp_eproc.e_ucred.cr_uid) {
          proc->super.st_uid = ps[i].kp_eproc.e_ucred.cr_uid;


### PR DESCRIPTION
Resolves #751

#368 fixed the CPU percentages for M1 macs, but it didn't correctly address the calculations of CPU times.

As it turns out, the CPU percentage calculation is wrong, but since it was a ratio, two errors cancelled each other out.

This PR fixes that.

<img width="878" alt="Comparison" src="https://user-images.githubusercontent.com/5703449/130301551-0476e6b5-0282-424f-a07f-a0ac27422288.png">

Some notes:

* I did my development/testing on an M1 Mac Mini, but I also confirmed I haven't introduced regressions by double checking my final work against my Intel-powered MacBook Pro.
* I ran an infinite loop in a Swift REPL to peg one CPU core to 100%. I used this as a test-case to confirm CPU percentages were correct.
* I used Activity Monitor as a source-of-truth to confirm CPU times were working correctly.
* I set the "delay" to 10 (with `htop -d 10`, i.e. the refresh rate should be once per second, to make it easier to debug the `time_interval` mistakes.

With the existing code:

* The value of `time_interval` in `DarwinProcess_setFromLibprocPidinfo ` was wrong. Its variable name is useless, but it looks like it should nominally be a value in nanoseconds.

	* Its value was around `24090000.000000` nanoseconds (~`0.024` seconds).
	* It was expected to roughly `1e9` (around one second), since I was running with `-d 10` and I had approx one core at 100% and not much else.
	* It was off by a factor of `125/3` (`41.666`), our beloved `Platform_timebaseToNS`!

* The value of `total_current_time` in `DarwinProcess_setFromLibprocPidinfo` was wrong. It seems like it should also be a value in nanoseconds
	* Its value was around `1,147,173`, at a time when the correct value was around `43,752,916 ns` (a factor of `38.1`, which is close to our beloved `41.666`)

