### PR TITLE
MemorySwapMeter: align with CPU meter

### DIFF
--- a/MemorySwapMeter.c
+++ b/MemorySwapMeter.c
@@ -33,10 +33,14 @@ static void MemorySwapMeter_updateValues(Meter* this) {
 static void MemorySwapMeter_draw(Meter* this, int x, int y, int w) {
    MemorySwapMeterData* data = this->meterData;
 
+   /* Use the same width for each sub meter to align with CPU meter */
+   const int colwidth = w / 2;
+   const int diff = w - colwidth * 2;
+
    assert(data->memoryMeter->draw);
-   data->memoryMeter->draw(data->memoryMeter, x, y, w / 2);
+   data->memoryMeter->draw(data->memoryMeter, x, y, colwidth);
    assert(data->swapMeter->draw);
-   data->swapMeter->draw(data->swapMeter, x + w / 2, y, w - w / 2);
+   data->swapMeter->draw(data->swapMeter, x + colwidth + diff, y, colwidth);
 }
 
 static void MemorySwapMeter_init(Meter* this) {


### PR DESCRIPTION
Use the same width for each sub meter to align with CPU meter.
Currently if the total width is even, so it does not split exactly into 2 equal parts plus 1 (for the middle space character column), the extra column is added to the second meter width.

Closes: #783