### PR TITLE
PCP: do not set exe to empty string

### DIFF
--- a/pcp/PCPProcessList.c
+++ b/pcp/PCPProcessList.c
@@ -317,7 +317,7 @@ static void PCPProcessList_updateCmdline(Process* process, int pid, int offset, 
    Process_updateComm(process, comm);
 
    if (PCPMetric_instance(PCP_PROC_EXE, pid, offset, &value, PM_TYPE_STRING)) {
-      Process_updateExe(process, value.cp);
+      Process_updateExe(process, value.cp[0] ? value.cp : NULL);
       free(value.cp);
    }
 }


### PR DESCRIPTION
In case the executable is an empty string, e.g. if pcp is run by an
unprivileged user, do not set procExe to an empty value, which breaks
the formatting of the PROCEXE column and the merged-cmdline logic.