### PR TITLE
CGroupUtils: avoid unsigned integer underflow

### DIFF
--- a/linux/CGroupUtils.c
+++ b/linux/CGroupUtils.c
@@ -33,7 +33,7 @@ static bool StrBuf_putc_write(StrBuf_state* p, char c) {
 }
 
 static bool StrBuf_putsn(StrBuf_state* p, StrBuf_putc_t w, const char* s, size_t count) {
-   while (count--)
+   for (; count; count--)
       if (!w(p, *s++))
          return false;
 


### PR DESCRIPTION
Do not underflow count at the last iteration, which triggers UBSAN when
using -fsanitize=unsigned-integer-overflow. This is useful as those
underflows can be a result of a flawed counting logic (e.g. a counter
gets reduced more than increased).