### PR TITLE
Altered --pids to show child/descendant processes of specified pid

### DIFF
--- a/ProcessList.c
+++ b/ProcessList.c
@@ -557,9 +557,8 @@ void ProcessList_rebuildPanel(ProcessList* this) {
 
       if ( (!p->show)
          || (this->userId != (uid_t) -1 && (p->st_uid != this->userId))
-         || (incFilter && !(String_contains_i(Process_getCommand(p), incFilter))) ) {
+         || (incFilter && !(String_contains_i(Process_getCommand(p), incFilter))) )
          continue;
-      }
 
       if (this->pidMatchList && !Hashtable_get(this->pidMatchList, p->tgid)) {
          /* Follow processes parents to find matches to process match list */


### PR DESCRIPTION
Hey everyone,

I've found that there's a lot of times that I use htop to track forking and joining of processes, and the current filtering functionality doesn't make it easy to show just one full tree of processes without a bunch of other processes bumping me up and down while I'm debugging. 

This patch will change the --pids  flag to display not just the  process with the pid specified, but the child processes.

Does this functionality sound like it would be useful? perhaps if it were separated out into a different flag?