### PR TITLE
Add completion handling for dynamic meters and columns

### DIFF
--- a/CommandLine.c
+++ b/CommandLine.c
@@ -393,10 +393,8 @@ int CommandLine_run(const char* name, int argc, char** argv) {
 
    /* Delete these last, since they can get accessed in the crash handler */
    Settings_delete(settings);
-   if (dc)
-      Hashtable_delete(dc);
-   if (dm)
-      Hashtable_delete(dm);
+   DynamicColumns_delete(dc);
+   DynamicMeters_delete(dm);
 
    return 0;
 }

--- a/DynamicColumn.c
+++ b/DynamicColumn.c
@@ -22,6 +22,13 @@ Hashtable* DynamicColumns_new(void) {
    return Platform_dynamicColumns();
 }
 
+void DynamicColumns_delete(Hashtable* dynamics) {
+   if (dynamics) {
+      Platform_dynamicColumnsDone(dynamics);
+      Hashtable_delete(dynamics);
+   }
+}
+
 const char* DynamicColumn_init(unsigned int key) {
    return Platform_dynamicColumnInit(key);
 }

--- a/DynamicColumn.h
+++ b/DynamicColumn.h
@@ -21,6 +21,8 @@ typedef struct DynamicColumn_ {
 
 Hashtable* DynamicColumns_new(void);
 
+void DynamicColumns_delete(Hashtable* dynamics);
+
 const char* DynamicColumn_init(unsigned int key);
 
 const DynamicColumn* DynamicColumn_lookup(Hashtable* dynamics, unsigned int key);

--- a/DynamicMeter.c
+++ b/DynamicMeter.c
@@ -38,6 +38,13 @@ Hashtable* DynamicMeters_new(void) {
    return Platform_dynamicMeters();
 }
 
+void DynamicMeters_delete(Hashtable* dynamics) {
+   if (dynamics) {
+      Platform_dynamicMetersDone(dynamics);
+      Hashtable_delete(dynamics);
+   }
+}
+
 typedef struct {
    unsigned int key;
    const char* name;

--- a/DynamicMeter.h
+++ b/DynamicMeter.h
@@ -17,6 +17,8 @@ typedef struct DynamicMeter_ {
 
 Hashtable* DynamicMeters_new(void);
 
+void DynamicMeters_delete(Hashtable* dynamics);
+
 const char* DynamicMeter_lookup(Hashtable* dynamics, unsigned int key);
 
 bool DynamicMeter_search(Hashtable* dynamics, const char* name, unsigned int* key);

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -99,6 +99,8 @@ void Platform_gettime_monotonic(uint64_t* msec);
 
 static inline Hashtable* Platform_dynamicMeters(void) { return NULL; }
 
+static inline void Platform_dynamicMetersDone(ATTR_UNUSED Hashtable* table) { }
+
 static inline void Platform_dynamicMeterInit(ATTR_UNUSED Meter* meter) { }
 
 static inline void Platform_dynamicMeterUpdateValues(ATTR_UNUSED Meter* meter) { }
@@ -106,6 +108,8 @@ static inline void Platform_dynamicMeterUpdateValues(ATTR_UNUSED Meter* meter) {
 static inline void Platform_dynamicMeterDisplay(ATTR_UNUSED const Meter* meter, ATTR_UNUSED RichString* out) { }
 
 static inline Hashtable* Platform_dynamicColumns(void) { return NULL; }
+
+static inline void Platform_dynamicColumnsDone(ATTR_UNUSED Hashtable* table) { }
 
 static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int key) { return NULL; }
 

--- a/dragonflybsd/Platform.h
+++ b/dragonflybsd/Platform.h
@@ -92,6 +92,8 @@ static inline void Platform_gettime_monotonic(uint64_t* msec) {
 
 static inline Hashtable* Platform_dynamicMeters(void) { return NULL; }
 
+static inline void Platform_dynamicMetersDone(ATTR_UNUSED Hashtable* table) { }
+
 static inline void Platform_dynamicMeterInit(ATTR_UNUSED Meter* meter) { }
 
 static inline void Platform_dynamicMeterUpdateValues(ATTR_UNUSED Meter* meter) { }
@@ -99,6 +101,8 @@ static inline void Platform_dynamicMeterUpdateValues(ATTR_UNUSED Meter* meter) {
 static inline void Platform_dynamicMeterDisplay(ATTR_UNUSED const Meter* meter, ATTR_UNUSED RichString* out) { }
 
 static inline Hashtable* Platform_dynamicColumns(void) { return NULL; }
+
+static inline void Platform_dynamicColumnsDone(ATTR_UNUSED Hashtable* table) { }
 
 static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int key) { return NULL; }
 

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -92,6 +92,8 @@ static inline void Platform_gettime_monotonic(uint64_t* msec) {
 
 static inline Hashtable* Platform_dynamicMeters(void) { return NULL; }
 
+static inline void Platform_dynamicMetersDone(ATTR_UNUSED Hashtable* table) { }
+
 static inline void Platform_dynamicMeterInit(ATTR_UNUSED Meter* meter) { }
 
 static inline void Platform_dynamicMeterUpdateValues(ATTR_UNUSED Meter* meter) { }
@@ -101,6 +103,8 @@ static inline void Platform_dynamicMeterDisplay(ATTR_UNUSED const Meter* meter, 
 static inline Hashtable* Platform_dynamicColumns(void) { return NULL; }
 
 static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int key) { return NULL; }
+
+static inline void Platform_dynamicColumnsDone(ATTR_UNUSED Hashtable* table) { }
 
 static inline bool Platform_dynamicColumnWriteField(ATTR_UNUSED const Process* proc, ATTR_UNUSED RichString* str, ATTR_UNUSED unsigned int key) { return false; }
 

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -112,6 +112,8 @@ static inline void Platform_gettime_monotonic(uint64_t* msec) {
 
 static inline Hashtable* Platform_dynamicMeters(void) { return NULL; }
 
+static inline void Platform_dynamicMetersDone(ATTR_UNUSED Hashtable* table) { }
+
 static inline void Platform_dynamicMeterInit(ATTR_UNUSED Meter* meter) { }
 
 static inline void Platform_dynamicMeterUpdateValues(ATTR_UNUSED Meter* meter) { }
@@ -119,6 +121,8 @@ static inline void Platform_dynamicMeterUpdateValues(ATTR_UNUSED Meter* meter) {
 static inline void Platform_dynamicMeterDisplay(ATTR_UNUSED const Meter* meter, ATTR_UNUSED RichString* out) { }
 
 static inline Hashtable* Platform_dynamicColumns(void) { return NULL; }
+
+static inline void Platform_dynamicColumnsDone(ATTR_UNUSED Hashtable* table) { }
 
 static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int key) { return NULL; }
 

--- a/netbsd/Platform.h
+++ b/netbsd/Platform.h
@@ -96,6 +96,8 @@ static inline void Platform_gettime_monotonic(uint64_t* msec) {
 
 static inline Hashtable* Platform_dynamicMeters(void) { return NULL; }
 
+static inline void Platform_dynamicMetersDone(ATTR_UNUSED Hashtable* table) { }
+
 static inline void Platform_dynamicMeterInit(ATTR_UNUSED Meter* meter) { }
 
 static inline void Platform_dynamicMeterUpdateValues(ATTR_UNUSED Meter* meter) { }
@@ -103,6 +105,8 @@ static inline void Platform_dynamicMeterUpdateValues(ATTR_UNUSED Meter* meter) {
 static inline void Platform_dynamicMeterDisplay(ATTR_UNUSED const Meter* meter, ATTR_UNUSED RichString* out) { }
 
 static inline Hashtable* Platform_dynamicColumns(void) { return NULL; }
+
+static inline void Platform_dynamicColumnsDone(ATTR_UNUSED Hashtable* table) { }
 
 static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int key) { return NULL; }
 

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -90,6 +90,8 @@ static inline void Platform_gettime_monotonic(uint64_t* msec) {
 
 static inline Hashtable* Platform_dynamicMeters(void) { return NULL; }
 
+static inline void Platform_dynamicMetersDone(ATTR_UNUSED Hashtable* table) { }
+
 static inline void Platform_dynamicMeterInit(ATTR_UNUSED Meter* meter) { }
 
 static inline void Platform_dynamicMeterUpdateValues(ATTR_UNUSED Meter* meter) { }
@@ -97,6 +99,8 @@ static inline void Platform_dynamicMeterUpdateValues(ATTR_UNUSED Meter* meter) {
 static inline void Platform_dynamicMeterDisplay(ATTR_UNUSED const Meter* meter, ATTR_UNUSED RichString* out) { }
 
 static inline Hashtable* Platform_dynamicColumns(void) { return NULL; }
+
+static inline void Platform_dynamicColumnsDone(ATTR_UNUSED Hashtable* table) { }
 
 static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int key) { return NULL; }
 

--- a/pcp/PCPDynamicColumn.c
+++ b/pcp/PCPDynamicColumn.c
@@ -226,6 +226,18 @@ void PCPDynamicColumns_init(PCPDynamicColumns* columns) {
    free(path);
 }
 
+static void PCPDynamicColumns_free(ATTR_UNUSED ht_key_t key, void* value, ATTR_UNUSED void* data) {
+   PCPDynamicColumn* column = (PCPDynamicColumn*) value;
+   free(column->metricName);
+   free(column->super.heading);
+   free(column->super.caption);
+   free(column->super.description);
+}
+
+void PCPDynamicColumns_done(Hashtable* table) {
+   Hashtable_foreach(table, PCPDynamicColumns_free, NULL);
+}
+
 void PCPDynamicColumn_writeField(PCPDynamicColumn* this, const Process* proc, RichString* str) {
    const PCPProcess* pp = (const PCPProcess*) proc;
    unsigned int type = PCPMetric_type(this->id);

--- a/pcp/PCPDynamicColumn.h
+++ b/pcp/PCPDynamicColumn.h
@@ -26,6 +26,8 @@ typedef struct PCPDynamicColumns_ {
 
 void PCPDynamicColumns_init(PCPDynamicColumns* columns);
 
+void PCPDynamicColumns_done(Hashtable* table);
+
 void PCPDynamicColumn_writeField(PCPDynamicColumn* this, const Process* proc, RichString* str);
 
 int PCPDynamicColumn_compareByKey(const PCPProcess* p1, const PCPProcess* p2, ProcessField key);

--- a/pcp/PCPDynamicMeter.c
+++ b/pcp/PCPDynamicMeter.c
@@ -283,6 +283,22 @@ void PCPDynamicMeters_init(PCPDynamicMeters* meters) {
    free(path);
 }
 
+static void PCPDynamicMeter_free(ATTR_UNUSED ht_key_t key, void* value, ATTR_UNUSED void* data) {
+   PCPDynamicMeter* meter = (PCPDynamicMeter*) value;
+   for (size_t i = 0; i < meter->totalMetrics; i++) {
+      free(meter->metrics[i].name);
+      free(meter->metrics[i].label);
+      free(meter->metrics[i].suffix);
+   }
+   free(meter->metrics);
+   free(meter->super.caption);
+   free(meter->super.description);
+}
+
+void PCPDynamicMeters_done(Hashtable* table) {
+   Hashtable_foreach(table, PCPDynamicMeter_free, NULL);
+}
+
 void PCPDynamicMeter_enable(PCPDynamicMeter* this) {
    for (size_t i = 0; i < this->totalMetrics; i++)
       PCPMetric_enable(this->metrics[i].id, true);

--- a/pcp/PCPDynamicMeter.h
+++ b/pcp/PCPDynamicMeter.h
@@ -33,6 +33,8 @@ typedef struct PCPDynamicMeters_ {
 
 void PCPDynamicMeters_init(PCPDynamicMeters* meters);
 
+void PCPDynamicMeters_done(Hashtable* table);
+
 void PCPDynamicMeter_enable(PCPDynamicMeter* this);
 
 void PCPDynamicMeter_updateValues(PCPDynamicMeter* this, Meter* meter);

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -363,6 +363,14 @@ void Platform_init(void) {
    Platform_getMaxPid();
 }
 
+void Platform_dynamicColumnsDone(Hashtable* columns) {
+   PCPDynamicColumns_done(columns);
+}
+
+void Platform_dynamicMetersDone(Hashtable* meters) {
+   PCPDynamicMeters_done(meters);
+}
+
 void Platform_done(void) {
    pmDestroyContext(pcp->context);
    if (pcp->result)

--- a/pcp/Platform.h
+++ b/pcp/Platform.h
@@ -138,6 +138,8 @@ void Platform_gettime_monotonic(uint64_t* msec);
 
 Hashtable* Platform_dynamicMeters(void);
 
+void Platform_dynamicMetersDone(Hashtable* meters);
+
 void Platform_dynamicMeterInit(Meter* meter);
 
 void Platform_dynamicMeterUpdateValues(Meter* meter);
@@ -145,6 +147,8 @@ void Platform_dynamicMeterUpdateValues(Meter* meter);
 void Platform_dynamicMeterDisplay(const Meter* meter, RichString* out);
 
 Hashtable* Platform_dynamicColumns(void);
+
+void Platform_dynamicColumnsDone(Hashtable* columns);
 
 const char* Platform_dynamicColumnInit(unsigned int key);
 

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -131,6 +131,8 @@ IGNORE_WCASTQUAL_END
 
 static inline Hashtable* Platform_dynamicMeters(void) { return NULL; }
 
+static inline void Platform_dynamicMetersDone(ATTR_UNUSED Hashtable* table) { }
+
 static inline void Platform_dynamicMeterInit(ATTR_UNUSED Meter* meter) { }
 
 static inline void Platform_dynamicMeterUpdateValues(ATTR_UNUSED Meter* meter) { }
@@ -138,6 +140,8 @@ static inline void Platform_dynamicMeterUpdateValues(ATTR_UNUSED Meter* meter) {
 static inline void Platform_dynamicMeterDisplay(ATTR_UNUSED const Meter* meter, ATTR_UNUSED RichString* out) { }
 
 static inline Hashtable* Platform_dynamicColumns(void) { return NULL; }
+
+static inline void Platform_dynamicColumnsDone(ATTR_UNUSED Hashtable* table) { }
 
 static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int key) { return NULL; }
 

--- a/unsupported/Platform.h
+++ b/unsupported/Platform.h
@@ -79,6 +79,8 @@ static inline void Platform_gettime_monotonic(uint64_t* msec) {
 
 static inline Hashtable* Platform_dynamicMeters(void) { return NULL; }
 
+static inline void Platform_dynamicMetersDone(ATTR_UNUSED Hashtable* table) { }
+
 static inline void Platform_dynamicMeterInit(ATTR_UNUSED Meter* meter) { }
 
 static inline void Platform_dynamicMeterUpdateValues(ATTR_UNUSED Meter* meter) { }
@@ -86,6 +88,8 @@ static inline void Platform_dynamicMeterUpdateValues(ATTR_UNUSED Meter* meter) {
 static inline void Platform_dynamicMeterDisplay(ATTR_UNUSED const Meter* meter, ATTR_UNUSED RichString* out) { }
 
 static inline Hashtable* Platform_dynamicColumns(void) { return NULL; }
+
+static inline void Platform_dynamicColumnsDone(ATTR_UNUSED Hashtable* table) { }
 
 static inline const char* Platform_dynamicColumnInit(ATTR_UNUSED unsigned int key) { return NULL; }
 


### PR DESCRIPTION
Be sure to free dynamic memory allocated for meters and
columns strings, no-op on platforms other than pcp.

Closes #774