### PR TITLE
Report hugepage memory as real and used memory (as before)

### DIFF
--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -331,8 +331,8 @@ void Platform_setMemoryValues(Meter* this) {
    const ProcessList* pl = this->pl;
    const LinuxProcessList* lpl = (const LinuxProcessList*) pl;
 
-   this->total     = pl->totalMem > lpl->totalHugePageMem ? pl->totalMem - lpl->totalHugePageMem : pl->totalMem;
-   this->values[0] = pl->usedMem > lpl->totalHugePageMem ? pl->usedMem - lpl->totalHugePageMem : pl->usedMem;
+   this->total     = pl->totalMem;
+   this->values[0] = pl->usedMem;
    this->values[1] = pl->buffersMem;
    this->values[2] = pl->sharedMem;
    this->values[3] = pl->cachedMem;


### PR DESCRIPTION
This is real, physical memory available for applications to
use.  We should not try to pretend otherwise; its confusing
for users and inconsistent with all other tools.