### PR TITLE
astyle: Add `--pad-header` option

### DIFF
--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -196,7 +196,7 @@ They can be a great asset to structure the flow of a method.
 If you want to automate formatting your code, the following command gives you a good baseline of how it should look:
 
 ```bash
-astyle -r -xb -s3 -p -xg -c -k1 -W1 \*.c \*.h
+astyle -r -xb -s3 -p -xg -c -k1 -W1 -H \*.c \*.h
 ```
 
 Working with System APIs


### PR DESCRIPTION
Insert space padding between a header (e.g. 'if', 'for', 'while'...) and the
following paren. ex:

if(isFoo((a+2), b))
    bar(a, b);

becomes:

if (isFoo((a+2), b))
    bar(a, b);

Link: http://astyle.sourceforge.net/astyle.html#_pad-paren
Signed-off-by: Sohaib Mohamed <sohaib.amhmd@gmail.com>