### PR TITLE
Suppress reporting memory leaks originating from libdevstat

### DIFF
--- a/scripts/htop_suppressions.valgrind
+++ b/scripts/htop_suppressions.valgrind
@@ -45,3 +45,39 @@
    fun:CRT_setColors
    fun:CRT_init
 }
+
+{
+   <devstat internal memory>
+   Memcheck:Leak
+   match-leak-kinds: possible,reachable
+   ...
+   obj:*/libdevstat*
+   fun:devstat_getdevs
+}
+
+{
+   <devstat internal memory>
+   Memcheck:Leak
+   match-leak-kinds: possible,reachable
+   ...
+   obj:*/libdevstat*
+   fun:devstat_selectdevs
+}
+
+{
+   <devstat internal memory>
+   Memcheck:Leak
+   match-leak-kinds: possible,reachable
+   ...
+   obj:*/libdevstat*
+   fun:devstat_buildmatch
+}
+
+{
+   <devstat internal memory>
+   Memcheck:Leak
+   match-leak-kinds: possible,reachable
+   ...
+   obj:*/libdevstat*
+   fun:get_devstat_kvm
+}


### PR DESCRIPTION
Based on https://cgit.freebsd.org/src/tree/lib/libdevstat/devstat.c, I have identified four functions that call memory allocation functions.
`devstat_getdevs()`, `devstat_selectdevs()`, `devstat_buildmatch()`, and, `get_devstat_kvm()`.