### PR TITLE
Linux: define O_PATH if not defined

### DIFF
--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -58,6 +58,10 @@ in the source distribution for its full text.
 #include "LibSensors.h"
 #endif
 
+#ifndef O_PATH
+#define O_PATH         010000000 // declare for ancient glibc versions
+#endif
+
 
 static long long btime = -1;
 


### PR DESCRIPTION
Defining O_PATH if not defined by <fcntl.h> does not really add any
maintenance cost and might improve some portability.

Related: #804