### PR TITLE
Process: highlight UNINTERRUPTIBLE_WAIT state (D)

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -916,13 +916,13 @@ void Process_writeField(const Process* this, RichString* str, ProcessField field
          case BLOCKED:
          case DEFUNCT:
          case STOPPED:
+         case UNINTERRUPTIBLE_WAIT:
          case ZOMBIE:
             attr = CRT_colors[PROCESS_D_STATE];
             break;
 
          case QUEUED:
          case WAITING:
-         case UNINTERRUPTIBLE_WAIT:
          case IDLE:
          case SLEEPING:
             attr = CRT_colors[PROCESS_SHADOW];


### PR DESCRIPTION
Commit d8dfbbd3 ("Tidy up process state handling") did change the
highlighting of the UNINTERRUPTIBLE_WAIT state (D) from red to gray.
As this state might means the process probably still has work to do and
can hint at bottlenecks, revert this particular change.

Fixes: d8dfbbd3 ("Tidy up process state handling")