### PR TITLE
Correct display of custom thread names in non-merged view

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -417,7 +417,7 @@ void Process_makeCommandStr(Process* this) {
       return;
    if (this->state == ZOMBIE && !this->mergedCommand.str)
       return;
-   if (Process_isUserlandThread(this) && settings->showThreadNames && (showThreadNames == mc->prevShowThreadNames))
+   if (Process_isUserlandThread(this) && settings->showThreadNames && (showThreadNames == mc->prevShowThreadNames) && (mc->prevMergeSet == showMergedCommand))
       return;
 
    /* this->mergedCommand.str needs updating only if its state or contents changed.
@@ -516,10 +516,13 @@ void Process_makeCommandStr(Process* this) {
    assert(cmdlineBasenameStart <= (int)strlen(cmdline));
 
    if (!showMergedCommand || !procExe || !procComm) { /* fall back to cmdline */
-      if (showMergedCommand && (!Process_isUserlandThread(this) || showThreadNames) && !procExe && procComm && strlen(procComm)) { /* Prefix column with comm */
+      if ((showMergedCommand || (Process_isUserlandThread(this) && showThreadNames)) && procComm && strlen(procComm)) { /* set or prefix column with comm */
          if (strncmp(cmdline + cmdlineBasenameStart, procComm, MINIMUM(TASK_COMM_LEN - 1, strlen(procComm))) != 0) {
             WRITE_HIGHLIGHT(0, strlen(procComm), commAttr, CMDLINE_HIGHLIGHT_FLAG_COMM);
             str = stpcpy(str, procComm);
+
+            if(!showMergedCommand)
+               return;
 
             WRITE_SEPARATOR;
          }

--- a/Process.c
+++ b/Process.c
@@ -516,7 +516,7 @@ void Process_makeCommandStr(Process* this) {
    assert(cmdlineBasenameStart <= (int)strlen(cmdline));
 
    if (!showMergedCommand || !procExe || !procComm) { /* fall back to cmdline */
-      if ((showMergedCommand || (Process_isUserlandThread(this) && showThreadNames)) && procComm && strlen(procComm)) { /* set or prefix column with comm */
+      if ((showMergedCommand || (Process_isUserlandThread(this) && showThreadNames)) && procComm && strlen(procComm)) { /* set column to or prefix it with comm */
          if (strncmp(cmdline + cmdlineBasenameStart, procComm, MINIMUM(TASK_COMM_LEN - 1, strlen(procComm))) != 0) {
             WRITE_HIGHLIGHT(0, strlen(procComm), commAttr, CMDLINE_HIGHLIGHT_FLAG_COMM);
             str = stpcpy(str, procComm);


### PR DESCRIPTION
Proposed fix for issue #877 - getting back custom thread names.

It seems that in `Process_makeCommandStr` whenever a thread is in question and `showMergedCommand` is disabled, the `if` in line https://github.com/htop-dev/htop/blob/main/Process.c#L518 evaluated to true. Every code path returns before exiting the scope of this `if` body. But there, if and only if `showMergedCommand` is enabled __and__ is not a thread then the result is set to procComm (i.e. thread name).
I think it ought to be that if `showMergedCommand` is enabled __or__ this is a thread then the result should contain procComm.
Hence the proposed patch.

Plus: when the user toggles "Merge exe, comm and cmdline in Command" (`showMergedCommand`), then the line  https://github.com/htop-dev/htop/blob/main/Process.c#L420 should not return true, or else the settings change dose not affect existing processes.

(Another system update, another time I hit this issue... )
