### PR TITLE
configure: resolve autotools 2.70 deprecation warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ AC_USE_SYSTEM_EXTENSIONS
 
 AC_PROG_CC
 AM_PROG_CC_C_O
-AC_PROG_CC_C99
+m4_version_prereq([2.70], [], [AC_PROG_CC_C99])
 AS_IF([test "x$ac_cv_prog_cc_c99" = xno], [AC_MSG_ERROR([htop is written in C99. A newer compiler is required.])])
 
 # ----------------------------------------------------------------------
@@ -131,7 +131,7 @@ esac
 # ----------------------------------------------------------------------
 
 AC_HEADER_DIRENT
-AC_HEADER_STDC
+m4_version_prereq([2.70], [AC_CHECK_INCLUDES_DEFAULT], [AC_HEADER_STDC])
 AC_CHECK_HEADERS([ \
     stdlib.h \
     string.h \


### PR DESCRIPTION
    configure.ac:72: warning: The macro `AC_PROG_CC_C99' is obsolete.
    configure.ac:72: You should run autoupdate.
    ./lib/autoconf/c.m4:1659: AC_PROG_CC_C99 is expanded from...
    configure.ac:72: the top level
    configure.ac:134: warning: The macro `AC_HEADER_STDC' is obsolete.
    configure.ac:134: You should run autoupdate.
    ./lib/autoconf/headers.m4:704: AC_HEADER_STDC is expanded from...
    configure.ac:134: the top level