### PR TITLE
Handle interrupted sampling from within libpcp PDU transfers

### DIFF
--- a/pcp/PCPMetric.c
+++ b/pcp/PCPMetric.c
@@ -164,7 +164,10 @@ bool PCPMetric_fetch(struct timeval* timestamp) {
       pmFreeResult(pcp->result);
       pcp->result = NULL;
    }
-   int sts = pmFetch(pcp->totalMetrics, pcp->fetch, &pcp->result);
+   int sts, count = 0;
+   do {
+       sts = pmFetch(pcp->totalMetrics, pcp->fetch, &pcp->result);
+   } while (sts == PM_ERR_IPC && ++count < 3);
    if (sts < 0) {
       if (pmDebugOptions.appl0)
          fprintf(stderr, "Error: cannot fetch metric values: %s\n",

--- a/pcp/PCPProcessList.c
+++ b/pcp/PCPProcessList.c
@@ -680,7 +680,8 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
    PCPMetric_enable(PCP_PROC_SMAPS_SWAPPSS, smaps_flag && enabled);
 
    struct timeval timestamp;
-   PCPMetric_fetch(&timestamp);
+   if (PCPMetric_fetch(&timestamp) != true)
+      return;
 
    double sample = this->timestamp;
    this->timestamp = pmtimevalToReal(&timestamp);


### PR DESCRIPTION
This situation can arise if pcp-htop screen is resized right
at the same time sampling from pmcd(1) is happening.  Have a
couple more goes at it before giving up entirely; once there
is no data available though we cannot proceed into accessing
the sample result data structure (segv will result) so a new
short-circuit guard is added there also.