### PR TITLE
Linux: always compute procExeDeleted if already set

### DIFF
--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -1236,8 +1236,8 @@ static bool LinuxProcessList_readCmdlineFile(Process* process, openat_arg_t proc
    if (amtRead > 0) {
       filename[amtRead] = 0;
       if (!process->procExe ||
-         (!process->procExeDeleted && !String_eq(filename, process->procExe)) ||
-         (process->procExeDeleted && !String_startsWith(filename, process->procExe))) {
+          (!process->procExeDeleted && !String_eq(filename, process->procExe)) ||
+          process->procExeDeleted) {
 
          const char* deletedMarker = " (deleted)";
          const size_t markerLen = strlen(deletedMarker);


### PR DESCRIPTION
A process, whose executable has been replaced and thus marked by htop,
can be re-executed with the replaced executable, with the same PID, in
two ways: the Linux feature checkpoint/restore or re-execution of PID 1.
The actual check is just a string comparison, like the dropped
condition, leading to (almost) no computation overhead.