### PR TITLE
Linux: use proper way to detect kernel threads

### DIFF
--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -48,6 +48,9 @@ typedef struct LinuxProcess_ {
    long m_drs;
    long m_lrs;
 
+   /* Process flags */
+   unsigned long int flags;
+
    /* Data read (in bytes) */
    unsigned long long io_rchar;
 


### PR DESCRIPTION
Use `PF_KTHREAD` flag in `/proc/[pid]/stat` to detect kernel threads.
This fixed an issue when a process's cmdline is empty, htop think it is a kernel thread.