### PR TITLE
Refactor Darwin platform unit conversion helpers

### DIFF
--- a/darwin/DarwinProcess.c
+++ b/darwin/DarwinProcess.c
@@ -269,13 +269,6 @@ ERROR_A:
    Process_updateCmdline(proc, k->kp_proc.p_comm, 0, strlen(k->kp_proc.p_comm));
 }
 
-// Converts ticks in the Mach "timebase" to nanoseconds.
-// See `mach_timebase_info`, as used to define the `Platform_timebaseToNS` constant.
-static uint64_t machTicksToNanoseconds(uint64_t schedulerTicks) {
-   double nanoseconds_per_mach_tick = Platform_timebaseToNS;
-   return (uint64_t) (nanoseconds_per_mach_tick * (double) schedulerTicks);
-}
-
 // Converts nanoseconds to hundreths of a second (centiseconds) as needed by the "time" field of the Process struct.
 static long long int nanosecondsToCentiseconds(uint64_t nanoseconds) {
    const uint64_t centiseconds_per_second = 100;
@@ -350,8 +343,8 @@ void DarwinProcess_setFromLibprocPidinfo(DarwinProcess* proc, DarwinProcessList*
    if (sizeof(pti) == proc_pidinfo(proc->super.pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti))) {
       uint64_t total_existing_time_ns = proc->stime + proc->utime;
 
-      uint64_t user_time_ns = machTicksToNanoseconds(pti.pti_total_user);
-      uint64_t system_time_ns = machTicksToNanoseconds(pti.pti_total_system);
+      uint64_t user_time_ns = Platform_machTicksToNanoseconds(pti.pti_total_user);
+      uint64_t system_time_ns = Platform_machTicksToNanoseconds(pti.pti_total_system);
 
       uint64_t total_current_time_ns = user_time_ns + system_time_ns;
 

--- a/darwin/DarwinProcessList.c
+++ b/darwin/DarwinProcessList.c
@@ -160,13 +160,6 @@ void ProcessList_delete(ProcessList* this) {
    free(this);
 }
 
-// Converts "scheduler ticks" to nanoseconds.
-// See `sysconf(_SC_CLK_TCK)`, as used to define the `Platform_clockTicksPerSec` constant.
-static double schedulerTicksToNanoseconds(const double ticks) {
-   const double nanos_per_sec = 1e9;
-   return ticks * (nanos_per_sec / (double) Platform_clockTicksPerSec);
-}
-
 void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
    DarwinProcessList* dpl = (DarwinProcessList*)super;
    bool preExisting = true;
@@ -194,7 +187,7 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
       }
    }
 
-   const double time_interval_ns = schedulerTicksToNanoseconds(dpl->global_diff) / (double) dpl->super.activeCPUs;
+   const double time_interval_ns = Platform_schedulerTicksToNanoseconds(dpl->global_diff) / (double) dpl->super.activeCPUs;
 
    /* Clear the thread counts */
    super->kernelThreads = 0;

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -27,10 +27,6 @@ in the source distribution for its full text.
 
 extern const ProcessField Platform_defaultFields[];
 
-extern double Platform_timebaseToNS;
-
-extern long Platform_clockTicksPerSec;
-
 extern const SignalItem Platform_signals[];
 
 extern const unsigned int Platform_numberOfSignals;
@@ -38,6 +34,14 @@ extern const unsigned int Platform_numberOfSignals;
 extern const MeterClass* const Platform_meterTypes[];
 
 void Platform_init(void);
+
+// Converts ticks in the Mach "timebase" to nanoseconds.
+// See `mach_timebase_info`, as used to define the `Platform_nanosecondsPerMachTick` constant.
+uint64_t Platform_machTicksToNanoseconds(uint64_t mach_ticks);
+
+// Converts "scheduler ticks" to nanoseconds.
+// See `sysconf(_SC_CLK_TCK)`, as used to define the `Platform_schedulerTicksPerNS` constant.
+double Platform_schedulerTicksToNanoseconds(const double scheduler_ticks);
 
 void Platform_done(void);
 


### PR DESCRIPTION
Builds on top of htop-dev/htop#752 and shuffles around some unit conversion helper functions. This allows us to encapsulate the conversion factor variables, which were previously publicly exposed by the head