### PR TITLE
HeaderLayout: save special ID in configuration

### DIFF
--- a/HeaderLayout.h
+++ b/HeaderLayout.h
@@ -12,6 +12,7 @@ in the source distribution for its full text.
 #include <stdint.h>
 
 #include "Macros.h"
+#include "XUtils.h"
 
 
 typedef enum HeaderLayout_ {
@@ -30,25 +31,45 @@ typedef enum HeaderLayout_ {
 static const struct {
    uint8_t columns;
    const uint8_t widths[4];
+   const char* name;
    const char* description;
 } HeaderLayout_layouts[LAST_HEADER_LAYOUT] = {
-   [HF_TWO_50_50]        = { 2, { 50, 50,  0,  0 }, "2 columns - 50/50 (default)", },
-   [HF_TWO_33_67]        = { 2, { 33, 67,  0,  0 }, "2 columns - 33/67", },
-   [HF_TWO_67_33]        = { 2, { 67, 33,  0,  0 }, "2 columns - 67/33", },
-   [HF_THREE_33_34_33]   = { 3, { 33, 34, 33,  0 }, "3 columns - 33/34/33", },
-   [HF_THREE_25_25_50]   = { 3, { 25, 25, 50,  0 }, "3 columns - 25/25/50", },
-   [HF_THREE_25_50_25]   = { 3, { 25, 50, 25,  0 }, "3 columns - 25/50/25", },
-   [HF_THREE_50_25_25]   = { 3, { 50, 25, 25,  0 }, "3 columns - 50/25/25", },
-   [HF_THREE_40_20_40]   = { 3, { 40, 20, 40,  0 }, "3 columns - 40/20/40", },
-   [HF_FOUR_25_25_25_25] = { 4, { 25, 25, 25, 25 }, "4 columns - 25/25/25/25", },
+   [HF_TWO_50_50]        = { 2, { 50, 50,  0,  0 }, "two_50_50",        "2 columns - 50/50 (default)", },
+   [HF_TWO_33_67]        = { 2, { 33, 67,  0,  0 }, "two_33_67",        "2 columns - 33/67",           },
+   [HF_TWO_67_33]        = { 2, { 67, 33,  0,  0 }, "two_67_33",        "2 columns - 67/33",           },
+   [HF_THREE_33_34_33]   = { 3, { 33, 34, 33,  0 }, "three_33_34_33",   "3 columns - 33/34/33",        },
+   [HF_THREE_25_25_50]   = { 3, { 25, 25, 50,  0 }, "three_25_25_50",   "3 columns - 25/25/50",        },
+   [HF_THREE_25_50_25]   = { 3, { 25, 50, 25,  0 }, "three_25_50_25",   "3 columns - 25/50/25",        },
+   [HF_THREE_50_25_25]   = { 3, { 50, 25, 25,  0 }, "three_50_25_25",   "3 columns - 50/25/25",        },
+   [HF_THREE_40_20_40]   = { 3, { 40, 20, 40,  0 }, "three_40_20_40",   "3 columns - 40/20/40",        },
+   [HF_FOUR_25_25_25_25] = { 4, { 25, 25, 25, 25 }, "four_25_25_25_25", "4 columns - 25/25/25/25",     },
 };
 
 static inline size_t HeaderLayout_getColumns(HeaderLayout hLayout) {
    /* assert the layout is initialized */
    assert(0 <= hLayout);
    assert(hLayout < LAST_HEADER_LAYOUT);
+   assert(HeaderLayout_layouts[hLayout].name[0]);
    assert(HeaderLayout_layouts[hLayout].description[0]);
    return HeaderLayout_layouts[hLayout].columns;
+}
+
+static inline const char* HeaderLayout_getName(HeaderLayout hLayout) {
+   /* assert the layout is initialized */
+   assert(0 <= hLayout);
+   assert(hLayout < LAST_HEADER_LAYOUT);
+   assert(HeaderLayout_layouts[hLayout].name[0]);
+   assert(HeaderLayout_layouts[hLayout].description[0]);
+   return HeaderLayout_layouts[hLayout].name;
+}
+
+static inline HeaderLayout HeaderLayout_fromName(const char* name) {
+   for (size_t i = 0; i < LAST_HEADER_LAYOUT; i++) {
+      if (String_eq(HeaderLayout_layouts[i].name, name))
+         return (HeaderLayout) i;
+   }
+
+   return LAST_HEADER_LAYOUT;
 }
 
 #endif /* HEADER_HeaderLayout */

--- a/Settings.c
+++ b/Settings.c
@@ -7,6 +7,7 @@ in the source distribution for its full text.
 
 #include "Settings.h"
 
+#include <ctype.h>
 #include <errno.h>
 #include <limits.h>
 #include <stdio.h>
@@ -266,7 +267,7 @@ static bool Settings_read(Settings* this, const char* fileName, unsigned int ini
          this->enableMouse = atoi(option[1]);
       #endif
       } else if (String_eq(option[0], "header_layout")) {
-         this->hLayout = atoi(option[1]);
+         this->hLayout = isdigit((unsigned char)option[1][0]) ? ((HeaderLayout) atoi(option[1])) : HeaderLayout_fromName(option[1]);
          if (this->hLayout < 0 || this->hLayout >= LAST_HEADER_LAYOUT)
             this->hLayout = HF_TWO_50_50;
          free(this->hColumns);
@@ -394,7 +395,7 @@ int Settings_write(const Settings* this, bool onCrash) {
    fprintf(fd, "enable_mouse=%d\n", (int) this->enableMouse);
    #endif
    fprintf(fd, "delay=%d\n", (int) this->delay);
-   fprintf(fd, "header_layout=%d\n", (int) this->hLayout);
+   fprintf(fd, "header_layout=%s\n", HeaderLayout_getName(this->hLayout));
    for (unsigned int i = 0; i < HeaderLayout_getColumns(this->hLayout); i++) {
       fprintf(fd, "column_meters_%u=", i);
       writeMeters(this, fd, i);


### PR DESCRIPTION
Use a special ID in the user configuration file instead of the compile
time enum value, so that future reorderings or insertions do not change
the user selected layout.