### PR TITLE
FreeBSD: add comment for memory leak workaround

### DIFF
--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -284,6 +284,7 @@ bool Platform_getDiskIO(DiskIOData* data) {
    if (devstat_checkversion(NULL) < 0)
       return false;
 
+   // use static to plug memory leak; see #841
    static struct devinfo info = { 0 };
    struct statinfo current = { .dinfo = &info };
 


### PR DESCRIPTION
Follow-up of #841 

Avoid unintentional reverts.