### PR TITLE
HeaderOptionsPanel: select the current not saved option

### DIFF
--- a/HeaderOptionsPanel.c
+++ b/HeaderOptionsPanel.c
@@ -82,6 +82,6 @@ HeaderOptionsPanel* HeaderOptionsPanel_new(Settings* settings, ScreenManager* sc
    for (int i = 0; i < LAST_HEADER_LAYOUT; i++) {
       Panel_add(super, (Object*) CheckItem_newByVal(HeaderLayout_layouts[i].description, false));
    }
-   CheckItem_set((CheckItem*)Panel_get(super, settings->hLayout), true);
+   CheckItem_set((CheckItem*)Panel_get(super, scr->header->headerLayout), true);
    return this;
 }


### PR DESCRIPTION
Select the current active header layout, not the current saved layout from the settings, as the value gets only saved back from the active header to settings on closing the setup menu.

Closes: #785