### PR TITLE
linux/SystemdMeter: use warning for some states

### DIFF
--- a/linux/SystemdMeter.c
+++ b/linux/SystemdMeter.c
@@ -307,8 +307,12 @@ static int valueDigitColor(unsigned int value) {
 static void SystemdMeter_display(ATTR_UNUSED const Object* cast, RichString* out) {
    char buffer[16];
    int len;
+   int color = METER_VALUE_ERROR;
 
-   int color = (systemState && String_eq(systemState, "running")) ? METER_VALUE_OK : METER_VALUE_ERROR;
+   if (systemState) {
+      color = String_eq(systemState, "running") ? METER_VALUE_OK :
+              String_eq(systemState, "degraded") ? METER_VALUE_ERROR : METER_VALUE_WARN;
+   }
    RichString_writeAscii(out, CRT_colors[color], systemState ? systemState : "N/A");
 
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " (");


### PR DESCRIPTION
Searching man systemd(1) for "is-system-running" we see these states:

initializing
starting
running
degraded
maintenance
stopping
offline
unknown

Let's differentiate some more: green (ok) if state is "running", red (error)
if the state is unknown to htop or "degraded", yellow (warning) for
everything else (incl. "initializing", "starting", "maintenance" &
"stopping").