### PR TITLE
Fix an issue where the last line is not cleared when a signal is received

### DIFF
--- a/CRT.c
+++ b/CRT.c
@@ -961,6 +961,11 @@ IGNORE_WCASTQUAL_END
 }
 
 void CRT_done() {
+   attron(CRT_colors[RESET_COLOR]);
+   mvhline(LINES - 1, 0, ' ', COLS);
+   attroff(CRT_colors[RESET_COLOR]);
+   refresh();
+
    curs_set(1);
    endwin();
 

--- a/CommandLine.c
+++ b/CommandLine.c
@@ -375,11 +375,6 @@ int CommandLine_run(const char* name, int argc, char** argv) {
 
    ScreenManager_run(scr, NULL, NULL);
 
-   attron(CRT_colors[RESET_COLOR]);
-   mvhline(LINES - 1, 0, ' ', COLS);
-   attroff(CRT_colors[RESET_COLOR]);
-   refresh();
-
    Platform_done();
 
    CRT_done();


### PR DESCRIPTION
When we are using the application on a terminal which does not support ALTBUF (like the linux kernel VT) the application can be properly exited using the F10 key. This will clear the last line of the terminal before exiting. When the application receives a signal (SIGINT,SIGTERM,SIGQUIT) it will close but it doesn't clear the last line.

Here we move the logic to clear the last line into the `CRT_done` function. This ensures that it will be executed when the `CRT_handleSIGTERM` is called.