### PR TITLE
Release memory for cmdline when Process_updateCmdline() returns.

### DIFF
--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -444,6 +444,8 @@ static void FreeBSDProcessList_updateProcessName(kvm_t* kd, const struct kinfo_p
    *at = '\0';
 
    Process_updateCmdline(proc, cmdline, 0, end);
+
+   free(cmdline);
 }
 
 static char* FreeBSDProcessList_readJailName(const struct kinfo_proc* kproc) {


### PR DESCRIPTION
This closes a nasty memory leak. There is at least another leak looming somewhere when Disk I/O is shown in the header area. That could very well be an issue within libdevstat native to FreeBSD.