### PR TITLE
Highlight percentages similar to large numbers

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -718,7 +718,7 @@ void Process_printPercentage(float val, char* buffer, int n, int* attr) {
          *attr = CRT_colors[PROCESS_MEGABYTES];
          xSnprintf(buffer, n, "%3d. ", (int)val);
       } else {
-         *attr = CRT_colors[PROCESS_GIGABYTES];
+         *attr = CRT_colors[PROCESS_MEGABYTES];
          xSnprintf(buffer, n, "%4d ", (int)val);
       }
    } else {

--- a/Process.c
+++ b/Process.c
@@ -715,8 +715,10 @@ void Process_printPercentage(float val, char* buffer, int n, int* attr) {
          }
          xSnprintf(buffer, n, "%4.1f ", val);
       } else if (val < 999) {
+         *attr = CRT_colors[PROCESS_MEGABYTES];
          xSnprintf(buffer, n, "%3d. ", (int)val);
       } else {
+         *attr = CRT_colors[PROCESS_GIGABYTES];
          xSnprintf(buffer, n, "%4d ", (int)val);
       }
    } else {


### PR DESCRIPTION
This change introduces a highlighting of percentages above 100% as cyan and above 1000 as green, similar to the colors used for MB and GB for e.g. the amount of memory used by an application.

Split off from #777.