### PR TITLE
Incorporate shared memory in bar text

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -733,9 +733,9 @@ static Htop_Reaction actionHelp(State* st) {
    mvaddstr(line++, 0, "Memory bar:    ");
    addattrstr(CRT_colors[BAR_BORDER], "[");
    addbartext(CRT_colors[MEMORY_USED], "", "used");
-   addbartext(CRT_colors[MEMORY_BUFFERS_TEXT], "/", "buffers");
    addbartext(CRT_colors[MEMORY_SHARED], "/", "shared");
    addbartext(CRT_colors[MEMORY_COMPRESSED], "/", "compressed");
+   addbartext(CRT_colors[MEMORY_BUFFERS_TEXT], "/", "buffers");
    addbartext(CRT_colors[MEMORY_CACHE], "/", "cache");
    addbartext(CRT_colors[BAR_SHADOW], "          ", "used");
    addbartext(CRT_colors[BAR_SHADOW], "/", "total");

--- a/Action.c
+++ b/Action.c
@@ -733,9 +733,9 @@ static Htop_Reaction actionHelp(State* st) {
    mvaddstr(line++, 0, "Memory bar:    ");
    addattrstr(CRT_colors[BAR_BORDER], "[");
    addbartext(CRT_colors[MEMORY_USED], "", "used");
-   addbartext(CRT_colors[MEMORY_COMPRESSED], "/", "compressed");
    addbartext(CRT_colors[MEMORY_BUFFERS_TEXT], "/", "buffers");
    addbartext(CRT_colors[MEMORY_SHARED], "/", "shared");
+   addbartext(CRT_colors[MEMORY_COMPRESSED], "/", "compressed");
    addbartext(CRT_colors[MEMORY_CACHE], "/", "cache");
    addbartext(CRT_colors[BAR_SHADOW], "          ", "used");
    addbartext(CRT_colors[BAR_SHADOW], "/", "total");

--- a/MemoryMeter.c
+++ b/MemoryMeter.c
@@ -41,8 +41,10 @@ static void MemoryMeter_updateValues(Meter* this) {
       "MEMORY_METER_AVAILABLE is not the last item in MemoryMeterValues");
    this->curItems = MEMORY_METER_AVAILABLE;
 
-   /* we actually want to show "used + compressed" */
+   /* we actually want to show "used + shared + compressed" */
    double used = this->values[MEMORY_METER_USED];
+   if (isPositive(this->values[MEMORY_METER_SHARED]))
+      used += this->values[MEMORY_METER_SHARED];
    if (isPositive(this->values[MEMORY_METER_COMPRESSED]))
       used += this->values[MEMORY_METER_COMPRESSED];
 

--- a/MemoryMeter.c
+++ b/MemoryMeter.c
@@ -19,9 +19,9 @@ in the source distribution for its full text.
 
 static const int MemoryMeter_attributes[] = {
    MEMORY_USED,
-   MEMORY_BUFFERS,
    MEMORY_SHARED,
    MEMORY_COMPRESSED,
+   MEMORY_BUFFERS,
    MEMORY_CACHE
 };
 
@@ -66,10 +66,6 @@ static void MemoryMeter_display(const Object* cast, RichString* out) {
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " used:");
    RichString_appendAscii(out, CRT_colors[MEMORY_USED], buffer);
 
-   Meter_humanUnit(buffer, this->values[MEMORY_METER_BUFFERS], sizeof(buffer));
-   RichString_appendAscii(out, CRT_colors[METER_TEXT], " buffers:");
-   RichString_appendAscii(out, CRT_colors[MEMORY_BUFFERS_TEXT], buffer);
-
    /* shared memory is not supported on all platforms */
    if (isNonnegative(this->values[MEMORY_METER_SHARED])) {
       Meter_humanUnit(buffer, this->values[MEMORY_METER_SHARED], sizeof(buffer));
@@ -83,6 +79,10 @@ static void MemoryMeter_display(const Object* cast, RichString* out) {
       RichString_appendAscii(out, CRT_colors[METER_TEXT], " compressed:");
       RichString_appendAscii(out, CRT_colors[MEMORY_COMPRESSED], buffer);
    }
+
+   Meter_humanUnit(buffer, this->values[MEMORY_METER_BUFFERS], sizeof(buffer));
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " buffers:");
+   RichString_appendAscii(out, CRT_colors[MEMORY_BUFFERS_TEXT], buffer);
 
    Meter_humanUnit(buffer, this->values[MEMORY_METER_CACHE], sizeof(buffer));
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " cache:");

--- a/MemoryMeter.h
+++ b/MemoryMeter.h
@@ -11,9 +11,9 @@ in the source distribution for its full text.
 
 typedef enum {
    MEMORY_METER_USED = 0,
-   MEMORY_METER_BUFFERS = 1,
-   MEMORY_METER_SHARED = 2,
-   MEMORY_METER_COMPRESSED = 3,
+   MEMORY_METER_SHARED = 1,
+   MEMORY_METER_COMPRESSED = 2,
+   MEMORY_METER_BUFFERS = 3,
    MEMORY_METER_CACHE = 4,
    MEMORY_METER_AVAILABLE = 5,
    MEMORY_METER_ITEMCOUNT = 6, // number of entries in this enum

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -292,9 +292,9 @@ void Platform_setMemoryValues(Meter* mtr) {
 
    mtr->total = dhost->host_info.max_mem / 1024;
    mtr->values[MEMORY_METER_USED] = (double)(vm->active_count + vm->wire_count) * page_K;
-   mtr->values[MEMORY_METER_BUFFERS] = (double)vm->purgeable_count * page_K;
    // mtr->values[MEMORY_METER_SHARED] = "shared memory, like tmpfs and shm"
    // mtr->values[MEMORY_METER_COMPRESSED] = "compressed memory, like zswap on linux"
+   mtr->values[MEMORY_METER_BUFFERS] = (double)vm->purgeable_count * page_K;
    mtr->values[MEMORY_METER_CACHE] = (double)vm->inactive_count * page_K;
    // mtr->values[MEMORY_METER_AVAILABLE] = "available memory"
 }

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -214,9 +214,9 @@ void Platform_setMemoryValues(Meter* this) {
 
    this->total = host->totalMem;
    this->values[MEMORY_METER_USED] = host->usedMem;
-   this->values[MEMORY_METER_BUFFERS] = host->buffersMem;
    // this->values[MEMORY_METER_SHARED] = "shared memory, like tmpfs and shm"
-   // mtr->values[MEMORY_METER_COMPRESSED] = "compressed memory, like zswap on linux"
+   // this->values[MEMORY_METER_COMPRESSED] = "compressed memory, like zswap on linux"
+   this->values[MEMORY_METER_BUFFERS] = host->buffersMem;
    this->values[MEMORY_METER_CACHE] = host->cachedMem;
    // this->values[MEMORY_METER_AVAILABLE] = "available memory"
 }

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -229,9 +229,9 @@ void Platform_setMemoryValues(Meter* this) {
 
    this->total = host->totalMem;
    this->values[MEMORY_METER_USED] = host->usedMem;
-   this->values[MEMORY_METER_BUFFERS] = host->buffersMem;
    this->values[MEMORY_METER_SHARED] = host->sharedMem;
    // this->values[MEMORY_METER_COMPRESSED] = "compressed memory, like zswap on linux"
+   this->values[MEMORY_METER_BUFFERS] = host->buffersMem;
    this->values[MEMORY_METER_CACHE] = host->cachedMem;
    // this->values[MEMORY_METER_AVAILABLE] = "available memory"
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -360,9 +360,9 @@ void Platform_setMemoryValues(Meter* this) {
 
    this->total = host->totalMem;
    this->values[MEMORY_METER_USED] = host->usedMem;
-   this->values[MEMORY_METER_BUFFERS] = host->buffersMem;
    this->values[MEMORY_METER_SHARED] = host->sharedMem;
    this->values[MEMORY_METER_COMPRESSED] = 0; /* compressed */
+   this->values[MEMORY_METER_BUFFERS] = host->buffersMem;
    this->values[MEMORY_METER_CACHE] = host->cachedMem;
    this->values[MEMORY_METER_AVAILABLE] = host->availableMem;
 

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -272,9 +272,9 @@ void Platform_setMemoryValues(Meter* this) {
    const Machine* host = this->host;
    this->total = host->totalMem;
    this->values[MEMORY_METER_USED] = host->usedMem;
-   this->values[MEMORY_METER_BUFFERS] = host->buffersMem;
    // this->values[MEMORY_METER_SHARED] = "shared memory, like tmpfs and shm"
    // this->values[MEMORY_METER_COMPRESSED] = "compressed memory, like zswap on linux"
+   this->values[MEMORY_METER_BUFFERS] = host->buffersMem;
    this->values[MEMORY_METER_CACHE] = host->cachedMem;
    // this->values[MEMORY_METER_AVAILABLE] = "available memory"
 }

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -229,9 +229,9 @@ void Platform_setMemoryValues(Meter* this) {
    usedMem -= buffersMem + cachedMem;
    this->total = host->totalMem;
    this->values[MEMORY_METER_USED] = usedMem;
-   this->values[MEMORY_METER_BUFFERS] = buffersMem;
    // this->values[MEMORY_METER_SHARED] = "shared memory, like tmpfs and shm"
    // this->values[MEMORY_METER_COMPRESSED] = "compressed memory, like zswap on linux"
+   this->values[MEMORY_METER_BUFFERS] = buffersMem;
    this->values[MEMORY_METER_CACHE] = cachedMem;
    // this->values[MEMORY_METER_AVAILABLE] = "available memory"
 }

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -240,9 +240,9 @@ void Platform_setMemoryValues(Meter* this) {
    const Machine* host = this->host;
    this->total = host->totalMem;
    this->values[MEMORY_METER_USED] = host->usedMem;
-   this->values[MEMORY_METER_BUFFERS] = host->buffersMem;
    // this->values[MEMORY_METER_SHARED] = "shared memory, like tmpfs and shm"
    // this->values[MEMORY_METER_COMPRESSED] = "compressed memory, like zswap on linux"
+   this->values[MEMORY_METER_BUFFERS] = host->buffersMem;
    this->values[MEMORY_METER_CACHE] = host->cachedMem;
    // this->values[MEMORY_METER_AVAILABLE] = "available memory"
 }


### PR DESCRIPTION
Shared memory is claimed, and as significant a part of the memory load as the "used" memory. Since "shared" was separated from the "used" value, the basic "used/total" display in the bar text has become less meaningful for Linux, as it only reflects a subset of the claimed memory. The difference often isn't huge, but it can become so if tmpfs is heavily used.

Improve the situation by adding used and shared for that text, making it "claimed/total".

In accordance with that logic, move the shared value leftwards next to the used value, so that we're summing the two leftmost values - a contiguous region.

Fixes #906.

(This could be separated into two PRs, but they would conflict - doing it as two patches).