### PR TITLE
Several tweaks while running under Valgrind

### DIFF
--- a/CRT.c
+++ b/CRT.c
@@ -772,6 +772,8 @@ static void dumpStderr(void) {
 
    fsync(STDERR_FILENO);
    dup2(stderrRedirectBackupFd, STDERR_FILENO);
+   close(stderrRedirectBackupFd);
+   stderrRedirectBackupFd = -1;
    lseek(stderrRedirectNewFd, 0, SEEK_SET);
 
    bool header = false;

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -169,7 +169,11 @@ static void LinuxProcessList_updateCPUcount(ProcessList* super) {
    if (!dir) {
       super->activeCPUs = 1;
       super->existingCPUs = 1;
+      bool init = (this->cpuData == NULL);
       this->cpuData = xReallocArray(this->cpuData, 2, sizeof(CPUData));
+      if (init) {
+         memset(this->cpuData, '\0', 2 * sizeof(CPUData));
+      }
       this->cpuData[0].online = true; /* average is always "online" */
       this->cpuData[1].online = true;
       return;
@@ -205,10 +209,12 @@ static void LinuxProcessList_updateCPUcount(ProcessList* super) {
       unsigned int max = MAXIMUM(existing, id + 1);
       if (max > currExisting) {
          this->cpuData = xReallocArray(this->cpuData, max + /* aggregate */ 1, sizeof(CPUData));
-         for (unsigned int j = currExisting; j < max; j++) {
-            this->cpuData[j].online = false;
+         if (currExisting == 0) {
+            memset(this->cpuData, '\0', (max + 1) * sizeof(CPUData)); /* zero everything */
+            this->cpuData[0].online = true; /* average is always "online" */
+         } else {
+            memset(this->cpuData + currExisting + 1, '\0', (max - currExisting) * sizeof(CPUData)); /* zero only added memory */
          }
-         this->cpuData[0].online = true; /* average is always "online" */
          currExisting = max;
       }
 

--- a/scripts/htop_suppressions.valgrind
+++ b/scripts/htop_suppressions.valgrind
@@ -1,63 +1,47 @@
 {
-   <ncurses internal memory allocated at startup>
-   Memcheck:Leak
-   match-leak-kinds: reachable
-   ...
-   fun:CRT_init
-   fun:main
-}
-
-{
-   <ncurses internal memory allocated at startup>
-   Memcheck:Leak
-   match-leak-kinds: reachable
-   ...
-   fun:CRT_init
-}
-
-{
    <ncurses internal memory>
    Memcheck:Leak
-   match-leak-kinds: reachable
-   ...
-   fun:wgetch
-   fun:ScreenManager_run
-   fun:Action_runSetup
-   fun:actionSetup
-   fun:MainPanel_eventHandler
-   fun:ScreenManager_run
-   fun:main
-}
-
-{
-   <ncurses internal memory>
-   Memcheck:Leak
-   match-leak-kinds: reachable
-   ...
-   fun:wgetch
-   fun:ScreenManager_run
-   fun:main
-}
-
-{
-   <ncurses internal memory>
-   Memcheck:Leak
-   match-leak-kinds: reachable
-   ...
-   fun:wrefresh
-   fun:main
-}
-
-{
-   <ncurses internal memory>
-   Memcheck:Leak
-   match-leak-kinds: reachable
-   fun:realloc
-   fun:_nc_doalloc
-   fun:_nc_tparm_analyze
-   fun:tparm
+   match-leak-kinds: possible,reachable
    ...
    fun:doupdate_sp
    fun:wrefresh
-   obj:*
+}
+
+{
+   <ncurses internal memory>
+   Memcheck:Leak
+   match-leak-kinds: possible,reachable
+   ...
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:CRT_init
+}
+
+{
+   <ncurses internal memory>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   obj:*/libtinfo*
+   fun:CRT_init
+}
+
+{
+   <ncurses internal memory>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   obj:*/libncurses*
+   fun:CRT_init
+}
+
+{
+   <ncurses internal memory>
+   Memcheck:Leak
+   match-leak-kinds: possible,reachable
+   ...
+   obj:*/libncurses*
+   fun:CRT_setColors
+   fun:CRT_init
 }

--- a/scripts/run_valgrind.sh
+++ b/scripts/run_valgrind.sh
@@ -3,4 +3,4 @@
 SCRIPT=$(readlink -f "$0")
 SCRIPTDIR=$(dirname "$SCRIPT")
 
-valgrind --leak-check=full --show-reachable=yes --show-leak-kinds=all --track-fds=yes --errors-for-leak-kinds=all --suppressions="${SCRIPTDIR}/htop_suppressions.valgrind" "${SCRIPTDIR}/../htop"
+valgrind --leak-check=full --show-reachable=yes --show-leak-kinds=all --track-fds=yes --errors-for-leak-kinds=all --track-origins=yes --suppressions="${SCRIPTDIR}/htop_suppressions.valgrind" "${SCRIPTDIR}/../htop"


### PR DESCRIPTION
* track origin of uninitialised values

* rewrite ncurses suppressions
   Simplify and update valgrind suppressions for possible leak and reachable memory inside ncurses.

* close backup stderr file after reset
   Close the backup file descriptor of original stderr once it has been restored at stderr.

* zero CPU data after allocation
   Zero all the CPU data, like totalPeriod, after its memory allocation via realloc(3).

   ```
  Conditional jump or move depends on uninitialised value(s)
      at 0x132A9B: LinuxProcessList_scanCPUTime (LinuxProcessList.c:1928)
      by 0x1358C3: ProcessList_goThroughEntries (LinuxProcessList.c:2079)
      by 0x12A79A: ProcessList_scan (ProcessList.c:627)
      by 0x11CA67: CommandLine_run (CommandLine.c:357)
      by 0x4A81E49: (below main) (libc-start.c:314)
    Uninitialised value was created by a heap allocation
      at 0x48396C5: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
      by 0x12F633: xRealloc (XUtils.c:64)
      by 0x12F633: xReallocArray (XUtils.c:78)
      by 0x1325A8: LinuxProcessList_updateCPUcount (LinuxProcessList.c:207)
      by 0x134E0A: ProcessList_new (LinuxProcessList.c:284)
      by 0x11C8D0: CommandLine_run (CommandLine.c:301)
      by 0x4A81E49: (below main) (libc-start.c:314)
   ```