### PR TITLE
simplify tree view sorting

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -189,8 +189,7 @@ static Htop_Reaction actionSetSortColumn(State* st) {
    }
    Object_delete(sortPanel);
 
-   if (st->pauseProcessUpdate)
-      ProcessList_sort(st->pl);
+   st->pl->needsSort = true;
 
    return reaction | HTOP_REFRESH | HTOP_REDRAW_BAR | HTOP_UPDATE_PANELHDR;
 }
@@ -281,8 +280,7 @@ static Htop_Reaction actionLowerPriority(State* st) {
 
 static Htop_Reaction actionInvertSortOrder(State* st) {
    ScreenSettings_invertSortOrder(st->settings->ss);
-   if (st->pauseProcessUpdate)
-      ProcessList_sort(st->pl);
+   st->pl->needsSort = true;
    return HTOP_REFRESH | HTOP_SAVE_SETTINGS | HTOP_KEEP_FOLLOWING;
 }
 

--- a/Process.h
+++ b/Process.h
@@ -255,6 +255,9 @@ typedef struct Process_ {
    unsigned int tree_depth;
    unsigned int tree_index;
 
+   /* Has no known parent process */
+   bool isRoot;
+
    /*
     * Internal state for merged Command display
     */

--- a/Process.h
+++ b/Process.h
@@ -250,10 +250,7 @@ typedef struct Process_ {
     * Internal state for tree-mode.
     */
    int indent;
-   unsigned int tree_left;
-   unsigned int tree_right;
    unsigned int tree_depth;
-   unsigned int tree_index;
 
    /* Has no known parent process */
    bool isRoot;

--- a/ProcessList.c
+++ b/ProcessList.c
@@ -274,13 +274,17 @@ static void ProcessList_buildTree(ProcessList* this) {
 
       // If PID corresponds with PPID (e.g. "kernel_task" (PID:0, PPID:0)
       // on Mac OS X 10.11.6) regard this process as root.
-      if (process->pid == ppid)
+      if (process->pid == ppid) {
          process->isRoot = true;
+         continue;
+      }
 
       // On Linux both the init process (pid 1) and the root UMH kernel thread (pid 2)
       // use a ppid of 0. As that PID can't exist, we can skip searching for it.
-      if (!ppid)
+      if (!ppid) {
          process->isRoot = true;
+         continue;
+      }
 
       // We don't know about its parent for whatever reason
       if (ProcessList_findProcess(this, ppid) == NULL)

--- a/ProcessList.c
+++ b/ProcessList.c
@@ -27,6 +27,7 @@ ProcessList* ProcessList_init(ProcessList* this, const ObjectClass* klass, Users
    this->processTable = Hashtable_new(200, false);
    this->displayTreeSet = Hashtable_new(200, false);
    this->draftingTreeSet = Hashtable_new(200, false);
+   this->needsSort = true;
 
    this->usersTable = usersTable;
    this->pidMatchList = pidMatchList;
@@ -496,6 +497,7 @@ void ProcessList_sort(ProcessList* this) {
    } else {
       Vector_insertionSort(this->processes);
    }
+   this->needsSort = false;
 }
 
 ProcessField ProcessList_keyAt(const ProcessList* this, int at) {
@@ -531,6 +533,9 @@ void ProcessList_collapseAllBranches(ProcessList* this) {
 }
 
 void ProcessList_rebuildPanel(ProcessList* this) {
+   if (this->needsSort)
+      ProcessList_sort(this);
+
    const char* incFilter = this->incFilter;
 
    const int currPos = Panel_getSelectedIndex(this->panel);

--- a/ProcessList.c
+++ b/ProcessList.c
@@ -229,10 +229,7 @@ static void ProcessList_buildTreeBranch(ProcessList* this, pid_t pid, int level,
          process->show = false;
       }
 
-      int s = Vector_size(this->displayList);
       Vector_add(this->displayList, process);
-
-      assert(Vector_size(this->displayList) == s + 1); (void)s;
 
       int nextIndent = indent | (1 << level);
       ProcessList_buildTreeBranch(this, process->pid, level + 1, (i < lastShown) ? nextIndent : indent, process->show && process->showChildren);

--- a/ProcessList.c
+++ b/ProcessList.c
@@ -25,8 +25,6 @@ ProcessList* ProcessList_init(ProcessList* this, const ObjectClass* klass, Users
    this->displayList = Vector_new(klass, false, DEFAULT_SIZE);
 
    this->processTable = Hashtable_new(200, false);
-   this->displayTreeSet = Hashtable_new(200, false);
-   this->draftingTreeSet = Hashtable_new(200, false);
    this->needsSort = true;
 
    this->usersTable = usersTable;
@@ -74,8 +72,6 @@ void ProcessList_done(ProcessList* this) {
    }
 #endif
 
-   Hashtable_delete(this->draftingTreeSet);
-   Hashtable_delete(this->displayTreeSet);
    Hashtable_delete(this->processTable);
 
    Vector_delete(this->displayList);
@@ -195,144 +191,7 @@ void ProcessList_remove(ProcessList* this, const Process* p) {
    assert(Hashtable_count(this->processTable) == Vector_count(this->processes));
 }
 
-// ProcessList_updateTreeSetLayer sorts this->displayTreeSet,
-// relying only on itself.
-//
-// Algorithm
-//
-// The algorithm is based on `depth-first search`,
-// even though `breadth-first search` approach may be more efficient on first glance,
-// after comparison it may be not, as it's not safe to go deeper without first updating the tree structure.
-// If it would be safe that approach would likely bring an advantage in performance.
-//
-// Each call of the function looks for a 'layer'. A 'layer' is a list of processes with the same depth.
-// First it sorts a list. Then it runs the function recursively for each element of the sorted list.
-// After that it updates the settings of processes.
-//
-// It relies on `leftBound` and `rightBound` as an optimization to cut the list size at the time it builds a 'layer'.
-//
-// It uses a temporary Hashtable `draftingTreeSet` because it's not safe to traverse a tree
-// and at the same time make changes in it.
-//
-static void ProcessList_updateTreeSetLayer(ProcessList* this, unsigned int leftBound, unsigned int rightBound, unsigned int deep, unsigned int left, unsigned int right, unsigned int* index, unsigned int* treeIndex, int indent) {
-
-   // It's guaranteed that layer_size is enough space
-   // but most likely it needs less. Specifically on first iteration.
-   int layerSize = (right - left) / 2;
-
-   // check if we reach `children` of `leaves`
-   if (layerSize == 0)
-      return;
-
-   Vector* layer = Vector_new(Vector_type(this->displayList), false, layerSize);
-
-   // Find all processes on the same layer (process with the same `deep` value
-   // and included in a range from `leftBound` to `rightBound`).
-   //
-   // This loop also keeps track of left_bound and right_bound of these processes
-   // in order not to lose this information once the list is sorted.
-   //
-   // The variables left_bound and right_bound are different from what the values lhs and rhs represent.
-   // While left_bound and right_bound define a range of processes to look at, the values given by lhs and rhs are indices into an array
-   //
-   // In the below example note how filtering a range of indices i is different from filtering for processes in the bounds left_bound < x < right_bound …
-   //
-   // The nested tree set is sorted by left value, which is guaranteed upon entry/exit of this function.
-   //
-   // i | l | r
-   // 1 | 1 | 9
-   // 2 | 2 | 8
-   // 3 | 4 | 5
-   // 4 | 6 | 7
-   for (unsigned int i = leftBound; i < rightBound; i++) {
-      Process* proc = (Process*)Hashtable_get(this->displayTreeSet, i);
-      assert(proc);
-      if (proc && proc->tree_depth == deep && proc->tree_left > left && proc->tree_right < right) {
-         if (Vector_size(layer) > 0) {
-            Process* previous_process = (Process*)Vector_get(layer, Vector_size(layer) - 1);
-
-            // Make a 'right_bound' of previous_process in a layer the current process's index.
-            //
-            // Use 'tree_depth' as a temporal variable.
-            // It's safe to do as later 'tree_depth' will be renovated.
-            previous_process->tree_depth = proc->tree_index;
-         }
-
-         Vector_add(layer, proc);
-      }
-   }
-
-   // The loop above changes just up to process-1.
-   // So the last process of the layer isn't updated by the above code.
-   //
-   // Thus, if present, set the `rightBound` to the last process on the layer
-   if (Vector_size(layer) > 0) {
-      Process* previous_process = (Process*)Vector_get(layer, Vector_size(layer) - 1);
-      previous_process->tree_depth = rightBound;
-   }
-
-   Vector_quickSort(layer);
-
-   int size = Vector_size(layer);
-   for (int i = 0; i < size; i++) {
-      Process* proc = (Process*)Vector_get(layer, i);
-
-      unsigned int idx = (*index)++;
-      int newLeft = (*treeIndex)++;
-
-      int level = deep == 0 ? 0 : (int)deep - 1;
-      int currentIndent = indent == -1 ? 0 : indent | (1 << level);
-      int nextIndent = indent == -1 ? 0 : ((i < size - 1) ? currentIndent : indent);
-
-      unsigned int newLeftBound = proc->tree_index;
-      unsigned int newRightBound = proc->tree_depth;
-      ProcessList_updateTreeSetLayer(this, newLeftBound, newRightBound, deep + 1, proc->tree_left, proc->tree_right, index, treeIndex, nextIndent);
-
-      int newRight = (*treeIndex)++;
-
-      proc->tree_left = newLeft;
-      proc->tree_right = newRight;
-      proc->tree_index = idx;
-      proc->tree_depth = deep;
-
-      if (indent == -1) {
-         proc->indent = 0;
-      } else if (i == size - 1) {
-         proc->indent = -currentIndent;
-      } else {
-         proc->indent = currentIndent;
-      }
-
-      Hashtable_put(this->draftingTreeSet, proc->tree_index, proc);
-
-      // It's not strictly necessary to do this, but doing so anyways
-      // allows for checking the correctness of the inner workings.
-      Hashtable_remove(this->displayTreeSet, newLeftBound);
-   }
-
-   Vector_delete(layer);
-}
-
-static void ProcessList_updateTreeSet(ProcessList* this) {
-   unsigned int index = 0;
-   unsigned int tree_index = 1;
-
-   const int vsize = Vector_size(this->displayList);
-
-   assert(Hashtable_count(this->draftingTreeSet) == 0);
-   assert((int)Hashtable_count(this->displayTreeSet) == vsize);
-
-   ProcessList_updateTreeSetLayer(this, 0, vsize, 0, 0, vsize * 2 + 1, &index, &tree_index, -1);
-
-   Hashtable* tmp = this->draftingTreeSet;
-   this->draftingTreeSet = this->displayTreeSet;
-   this->displayTreeSet = tmp;
-
-   assert(Hashtable_count(this->draftingTreeSet) == 0);
-   assert((int)Hashtable_count(this->displayTreeSet) == vsize);
-}
-
-static void ProcessList_buildTreeBranch(ProcessList* this, pid_t pid, int level, int indent, bool show, int* node_counter, int* node_index) {
+static void ProcessList_buildTreeBranch(ProcessList* this, pid_t pid, int level, int indent, bool show) {
    // On OpenBSD the kernel thread 'swapper' has pid 0.
    // Do not treat it as root of any tree.
    if (pid == 0)
@@ -366,10 +225,6 @@ static void ProcessList_buildTreeBranch(ProcessList* this, pid_t pid, int level,
    for (int i = l; i < r; i++) {
       Process* process = (Process*)Vector_get(this->processes, i);
 
-      int index = (*node_index)++;
-
-      int lft = (*node_counter)++;
-
       if (!show) {
          process->show = false;
       }
@@ -380,28 +235,15 @@ static void ProcessList_buildTreeBranch(ProcessList* this, pid_t pid, int level,
       assert(Vector_size(this->displayList) == s + 1); (void)s;
 
       int nextIndent = indent | (1 << level);
-      ProcessList_buildTreeBranch(this, process->pid, level + 1, (i < lastShown) ? nextIndent : indent, process->show && process->showChildren, node_counter, node_index);
+      ProcessList_buildTreeBranch(this, process->pid, level + 1, (i < lastShown) ? nextIndent : indent, process->show && process->showChildren);
       if (i == lastShown) {
          process->indent = -nextIndent;
       } else {
          process->indent = nextIndent;
       }
 
-      int rht = (*node_counter)++;
-
-      process->tree_left = lft;
-      process->tree_right = rht;
       process->tree_depth = level + 1;
-      process->tree_index = index;
-      Hashtable_put(this->displayTreeSet, index, process);
    }
-}
-
-static int ProcessList_treeProcessCompare(const void* v1, const void* v2) {
-   const Process* p1 = (const Process*)v1;
-   const Process* p2 = (const Process*)v2;
-
-   return SPACESHIP_NUMBER(p1->tree_left, p2->tree_left);
 }
 
 static int compareProcessByKnownParentThenNatural(const void* v1, const void* v2) {
@@ -422,9 +264,6 @@ static int compareProcessByKnownParentThenNatural(const void* v1, const void* v2
 // Builds a sorted tree from scratch, without relying on previously gathered information
 static void ProcessList_buildTree(ProcessList* this) {
    Vector_prune(this->displayList);
-
-   int node_counter = 1;
-   int node_index = 0;
 
    // Mark root processes
    int vsize = Vector_size(this->processes);
@@ -460,12 +299,8 @@ static void ProcessList_buildTree(ProcessList* this) {
          process = (Process*)Vector_get(this->processes, i);
          process->indent = 0;
          process->tree_depth = 0;
-         process->tree_left = node_counter++;
-         process->tree_index = node_index++;
          Vector_add(this->displayList, process);
-         Hashtable_put(this->displayTreeSet, process->tree_index, process);
-         ProcessList_buildTreeBranch(this, process->pid, 0, 0, process->showChildren, &node_counter, &node_index);
-         process->tree_right = node_counter++;
+         ProcessList_buildTreeBranch(this, process->pid, 0, 0, process->showChildren);
          continue;
       }
    }
@@ -658,13 +493,6 @@ void ProcessList_scan(ProcessList* this, bool pauseProcessUpdate) {
    // Set UID column width based on max UID.
    Process_setUidColumnWidth(maxUid);
 
-   if (this->settings->ss->treeView) {
-      // Clear out the hashtable to avoid any left-over processes from previous build
-      //
-      // The sorting algorithm relies on the fact that
-      // len(this->displayTreeSet) == len(this->processes)
-      Hashtable_clear(this->displayTreeSet);
-
+   if (this->settings->ss->treeView)
       ProcessList_buildTree(this);
-   }
 }

--- a/ProcessList.c
+++ b/ProcessList.c
@@ -492,7 +492,4 @@ void ProcessList_scan(ProcessList* this, bool pauseProcessUpdate) {
 
    // Set UID column width based on max UID.
    Process_setUidColumnWidth(maxUid);
-
-   if (this->settings->ss->treeView)
-      ProcessList_buildTree(this);
 }

--- a/ProcessList.c
+++ b/ProcessList.c
@@ -332,7 +332,7 @@ static void ProcessList_updateTreeSet(ProcessList* this) {
    assert((int)Hashtable_count(this->displayTreeSet) == vsize);
 }
 
-static void ProcessList_buildTreeBranch(ProcessList* this, pid_t pid, int level, int indent, int direction, bool show, int* node_counter, int* node_index) {
+static void ProcessList_buildTreeBranch(ProcessList* this, pid_t pid, int level, int indent, bool show, int* node_counter, int* node_index) {
    // On OpenBSD the kernel thread 'swapper' has pid 0.
    // Do not treat it as root of any tree.
    if (pid == 0)
@@ -362,16 +362,12 @@ static void ProcessList_buildTreeBranch(ProcessList* this, pid_t pid, int level,
       }
 
       int s = Vector_size(this->displayList);
-      if (direction == 1) {
-         Vector_add(this->displayList, process);
-      } else {
-         Vector_insert(this->displayList, 0, process);
-      }
+      Vector_add(this->displayList, process);
 
       assert(Vector_size(this->displayList) == s + 1); (void)s;
 
       int nextIndent = indent | (1 << level);
-      ProcessList_buildTreeBranch(this, process->pid, level + 1, (i < lastShown) ? nextIndent : indent, direction, process->show && process->showChildren, node_counter, node_index);
+      ProcessList_buildTreeBranch(this, process->pid, level + 1, (i < lastShown) ? nextIndent : indent, process->show && process->showChildren, node_counter, node_index);
       if (i == lastShown) {
          process->indent = -nextIndent;
       } else {
@@ -409,7 +405,6 @@ static void ProcessList_buildTree(ProcessList* this) {
 
    int node_counter = 1;
    int node_index = 0;
-   int direction = ScreenSettings_getActiveDirection(this->settings->ss);
 
    // Sort by PID
    Vector_quickSortCustomCompare(this->processes, ProcessList_treeProcessCompareByPID);
@@ -446,7 +441,7 @@ static void ProcessList_buildTree(ProcessList* this) {
          process->tree_index = node_index++;
          Vector_add(this->displayList, process);
          Hashtable_put(this->displayTreeSet, process->tree_index, process);
-         ProcessList_buildTreeBranch(this, process->pid, 0, 0, direction, process->showChildren, &node_counter, &node_index);
+         ProcessList_buildTreeBranch(this, process->pid, 0, 0, process->showChildren, &node_counter, &node_index);
          process->tree_right = node_counter++;
          continue;
       }

--- a/ProcessList.h
+++ b/ProcessList.h
@@ -43,9 +43,9 @@ typedef unsigned long long int memory_t;
 typedef struct ProcessList_ {
    const Settings* settings;
 
-   Vector* processes;
-   Vector* processes2;
-   Hashtable* processTable;
+   Vector* processes;         /* all known processes; sort order can vary and differ from display order */
+   Vector* displayList;       /* process tree flattened in display order (borrowed) */
+   Hashtable* processTable;   /* fast known process lookup by PID */
    UsersTable* usersTable;
 
    Hashtable* displayTreeSet;
@@ -109,7 +109,7 @@ void ProcessList_add(ProcessList* this, Process* p);
 
 void ProcessList_remove(ProcessList* this, const Process* p);
 
-void ProcessList_sort(ProcessList* this);
+void ProcessList_updateDisplayList(ProcessList* this);
 
 ProcessField ProcessList_keyAt(const ProcessList* this, int at);
 

--- a/ProcessList.h
+++ b/ProcessList.h
@@ -48,8 +48,6 @@ typedef struct ProcessList_ {
    Hashtable* processTable;   /* fast known process lookup by PID */
    UsersTable* usersTable;
 
-   Hashtable* displayTreeSet;
-   Hashtable* draftingTreeSet;
    bool needsSort;
 
    Hashtable* dynamicMeters;  /* runtime-discovered meters */

--- a/ProcessList.h
+++ b/ProcessList.h
@@ -50,6 +50,7 @@ typedef struct ProcessList_ {
 
    Hashtable* displayTreeSet;
    Hashtable* draftingTreeSet;
+   bool needsSort;
 
    Hashtable* dynamicMeters;  /* runtime-discovered meters */
    Hashtable* dynamicColumns; /* runtime-discovered Columns */

--- a/ProcessList.h
+++ b/ProcessList.h
@@ -44,7 +44,8 @@ typedef struct ProcessList_ {
    const Settings* settings;
 
    Vector* processes;         /* all known processes; sort order can vary and differ from display order */
-   Vector* displayList;       /* process tree flattened in display order (borrowed) */
+   Vector* displayList;       /* process tree flattened in display order (borrowed);
+                                 updated in ProcessList_updateDisplayList when rebuilding panel */
    Hashtable* processTable;   /* fast known process lookup by PID */
    UsersTable* usersTable;
 

--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -126,7 +126,7 @@ static void checkRecalculation(ScreenManager* this, double* oldTime, int* sortTi
       // always update header, especially to avoid gaps in graph meters
       Header_updateData(this->header);
       if (!this->state->pauseProcessUpdate && (*sortTimeout == 0 || this->settings->ss->treeView)) {
-         ProcessList_sort(pl);
+         pl->needsSort = true;
          *sortTimeout = 1;
       }
       // force redraw if the number of UID digits was changed

--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -121,14 +121,14 @@ static void checkRecalculation(ScreenManager* this, double* oldTime, int* sortTi
    if (*rescan) {
       *oldTime = newTime;
       int oldUidDigits = Process_uidDigits;
-      // scan processes first - some header values are calculated there
-      ProcessList_scan(pl, this->state->pauseProcessUpdate);
-      // always update header, especially to avoid gaps in graph meters
-      Header_updateData(this->header);
       if (!this->state->pauseProcessUpdate && (*sortTimeout == 0 || this->settings->ss->treeView)) {
          pl->needsSort = true;
          *sortTimeout = 1;
       }
+      // scan processes first - some header values are calculated there
+      ProcessList_scan(pl, this->state->pauseProcessUpdate);
+      // always update header, especially to avoid gaps in graph meters
+      Header_updateData(this->header);
       // force redraw if the number of UID digits was changed
       if (Process_uidDigits != oldUidDigits) {
          *force_redraw = true;


### PR DESCRIPTION
This PR merges building and sorting the tree back into one pair of functions and uses sort by parent PID to build tree with reasonable time complexity.

This is WIP as it uses a hack I don't like, but I don't see a nice way around it either. Currently the `processes` and `processes2` vectors in the ProcessList structure are marked as owned, but that does not play nice with time complexity, so `ProcessList_buildTree` for its duration allows processes to be present in both, and clears `processes2` in the end with a hack to avoid freeing them.