### PR TITLE
Linux: zero CPU data after allocation

### DIFF
--- a/XUtils.c
+++ b/XUtils.c
@@ -78,6 +78,22 @@ void* xReallocArray(void* ptr, size_t nmemb, size_t size) {
    return xRealloc(ptr, nmemb * size);
 }
 
+void* xReallocArrayZero(void* ptr, size_t prevmemb, size_t newmemb, size_t size) {
+   assert((ptr == NULL) == (prevmemb == 0));
+
+   if (prevmemb == newmemb) {
+      return ptr;
+   }
+
+   void* ret = xReallocArray(ptr, newmemb, size);
+
+   if (newmemb > prevmemb) {
+      memset((unsigned char*)ret + prevmemb * size, '\0', (newmemb - prevmemb) * size);
+   }
+
+   return ret;
+}
+
 inline bool String_contains_i(const char* s1, const char* s2) {
    return strcasestr(s1, s2) != NULL;
 }

--- a/XUtils.h
+++ b/XUtils.h
@@ -30,6 +30,8 @@ void* xRealloc(void* ptr, size_t size) ATTR_ALLOC_SIZE1(2);
 
 void* xReallocArray(void* ptr, size_t nmemb, size_t size) ATTR_ALLOC_SIZE2(2, 3);
 
+void* xReallocArrayZero(void* ptr, size_t prevmemb, size_t newmemb, size_t size) ATTR_ALLOC_SIZE2(3, 4);
+
 /*
  * String_startsWith gives better performance if strlen(match) can be computed
  * at compile time (e.g. when they are immutable string literals). :)

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -167,11 +167,11 @@ static void LinuxProcessList_updateCPUcount(ProcessList* super) {
 
    DIR* dir = opendir("/sys/devices/system/cpu");
    if (!dir) {
-      super->activeCPUs = 1;
-      super->existingCPUs = 1;
-      this->cpuData = xReallocArray(this->cpuData, 2, sizeof(CPUData));
+      this->cpuData = xReallocArrayZero(this->cpuData, super->existingCPUs ? (super->existingCPUs + 1) : 0, 2, sizeof(CPUData));
       this->cpuData[0].online = true; /* average is always "online" */
       this->cpuData[1].online = true;
+      super->activeCPUs = 1;
+      super->existingCPUs = 1;
       return;
    }
 
@@ -204,10 +204,7 @@ static void LinuxProcessList_updateCPUcount(ProcessList* super) {
       /* readdir() iterates with no specific order */
       unsigned int max = MAXIMUM(existing, id + 1);
       if (max > currExisting) {
-         this->cpuData = xReallocArray(this->cpuData, max + /* aggregate */ 1, sizeof(CPUData));
-         for (unsigned int j = currExisting; j < max; j++) {
-            this->cpuData[j].online = false;
-         }
+         this->cpuData = xReallocArrayZero(this->cpuData, currExisting ? (currExisting + 1) : 0, max + /* aggregate */ 1, sizeof(CPUData));
          this->cpuData[0].online = true; /* average is always "online" */
          currExisting = max;
       }


### PR DESCRIPTION
Zero all the CPU data, like totalPeriod, after its memory allocation via realloc(3).

```
Conditional jump or move depends on uninitialised value(s)
   at 0x132A9B: LinuxProcessList_scanCPUTime (LinuxProcessList.c:1928)
   by 0x1358C3: ProcessList_goThroughEntries (LinuxProcessList.c:2079)
   by 0x12A79A: ProcessList_scan (ProcessList.c:627)
   by 0x11CA67: CommandLine_run (CommandLine.c:357)
   by 0x4A81E49: (below main) (libc-start.c:314)
 Uninitialised value was created by a heap allocation
   at 0x48396C5: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x12F633: xRealloc (XUtils.c:64)
   by 0x12F633: xReallocArray (XUtils.c:78)
   by 0x1325A8: LinuxProcessList_updateCPUcount (LinuxProcessList.c:207)
   by 0x134E0A: ProcessList_new (LinuxProcessList.c:284)
   by 0x11C8D0: CommandLine_run (CommandLine.c:301)
   by 0x4A81E49: (below main) (libc-start.c:314)
```

Split from #782