### PR TITLE
Workaround for `mach_timebase_info` bug on Rosetta 2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -307,6 +307,7 @@ darwin_platform_headers = \
 	darwin/DarwinProcess.h \
 	darwin/DarwinProcessList.h \
 	darwin/Platform.h \
+	darwin/PlatformHelpers.h \
 	darwin/ProcessField.h \
 	generic/gettime.h \
 	generic/hostname.h \
@@ -318,6 +319,7 @@ darwin_platform_headers = \
 
 darwin_platform_sources = \
 	darwin/Platform.c \
+	darwin/PlatformHelpers.c \
 	darwin/DarwinProcess.c \
 	darwin/DarwinProcessList.c \
 	generic/gettime.c \

--- a/darwin/DarwinProcess.h
+++ b/darwin/DarwinProcess.h
@@ -12,6 +12,7 @@ in the source distribution for its full text.
 #include "Settings.h"
 #include "darwin/DarwinProcessList.h"
 
+
 typedef struct DarwinProcess_ {
    Process super;
 

--- a/darwin/DarwinProcessList.c
+++ b/darwin/DarwinProcessList.c
@@ -176,7 +176,7 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
       }
 
       // Disabled for High Sierra due to bug in macOS High Sierra
-      bool isScanThreadSupported  = !(Platform_CompareKernelVersion(17, 0, 0) >= 0 && Platform_CompareKernelVersion(17, 5, 0) < 0);
+      bool isScanThreadSupported  = !Platform_KernelVersionIsBetween((KernelVersion) {17, 0, 0}, (KernelVersion) {17, 5, 0});
 
       if (isScanThreadSupported) {
          DarwinProcess_scanThreads(proc);

--- a/darwin/DarwinProcessList.c
+++ b/darwin/DarwinProcessList.c
@@ -22,50 +22,10 @@ in the source distribution for its full text.
 #include "ProcessList.h"
 #include "darwin/DarwinProcess.h"
 #include "darwin/Platform.h"
+#include "darwin/PlatformHelpers.h"
 #include "generic/openzfs_sysctl.h"
 #include "zfs/ZfsArcStats.h"
 
-
-struct kern {
-   short int version[3];
-};
-
-static void GetKernelVersion(struct kern* k) {
-   static short int version_[3] = {0};
-   if (!version_[0]) {
-      // just in case it fails someday
-      version_[0] = version_[1] = version_[2] = -1;
-      char str[256] = {0};
-      size_t size = sizeof(str);
-      int ret = sysctlbyname("kern.osrelease", str, &size, NULL, 0);
-      if (ret == 0) {
-         sscanf(str, "%hd.%hd.%hd", &version_[0], &version_[1], &version_[2]);
-      }
-   }
-   memcpy(k->version, version_, sizeof(version_));
-}
-
-/* compare the given os version with the one installed returns:
-0 if equals the installed version
-positive value if less than the installed version
-negative value if more than the installed version
-*/
-static int CompareKernelVersion(short int major, short int minor, short int component) {
-   struct kern k;
-   GetKernelVersion(&k);
-
-   if (k.version[0] != major) {
-      return k.version[0] - major;
-   }
-   if (k.version[1] != minor) {
-      return k.version[1] - minor;
-   }
-   if (k.version[2] != component) {
-      return k.version[2] - component;
-   }
-
-   return 0;
-}
 
 static void ProcessList_getHostInfo(host_basic_info_data_t* p) {
    mach_msg_type_number_t info_size = HOST_BASIC_INFO_COUNT;
@@ -216,7 +176,7 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
       }
 
       // Disabled for High Sierra due to bug in macOS High Sierra
-      bool isScanThreadSupported  = ! ( CompareKernelVersion(17, 0, 0) >= 0 && CompareKernelVersion(17, 5, 0) < 0);
+      bool isScanThreadSupported  = !(Platform_CompareKernelVersion(17, 0, 0) >= 0 && Platform_CompareKernelVersion(17, 5, 0) < 0);
 
       if (isScanThreadSupported) {
          DarwinProcess_scanThreads(proc);

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -35,6 +35,7 @@ in the source distribution for its full text.
 #include "TasksMeter.h"
 #include "UptimeMeter.h"
 #include "darwin/DarwinProcessList.h"
+#include "darwin/PlatformHelpers.h"
 #include "zfs/ZfsArcMeter.h"
 #include "zfs/ZfsCompressedArcMeter.h"
 
@@ -42,6 +43,7 @@ in the source distribution for its full text.
 #include <mach/clock.h>
 #include <mach/mach.h>
 #endif
+
 #ifdef HAVE_MACH_MACH_TIME_H
 #include <mach/mach_time.h>
 #endif
@@ -125,15 +127,7 @@ static double Platform_nanosecondsPerMachTick = 1.0;
 static double Platform_nanosecondsPerSchedulerTick = -1;
 
 void Platform_init(void) {
-   // Check if we can determine the timebase used on this system.
-   // If the API is unavailable assume we get our timebase in nanoseconds.
-#ifdef HAVE_MACH_TIMEBASE_INFO
-   mach_timebase_info_data_t info;
-   mach_timebase_info(&info);
-   Platform_nanosecondsPerMachTick = (double)info.numer / (double)info.denom;
-#else
-   Platform_nanosecondsPerMachTick = 1.0;
-#endif
+   Platform_nanosecondsPerMachTick = Platform_calculateNanosecondsPerMachTick();
 
    // Determine the number of scheduler clock ticks per second
    errno = 0;

--- a/darwin/PlatformHelpers.c
+++ b/darwin/PlatformHelpers.c
@@ -58,14 +58,68 @@ bool Platform_KernelVersionIsBetween(KernelVersion lowerBound, KernelVersion upp
       && Platform_CompareKernelVersion(upperBound) < 0;
 }
 
+void Platform_getCPUBrandString(char *cpuBrandString, size_t cpuBrandStringSize) {
+   if (sysctlbyname("machdep.cpu.brand_string", cpuBrandString, &cpuBrandStringSize, NULL, 0) == -1) {
+      fprintf(stderr,
+         "WARN: Unable to determine the CPU brand string.\n"
+         "errno: %i, %s\n", errno, strerror(errno));
+
+      String_safeStrncpy(cpuBrandString, "UNKNOWN!", cpuBrandStringSize);
+   }
+}
+
+// Adapted from https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment
+bool Platform_isRunningTranslated() {
+   int ret = 0;
+   size_t size = sizeof(ret);
+   errno = 0;
+   if (sysctlbyname("sysctl.proc_translated", &ret, &size, NULL, 0) == -1) {
+      if (errno == ENOENT) return false;
+
+      fprintf(stderr,
+         "WARN: Could not determine if this process was running in a translation environment like Rosetta 2.\n"
+         "Assuming that we're not.\n"
+         "errno: %i, %s\n", errno, strerror(errno));
+
+      return false;
+   }
+   return ret;
+}
+
 double Platform_calculateNanosecondsPerMachTick() {
    // Check if we can determine the timebase used on this system.
    // If the API is unavailable assume we get our timebase in nanoseconds.
-#ifdef HAVE_MACH_TIMEBASE_INFO
-   mach_timebase_info_data_t info;
-   mach_timebase_info(&info);
-   return (double)info.numer / (double)info.denom;
-#else
+#ifndef HAVE_MACH_TIMEBASE_INFO
    return 1.0;
+#else
+   mach_timebase_info_data_t info;
+
+   /* WORKAROUND for `mach_timebase_info` giving incorrect values on M1 under Rosetta 2.
+    *    rdar://FB9546856 https://openradar.appspot.com/radar?id=5055988478509056
+    *
+    *    We don't know exactly what feature/attribute of the M1 chip causes this mistake under Rosetta 2.
+    *    Until we have more Apple ARM chips to compare against, the best we can do is special-case
+    *    the "Apple M1" chip specifically when running under Rosetta 2.
+    */
+
+   size_t cpuBrandStringSize = 1024;
+   char cpuBrandString[cpuBrandStringSize];
+   Platform_getCPUBrandString(cpuBrandString, cpuBrandStringSize);
+
+   bool isRunningUnderRosetta2 = Platform_isRunningTranslated();
+
+   // Kernel version 20.0.0 is macOS 11.0 (Big Sur)
+   bool isBuggedVersion = Platform_KernelVersionIsBetween((KernelVersion) {20, 0, 0}, (KernelVersion) {999, 999, 999});
+
+   if (isRunningUnderRosetta2 && String_eq(cpuBrandString, "Apple M1") && isBuggedVersion) {
+      // In this case `mach_timebase_info` provides the wrong value, so we hard-code the correct factor,
+      // as determined from `mach_timebase_info` when the process running natively.
+      info = (mach_timebase_info_data_t) { .numer = 125, .denom = 3 };
+   } else {
+      // No workarounds needed, use the OS-provided value.
+      mach_timebase_info(&info);
+   }
+
+   return (double)info.numer / (double)info.denom;
 #endif
 }

--- a/darwin/PlatformHelpers.c
+++ b/darwin/PlatformHelpers.c
@@ -1,0 +1,70 @@
+/*
+htop - darwin/PlatformHelpers.c
+(C) 2018 Pierre Malhaire, 2020-2021 htop dev team, 2021 Alexander Momchilov
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include "darwin/PlatformHelpers.h"
+
+#include <errno.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/sysctl.h>
+
+#include "CRT.h"
+
+#ifdef HAVE_MACH_MACH_TIME_H
+#include <mach/mach_time.h>
+#endif
+
+
+void Platform_GetKernelVersion(struct kern* k) {
+   static short int version_[3] = {0};
+   if (!version_[0]) {
+      // just in case it fails someday
+      version_[0] = version_[1] = version_[2] = -1;
+      char str[256] = {0};
+      size_t size = sizeof(str);
+      int ret = sysctlbyname("kern.osrelease", str, &size, NULL, 0);
+      if (ret == 0) {
+         sscanf(str, "%hd.%hd.%hd", &version_[0], &version_[1], &version_[2]);
+      }
+   }
+   memcpy(k->version, version_, sizeof(version_));
+}
+
+/* compare the given os version with the one installed returns:
+0 if equals the installed version
+positive value if less than the installed version
+negative value if more than the installed version
+*/
+int Platform_CompareKernelVersion(short int major, short int minor, short int component) {
+   struct kern k;
+   Platform_GetKernelVersion(&k);
+
+   if (k.version[0] != major) {
+      return k.version[0] - major;
+   }
+   if (k.version[1] != minor) {
+      return k.version[1] - minor;
+   }
+   if (k.version[2] != component) {
+      return k.version[2] - component;
+   }
+
+   return 0;
+}
+
+double Platform_calculateNanosecondsPerMachTick() {
+   // Check if we can determine the timebase used on this system.
+   // If the API is unavailable assume we get our timebase in nanoseconds.
+#ifdef HAVE_MACH_TIMEBASE_INFO
+   mach_timebase_info_data_t info;
+   mach_timebase_info(&info);
+   return (double)info.numer / (double)info.denom;
+#else
+   return 1.0;
+#endif
+}

--- a/darwin/PlatformHelpers.h
+++ b/darwin/PlatformHelpers.h
@@ -11,18 +11,23 @@ in the source distribution for its full text.
 #include <sys/types.h>
 
 
-struct kern {
-   short int version[3];
-};
+typedef struct KernelVersion {
+   short int major;
+   short int minor;
+   short int patch;
+} KernelVersion;
 
-void Platform_GetKernelVersion(struct kern* k);
+void Platform_GetKernelVersion(KernelVersion* k);
 
 /* compare the given os version with the one installed returns:
 0 if equals the installed version
 positive value if less than the installed version
 negative value if more than the installed version
 */
-int Platform_CompareKernelVersion(short int major, short int minor, short int component);
+int Platform_CompareKernelVersion(KernelVersion v);
+
+// lowerBound <= currentVersion < upperBound
+bool Platform_KernelVersionIsBetween(KernelVersion lowerBound, KernelVersion upperBound);
 
 double Platform_calculateNanosecondsPerMachTick(void);
 

--- a/darwin/PlatformHelpers.h
+++ b/darwin/PlatformHelpers.h
@@ -31,4 +31,10 @@ bool Platform_KernelVersionIsBetween(KernelVersion lowerBound, KernelVersion upp
 
 double Platform_calculateNanosecondsPerMachTick(void);
 
+void Platform_getCPUBrandString(char *cpuBrandString, size_t cpuBrandStringSize);
+
+bool Platform_isRunningTranslated(void);
+
+double Platform_calculateNanosecondsPerMachTick(void);
+
 #endif

--- a/darwin/PlatformHelpers.h
+++ b/darwin/PlatformHelpers.h
@@ -1,0 +1,29 @@
+#ifndef HEADER_PlatformHelpers
+#define HEADER_PlatformHelpers
+/*
+htop - darwin/PlatformHelpers.h
+(C) 2018 Pierre Malhaire, 2020-2021 htop dev team, 2021 Alexander Momchilov
+Released under the GNU GPLv2, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include <stdbool.h>
+#include <sys/types.h>
+
+
+struct kern {
+   short int version[3];
+};
+
+void Platform_GetKernelVersion(struct kern* k);
+
+/* compare the given os version with the one installed returns:
+0 if equals the installed version
+positive value if less than the installed version
+negative value if more than the installed version
+*/
+int Platform_CompareKernelVersion(short int major, short int minor, short int component);
+
+double Platform_calculateNanosecondsPerMachTick(void);
+
+#endif


### PR DESCRIPTION
This PR is mainly a workaround for https://openradar.appspot.com/radar?id=5055988478509056 (rdar://FB9546856), but also incorporates a refactor of some Darwin platform-related helper methods. I've split the different pieces into separate commits.



Ready for review after some initial rounds of feedback from @natoscott on https://github.com/amomchilov/htop/pull/3