### PR TITLE
Hashmap: avoid rehashing to same size on shrinking

### DIFF
--- a/Hashtable.c
+++ b/Hashtable.c
@@ -286,7 +286,7 @@ void* Hashtable_remove(Hashtable* this, ht_key_t key) {
 
    /* shrink on load-factor < 0.125 */
    if (8 * this->items < this->size)
-      Hashtable_setSize(this, this->size / 2);
+      Hashtable_setSize(this, this->size / 3); /* account for nextPrime rounding up */
 
    return res;
 }

--- a/Hashtable.c
+++ b/Hashtable.c
@@ -191,10 +191,14 @@ void Hashtable_setSize(Hashtable* this, size_t size) {
    if (size <= this->items)
       return;
 
+   size_t newSize = nextPrime(size);
+   if (newSize == this->size)
+      return;
+
    HashtableItem* oldBuckets = this->buckets;
    size_t oldSize = this->size;
 
-   this->size = nextPrime(size);
+   this->size = newSize;
    this->buckets = (HashtableItem*) xCalloc(this->size, sizeof(HashtableItem));
    this->items = 0;
 


### PR DESCRIPTION
Currently Htop does not shrink hashmaps from certain sizes, and wastes quite some CPU cycles doing that.

For example, a size 8191 hashmap would have its size halved to 4095 and rounded up by `nextPrime` back to 8191 (the previous prime is 4093). Still, `Hashmap_setSize` would rehash the map looping over all buckets. That would happen on every removal as long as the item count stays low enough.

This PR tackles the problem from both sides:
- avoid rehashing if the new size is the same as the old one,
- divide size by 3 so that `nextPrime` always finds a prime lower than the one used before shrinking.