### PR TITLE
Naive fix for issue #877 - getting back custom thread names

### DIFF
--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -1552,6 +1552,10 @@ static bool LinuxProcessList_recurseProcTree(LinuxProcessList* this, openat_arg_
             Process_updateCmdline(proc, NULL, 0, 0);
          } else if (!LinuxProcessList_readCmdlineFile(proc, procFd)) {
             Process_updateCmdline(proc, statCommand, 0, strlen(statCommand));
+         } else if (Process_isThread(proc)) {
+            if (settings->showThreadNames && statCommand[0]) {
+               Process_updateCmdline(proc, statCommand, 0, strlen(statCommand));
+            }
          }
 
          Process_fillStarttimeBuffer(proc);


### PR DESCRIPTION
Proposed fix for issue #877 - getting back custom thread names.

I attempted a 'git bisect' and ended up at: ce27f8379d143d64ab6a7787fdf38cb864e18edd

It seems that along with other changes replacing the command with thread name has been accidentally deleted.

Reverting this particular line:
https://github.com/htop-dev/htop/commit/ce27f8379d143d64ab6a7787fdf38cb864e18edd#diff-7b4ee00635e2355bc3b83ada6e57991d2a79ba37828dab7128c461c14645580aL1550
seems to fix the issue.

Please keep in mind that my PR is a naive revert attempt, and while I've tested some setups and it seems to fix the problem and did not break anything, it may not be the fix that one's looking for.