### PR TITLE
CRT: close backup stderr file after reset

### DIFF
--- a/CRT.c
+++ b/CRT.c
@@ -772,6 +772,8 @@ static void dumpStderr(void) {
 
    fsync(STDERR_FILENO);
    dup2(stderrRedirectBackupFd, STDERR_FILENO);
+   close(stderrRedirectBackupFd);
+   stderrRedirectBackupFd = -1;
    lseek(stderrRedirectNewFd, 0, SEEK_SET);
 
    bool header = false;


### PR DESCRIPTION
Close the backup file descriptor of original stderr once it has been restored at stderr.

Split from #782