### PR TITLE
{Disk,Network}IOMeter: degrade "no data" to warning

### DIFF
--- a/DiskIOMeter.c
+++ b/DiskIOMeter.c
@@ -98,7 +98,7 @@ static void DiskIOMeter_updateValues(Meter* this) {
 
 static void DiskIOMeter_display(ATTR_UNUSED const Object* cast, RichString* out) {
    if (!hasData) {
-      RichString_writeAscii(out, CRT_colors[METER_VALUE_ERROR], "no data");
+      RichString_writeAscii(out, CRT_colors[METER_VALUE_WARN], "no data");
       return;
    }
 

--- a/NetworkIOMeter.c
+++ b/NetworkIOMeter.c
@@ -105,7 +105,7 @@ static void NetworkIOMeter_updateValues(Meter* this) {
 
 static void NetworkIOMeter_display(ATTR_UNUSED const Object* cast, RichString* out) {
    if (!hasData) {
-      RichString_writeAscii(out, CRT_colors[METER_VALUE_ERROR], "no data");
+      RichString_writeAscii(out, CRT_colors[METER_VALUE_WARN], "no data");
       return;
    }
 


### PR DESCRIPTION
Starting htop I am now faced with "no data", painted in red. This color
should be reserved to critical issues, like "degraded" in systemd meter.

So degrade "no data" to warning state and paint it in yellow.