### PR TITLE
Compress cgroup names based on some heuristics

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -153,6 +153,7 @@ linux_platform_headers = \
 	generic/gettime.h \
 	generic/hostname.h \
 	generic/uname.h \
+	linux/CGroupUtils.h \
 	linux/HugePageMeter.h \
 	linux/IOPriority.h \
 	linux/IOPriorityPanel.h \
@@ -174,6 +175,7 @@ linux_platform_sources = \
 	generic/gettime.c \
 	generic/hostname.c \
 	generic/uname.c \
+	linux/CGroupUtils.c \
 	linux/HugePageMeter.c \
 	linux/IOPriorityPanel.c \
 	linux/LibSensors.c \

--- a/htop.1.in
+++ b/htop.1.in
@@ -488,7 +488,23 @@ The I/O rate of write(2) in bytes per second, for the process.
 The I/O rate, IO_READ_RATE + IO_WRITE_RATE (see above).
 .TP
 .B CGROUP
-Which cgroup the process is in.
+Which cgroup the process is in. For a shortened view see the CCGROUP column below.
+.TP
+.B CCGROUP
+Shortened view of the cgroup name that the process is in.
+This performs some pattern-based replacements to shorten the displayed string and thus condense the information.
+   \fB/*.slice\fR is shortened to \fB/[*]\fR (exceptions below)
+   \fB/system.slice\fR is shortened to \fB/[S]\fR
+   \fB/user.slice\fR is shortened to \fB/[U]\fR
+   \fB/user-*.slice\fR is shortened to \fB/[U:*]\fR (directly preceeding \fB/[U]\fR before dropped)
+   \fB/machine.slice\fR is shortened to \fB/[M]\fR
+   \fB/machine-*.scope\fR is shortened to \fB/[SNC:*]\fR (SNC: systemd nspawn container), uppercase for the monitor
+   \fB/lxc.monitor.*\fR is shortened to \fB/[LXC:*]\fR
+   \fB/lxc.payload.*\fR is shortened to \fB/[lxc:*]\fR
+   \fB/*.scope\fR is shortened to \fB/!*\fR
+   \fB/*.service\fR is shortened to \fB/*\fR (suffix removed)
+
+Encountered escape sequences (e.g. from systemd) inside the cgroup name are not decoded.
 .TP
 .B OOM
 OOM killer score.

--- a/linux/CGroupUtils.c
+++ b/linux/CGroupUtils.c
@@ -1,0 +1,285 @@
+/*
+htop - CGroupUtils.h
+(C) 2021 htop dev team
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include "linux/CGroupUtils.h"
+
+#include "XUtils.h"
+
+
+static bool CGroup_filterName_internal(const char *cgroup, char* buf, size_t bufsize) {
+   const char* str_slice_suffix = ".slice";
+   const char* str_system_slice = "system.slice";
+   const char* str_user_slice = "user.slice";
+   const char* str_machine_slice = "machine.slice";
+   const char* str_user_slice_prefix = "/user-";
+
+   const char* str_lxc_monitor_prefix = "lxc.monitor.";
+   const char* str_lxc_payload_prefix = "lxc.payload.";
+
+   const char* str_nspawn_scope_prefix = "machine-";
+   const char* str_nspawn_monitor_label = "/supervisor";
+
+   const char* str_service_suffix = ".service";
+   const char* str_scope_suffix = ".scope";
+
+   while(*cgroup) {
+      if ('/' == *cgroup) {
+         while ('/' == *cgroup)
+            cgroup++;
+
+         if (!bufsize)
+            return false;
+
+         *buf++ = '/';
+         bufsize--;
+
+         continue;
+      }
+
+      const char* labelStart = cgroup;
+      const char* nextSlash = strchrnul(labelStart, '/');
+      const size_t labelLen = nextSlash - labelStart;
+
+      if (String_startsWith(cgroup, str_system_slice)) {
+         cgroup += strlen(str_system_slice);
+
+         if (*cgroup && *cgroup != '/')
+            goto handle_default;
+
+         if (bufsize < 3)
+            return false;
+
+         *buf++ = '[';
+         *buf++ = 'S';
+         *buf++ = ']';
+         bufsize -= 3;
+
+         continue;
+      }
+
+      if (String_startsWith(cgroup, str_machine_slice)) {
+         cgroup += strlen(str_machine_slice);
+
+         if (*cgroup && *cgroup != '/')
+            goto handle_default;
+
+         if (bufsize < 3)
+            return false;
+
+         *buf++ = '[';
+         *buf++ = 'M';
+         *buf++ = ']';
+         bufsize -= 3;
+
+         continue;
+      }
+
+      if (String_startsWith(cgroup, str_user_slice)) {
+         cgroup += strlen(str_user_slice);
+
+         if (*cgroup && *cgroup != '/')
+            goto handle_default;
+
+         if (bufsize < 3)
+            return false;
+
+         *buf++ = '[';
+         *buf++ = 'U';
+         *buf++ = ']';
+         bufsize -= 3;
+
+         if (!String_startsWith(cgroup, str_user_slice_prefix))
+            continue;
+
+         const char* userSliceSlash = strchrnul(cgroup + strlen(str_user_slice_prefix), '/');
+         const char* sliceSpec = userSliceSlash - strlen(str_slice_suffix);
+
+         if (!String_startsWith(sliceSpec, str_slice_suffix))
+            continue;
+
+         const size_t sliceNameLen = sliceSpec - (cgroup + strlen(str_user_slice_prefix));
+
+         if (bufsize < sliceNameLen + 1)
+            return false;
+
+         buf[-1] = ':';
+
+         cgroup += strlen(str_user_slice_prefix);
+         while(cgroup < sliceSpec) {
+            *buf++ = *cgroup++;
+            bufsize--;
+         }
+         cgroup = userSliceSlash;
+
+         *buf++ = ']';
+         bufsize--;
+
+         continue;
+      }
+
+      if (labelLen > strlen(str_slice_suffix) && String_startsWith(nextSlash - strlen(str_slice_suffix), str_slice_suffix)) {
+         const size_t sliceNameLen = labelLen - strlen(str_slice_suffix);
+         if (bufsize < 2 + sliceNameLen)
+            return false;
+
+         *buf++ = '[';
+         bufsize--;
+
+         for(size_t i = sliceNameLen; i; i--) {
+            *buf++ = *cgroup++;
+            bufsize--;
+         }
+
+         *buf++ = ']';
+         bufsize--;
+
+         cgroup = nextSlash;
+
+         continue;
+      }
+
+      if (String_startsWith(cgroup, str_lxc_payload_prefix)) {
+         const size_t cgroupNameLen = labelLen - strlen(str_lxc_payload_prefix);
+         if (bufsize < 6 + cgroupNameLen)
+            return false;
+
+         *buf++ = '[';
+         *buf++ = 'l';
+         *buf++ = 'x';
+         *buf++ = 'c';
+         *buf++ = ':';
+         bufsize -= 5;
+
+         cgroup += strlen(str_lxc_payload_prefix);
+         while(cgroup < nextSlash) {
+            *buf++ = *cgroup++;
+            bufsize--;
+         }
+
+         *buf++ = ']';
+         bufsize--;
+
+         continue;
+      }
+
+      if (String_startsWith(cgroup, str_lxc_monitor_prefix)) {
+         const size_t cgroupNameLen = labelLen - strlen(str_lxc_monitor_prefix);
+         if (bufsize < 6 + cgroupNameLen)
+            return false;
+
+         *buf++ = '[';
+         *buf++ = 'L';
+         *buf++ = 'X';
+         *buf++ = 'C';
+         *buf++ = ':';
+         bufsize -= 5;
+
+         cgroup += strlen(str_lxc_monitor_prefix);
+         while(cgroup < nextSlash) {
+            *buf++ = *cgroup++;
+            bufsize--;
+         }
+
+         *buf++ = ']';
+         bufsize--;
+
+         continue;
+      }
+
+      if (labelLen > strlen(str_service_suffix) && String_startsWith(nextSlash - strlen(str_service_suffix), str_service_suffix)) {
+         const size_t serviceNameLen = labelLen - strlen(str_service_suffix);
+
+         if (String_startsWith(cgroup, "user@")) {
+            cgroup = nextSlash;
+
+            while(*cgroup == '/')
+               cgroup++;
+
+            continue;
+         }
+
+         if (bufsize < serviceNameLen)
+            return false;
+
+         for(size_t i = serviceNameLen; i; i--) {
+            *buf++ = *cgroup++;
+            bufsize--;
+         }
+
+         cgroup = nextSlash;
+
+         continue;
+      }
+
+      if (labelLen > strlen(str_scope_suffix) && String_startsWith(nextSlash - strlen(str_scope_suffix), str_scope_suffix)) {
+         const size_t scopeNameLen = labelLen - strlen(str_scope_suffix);
+
+         if (String_startsWith(cgroup, str_nspawn_scope_prefix)) {
+            const size_t machineScopeNameLen = scopeNameLen - strlen(str_nspawn_scope_prefix);
+            if (bufsize < 6 + machineScopeNameLen)
+               return false;
+
+            const bool is_monitor = String_startsWith(nextSlash, str_nspawn_monitor_label);
+
+            *buf++ = '[';
+            *buf++ = is_monitor ? 'S' : 's';
+            *buf++ = is_monitor ? 'N' : 'n';
+            *buf++ = is_monitor ? 'C' : 'c';
+            *buf++ = ':';
+            bufsize -= 5;
+
+            cgroup += strlen(str_nspawn_scope_prefix);
+            for(size_t i = machineScopeNameLen; i; i--) {
+               *buf++ = *cgroup++;
+               bufsize--;
+            }
+
+            *buf++ = ']';
+            bufsize--;
+
+            cgroup = nextSlash;
+
+            continue;
+         }
+
+         if (bufsize < 1 + scopeNameLen)
+            return false;
+
+         *buf++ = '!';
+         bufsize--;
+
+         for(size_t i = scopeNameLen; i; i--) {
+            *buf++ = *cgroup++;
+            bufsize--;
+         }
+
+         cgroup = nextSlash;
+
+         continue;
+      }
+
+handle_default:
+      // Default behavior: Copy the full label
+      cgroup = labelStart;
+
+      if (bufsize < (size_t)(nextSlash - cgroup))
+         return false;
+
+      while(cgroup < nextSlash) {
+         *buf++ = *cgroup++;
+         bufsize--;
+      }
+   }
+
+   return true;
+}
+
+bool CGroup_filterName(const char *cgroup, char* buf, size_t bufsize) {
+   memset(buf, 0, bufsize);
+
+   return CGroup_filterName_internal(cgroup, buf, bufsize - 1);
+}

--- a/linux/CGroupUtils.h
+++ b/linux/CGroupUtils.h
@@ -11,6 +11,6 @@ in the source distribution for its full text.
 #include <stddef.h>
 
 
-bool CGroup_filterName(const char *cgroup, char* buf, size_t bufsize);
+char* CGroup_filterName(const char *cgroup);
 
 #endif /* HEADER_CGroupUtils */

--- a/linux/CGroupUtils.h
+++ b/linux/CGroupUtils.h
@@ -1,0 +1,16 @@
+#ifndef HEADER_CGroupUtils
+#define HEADER_CGroupUtils
+/*
+htop - CGroupUtils.h
+(C) 2021 htop dev team
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include <stdbool.h>
+#include <stddef.h>
+
+
+bool CGroup_filterName(const char *cgroup, char* buf, size_t bufsize);
+
+#endif /* HEADER_CGroupUtils */

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -81,7 +81,7 @@ const ProcessFieldData Process_fields[LAST_PROCESSFIELD] = {
    [IO_READ_RATE] = { .name = "IO_READ_RATE", .title = " DISK READ  ", .description = "The I/O rate of read(2) in bytes per second for the process", .flags = PROCESS_FLAG_IO, .defaultSortDesc = true, },
    [IO_WRITE_RATE] = { .name = "IO_WRITE_RATE", .title = " DISK WRITE ", .description = "The I/O rate of write(2) in bytes per second for the process", .flags = PROCESS_FLAG_IO, .defaultSortDesc = true, },
    [IO_RATE] = { .name = "IO_RATE", .title = "   DISK R/W ", .description = "Total I/O rate in bytes per second", .flags = PROCESS_FLAG_IO, .defaultSortDesc = true, },
-   [CGROUP] = { .name = "CGROUP", .title = "    CGROUP ", .description = "Which cgroup the process is in", .flags = PROCESS_FLAG_LINUX_CGROUP, },
+   [CGROUP] = { .name = "CGROUP", .title = "CGROUP                              ", .description = "Which cgroup the process is in", .flags = PROCESS_FLAG_LINUX_CGROUP, },
    [OOM] = { .name = "OOM", .title = " OOM ", .description = "OOM (Out-of-Memory) killer score", .flags = PROCESS_FLAG_LINUX_OOM, .defaultSortDesc = true, },
    [IO_PRIORITY] = { .name = "IO_PRIORITY", .title = "IO ", .description = "I/O priority", .flags = PROCESS_FLAG_LINUX_IOPRIO, },
 #ifdef HAVE_DELAYACCT
@@ -246,7 +246,7 @@ static void LinuxProcess_writeField(const Process* this, RichString* str, Proces
    #ifdef HAVE_VSERVER
    case VXID: xSnprintf(buffer, n, "%5u ", lp->vxid); break;
    #endif
-   case CGROUP: xSnprintf(buffer, n, "%-10s ", lp->cgroup ? lp->cgroup : ""); break;
+   case CGROUP: xSnprintf(buffer, n, "%-35.35s ", lp->cgroup ? lp->cgroup : "N/A"); break;
    case OOM: xSnprintf(buffer, n, "%4u ", lp->oom); break;
    case IO_PRIORITY: {
       int klass = IOPriority_class(lp->ioPriority);

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -81,7 +81,8 @@ const ProcessFieldData Process_fields[LAST_PROCESSFIELD] = {
    [IO_READ_RATE] = { .name = "IO_READ_RATE", .title = " DISK READ  ", .description = "The I/O rate of read(2) in bytes per second for the process", .flags = PROCESS_FLAG_IO, .defaultSortDesc = true, },
    [IO_WRITE_RATE] = { .name = "IO_WRITE_RATE", .title = " DISK WRITE ", .description = "The I/O rate of write(2) in bytes per second for the process", .flags = PROCESS_FLAG_IO, .defaultSortDesc = true, },
    [IO_RATE] = { .name = "IO_RATE", .title = "   DISK R/W ", .description = "Total I/O rate in bytes per second", .flags = PROCESS_FLAG_IO, .defaultSortDesc = true, },
-   [CGROUP] = { .name = "CGROUP", .title = "CGROUP                              ", .description = "Which cgroup the process is in", .flags = PROCESS_FLAG_LINUX_CGROUP, },
+   [CGROUP] = { .name = "CGROUP", .title = "CGROUP (raw)                        ", .description = "Which cgroup the process is in", .flags = PROCESS_FLAG_LINUX_CGROUP, },
+   [CCGROUP] = { .name = "CCGROUP", .title = "CGROUP (compressed)                 ", .description = "Which cgroup the process is in (condensed to essentials)", .flags = PROCESS_FLAG_LINUX_CGROUP, },
    [OOM] = { .name = "OOM", .title = " OOM ", .description = "OOM (Out-of-Memory) killer score", .flags = PROCESS_FLAG_LINUX_OOM, .defaultSortDesc = true, },
    [IO_PRIORITY] = { .name = "IO_PRIORITY", .title = "IO ", .description = "I/O priority", .flags = PROCESS_FLAG_LINUX_IOPRIO, },
 #ifdef HAVE_DELAYACCT
@@ -111,6 +112,7 @@ Process* LinuxProcess_new(const Settings* settings) {
 void Process_delete(Object* cast) {
    LinuxProcess* this = (LinuxProcess*) cast;
    Process_done((Process*)cast);
+   free(this->cgroup_short);
    free(this->cgroup);
 #ifdef HAVE_OPENVZ
    free(this->ctid);
@@ -247,6 +249,7 @@ static void LinuxProcess_writeField(const Process* this, RichString* str, Proces
    case VXID: xSnprintf(buffer, n, "%5u ", lp->vxid); break;
    #endif
    case CGROUP: xSnprintf(buffer, n, "%-35.35s ", lp->cgroup ? lp->cgroup : "N/A"); break;
+   case CCGROUP: xSnprintf(buffer, n, "%-35.35s ", lp->cgroup_short ? lp->cgroup_short : (lp->cgroup ? lp->cgroup : "N/A")); break;
    case OOM: xSnprintf(buffer, n, "%4u ", lp->oom); break;
    case IO_PRIORITY: {
       int klass = IOPriority_class(lp->ioPriority);
@@ -370,6 +373,8 @@ static int LinuxProcess_compareByKey(const Process* v1, const Process* v2, Proce
    #endif
    case CGROUP:
       return SPACESHIP_NULLSTR(p1->cgroup, p2->cgroup);
+   case CCGROUP:
+      return SPACESHIP_NULLSTR(p1->cgroup_short, p2->cgroup_short);
    case OOM:
       return SPACESHIP_NUMBER(p1->oom, p2->oom);
    #ifdef HAVE_DELAYACCT

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -89,6 +89,7 @@ typedef struct LinuxProcess_ {
    unsigned int vxid;
    #endif
    char* cgroup;
+   char* cgroup_short;
    unsigned int oom;
    #ifdef HAVE_DELAYACCT
    unsigned long long int delay_read_time;

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -905,14 +905,14 @@ static void LinuxProcessList_readCGroupFile(LinuxProcess* process, openat_arg_t 
    if (!changed)
       return;
 
-   char* cgroup_short = xCalloc(strlen(process->cgroup) + 1, 1);
-   if (CGroup_filterName(process->cgroup, cgroup_short, strlen(process->cgroup) + 1)) {
+   char* cgroup_short = CGroup_filterName(process->cgroup);
+   if (cgroup_short) {
       free_and_xStrdup(&process->cgroup_short, cgroup_short);
+      free(cgroup_short);
    } else {
       free(process->cgroup_short);
       process->cgroup_short = NULL;
    }
-   free(cgroup_short);
 }
 
 #ifdef HAVE_VSERVER

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -872,9 +872,16 @@ static void LinuxProcessList_readCGroupFile(LinuxProcess* process, openat_arg_t 
       if (!ok)
          break;
 
-      char* group = strchr(buffer, ':');
-      if (!group)
-         break;
+      char* group = buffer;
+      for (size_t i = 0; i < 2; i++) {
+         group = strchrnul(group, ':');
+         if (!*group)
+            break;
+         group++;
+      }
+
+      char* eol = strchrnul(group, '\n');
+      *eol = '\0';
 
       if (at != output) {
          *at = ';';

--- a/linux/ProcessField.h
+++ b/linux/ProcessField.h
@@ -45,6 +45,7 @@ in the source distribution for its full text.
    SECATTR = 123,                \
    AUTOGROUP_ID = 127,           \
    AUTOGROUP_NICE = 128,         \
+   CCGROUP = 129,                \
    // End of list
 
 


### PR DESCRIPTION
This is some WIP for #216. The current implementation handles most common cgroup namespace patterns encountered for system/user/machine slices, shortens scope identifiers, trims service names and handles both LXC and systemd-nspawn (SNC) containers.

The code probably doesn't win a beauty contest yet, but should suffice as a preview.

Points to clean/optimize:
- [x] Shorten pattern output boilerplate (there's much repetition for string writing)
- [x] Clean up code flow for some of the more complex rules
- [x] Extract some helpers to ease parsing / string handling
- [x] Improve multi-label awareness to simplify rules relying on multiple tokens (like user slices, SNC)
- [x] Allow length determination mode to check for required buffer size
- [x] Include some more legacy rules
- [x] Document important shortening rules