### PR TITLE
Reduce allocation size of cp_time_n and cp_time_o on FreeBSD and DragonFlyBSD

### DIFF
--- a/dragonflybsd/DragonFlyBSDProcessList.c
+++ b/dragonflybsd/DragonFlyBSDProcessList.c
@@ -79,8 +79,8 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* dynamicMeters, H
 
    size_t sizeof_cp_time_array = sizeof(unsigned long) * CPUSTATES;
    len = 2; sysctlnametomib("kern.cp_time", MIB_kern_cp_time, &len);
-   dfpl->cp_time_o = xCalloc(cpus, sizeof_cp_time_array);
-   dfpl->cp_time_n = xCalloc(cpus, sizeof_cp_time_array);
+   dfpl->cp_time_o = xCalloc(CPUSTATES, sizeof(unsigned long));
+   dfpl->cp_time_n = xCalloc(CPUSTATES, sizeof(unsigned long));
    len = sizeof_cp_time_array;
 
    // fetch initial single (or average) CPU clicks from kernel

--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -109,8 +109,8 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* dynamicMeters, H
 
    size_t sizeof_cp_time_array = sizeof(unsigned long) * CPUSTATES;
    len = 2; sysctlnametomib("kern.cp_time", MIB_kern_cp_time, &len);
-   fpl->cp_time_o = xCalloc(cpus, sizeof_cp_time_array);
-   fpl->cp_time_n = xCalloc(cpus, sizeof_cp_time_array);
+   fpl->cp_time_o = xCalloc(CPUSTATES, sizeof(unsigned long));
+   fpl->cp_time_n = xCalloc(CPUSTATES, sizeof(unsigned long));
    len = sizeof_cp_time_array;
 
    // fetch initial single (or average) CPU clicks from kernel


### PR DESCRIPTION
Unless I'm missing something, these two arrays are only ever used to read one set of CPU data, not X (where X is the number of CPUs).

Usage is [here](https://github.com/htop-dev/htop/blob/f75a8bc3a1131151181d6794000b10063400221e/freebsd/FreeBSDProcessList.c#L190) and allocation is [here](https://github.com/htop-dev/htop/blob/f75a8bc3a1131151181d6794000b10063400221e/freebsd/FreeBSDProcessList.c#L112-L113).