### PR TITLE
add github workflow to build release tarball

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,0 +1,51 @@
+name: Build Source Release
+
+# Trigger whenever a release is created
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+
+    - name: archive
+      id: archive
+      run: |
+        VERSION=${{ github.event.release.tag_name }}
+        PKGNAME="htop-$VERSION"
+        SHASUM=$PKGNAME.tar.xz.sha256
+        autoreconf -i
+        mkdir -p /tmp/$PKGNAME
+        mv * /tmp/$PKGNAME
+        mv /tmp/$PKGNAME .
+        TARBALL=$PKGNAME.tar.xz
+        tar cJf $TARBALL $PKGNAME
+        sha256sum $TARBALL > $SHASUM
+        echo "::set-output name=tarball::$TARBALL"
+        echo "::set-output name=shasum::$SHASUM"
+    - name: upload tarball
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./${{ steps.archive.outputs.tarball }}
+        asset_name: ${{ steps.archive.outputs.tarball }}
+        asset_content_type: application/gzip
+
+    - name: upload shasum
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./${{ steps.archive.outputs.shasum }}
+        asset_name: ${{ steps.archive.outputs.shasum }}
+        asset_content_type: text/plain


### PR DESCRIPTION
the built release tarball provides a pre-built configure script and efficient packing with xz.
tested working.

this creates a release tarball attached to a *release*.
unfortunately i didnt find a way to attach it to a tag, that means after creating a tag one has to additionally go to tags tab, open tag and click "create release from tag".
apart from that no further action is required by the maintainer.

closes #876