### PR TITLE
Settings: set ok when reading configuration from sysconfdir

### DIFF
--- a/Settings.c
+++ b/Settings.c
@@ -542,7 +542,7 @@ Settings* Settings_new(unsigned int initialCpuCount, Hashtable* dynamicColumns) 
    }
    if (!ok) {
       this->changed = true;
-      Settings_read(this, SYSCONFDIR "/htoprc", initialCpuCount);
+      ok = Settings_read(this, SYSCONFDIR "/htoprc", initialCpuCount);
    }
    if (!ok) {
       Settings_defaultMeters(this, initialCpuCount);


### PR DESCRIPTION
Without this htoprc from sysconfdir is ignored and default meters
are loaded.