### PR TITLE
Add a fix to use gettimeofday if monotonic is not available.

### DIFF
--- a/generic/gettime.c
+++ b/generic/gettime.c
@@ -49,9 +49,13 @@ void Generic_gettime_monotonic(uint64_t* msec) {
    else
       *msec = 0;
 
-#else
+#else /* lower resolution gettimeofday() should be always available */
 
-# error "No monotonic clock available"
+   struct timeval tv;
+   if (gettimeofday(&tv, NULL) == 0)
+      *msec = ((uint64_t)tv.tv_sec * 1000) + ((uint64_t)tv.tv_usec / 1000);
+   else
+      *msec = 0;
 
 #endif
 }


### PR DESCRIPTION
Add an additional fix to support environments where monotonic is not available to Generic_gettime_monotonic.
The fix is necessary to support MacOS older than 10.13., tested down to 10.10..

See issue #373 for more information.

With regards, Lutz