### PR TITLE
Fix out of boundary writes in XUtils

### DIFF
--- a/XUtils.c
+++ b/XUtils.c
@@ -161,35 +161,6 @@ void String_freeArray(char** s) {
    free(s);
 }
 
-char* String_getToken(const char* line, const unsigned short int numMatch) {
-   const size_t len = strlen(line);
-   char inWord = 0;
-   unsigned short int count = 0;
-   char match[50];
-
-   size_t foundCount = 0;
-
-   for (size_t i = 0; i < len; i++) {
-      char lastState = inWord;
-      inWord = line[i] == ' ' ? 0 : 1;
-
-      if (lastState == 0 && inWord == 1)
-         count++;
-
-      if (inWord == 1) {
-         if (count == numMatch && line[i] != ' ' && line[i] != '\0' && line[i] != '\n' && line[i] != (char)EOF) {
-            if (foundCount == sizeof(match) / sizeof(match[0]) - 1)
-               break;
-            match[foundCount] = line[i];
-            foundCount++;
-         }
-      }
-   }
-
-   match[foundCount] = '\0';
-   return xStrdup(match);
-}
-
 char* String_readLine(FILE* fd) {
    const size_t step = 1024;
    size_t bufSize = step;

--- a/XUtils.c
+++ b/XUtils.c
@@ -101,6 +101,7 @@ inline bool String_contains_i(const char* s1, const char* s2) {
 char* String_cat(const char* s1, const char* s2) {
    const size_t l1 = strlen(s1);
    const size_t l2 = strlen(s2);
+   assert(SIZE_MAX - l1 > l2);
    char* out = xMalloc(l1 + l2 + 1);
    memcpy(out, s1, l1);
    memcpy(out + l1, s2, l2);
@@ -122,10 +123,10 @@ char* String_trim(const char* in) {
 }
 
 char** String_split(const char* s, char sep, size_t* n) {
-   const unsigned int rate = 10;
+   const size_t rate = 10;
    char** out = xCalloc(rate, sizeof(char*));
    size_t ctr = 0;
-   unsigned int blocks = rate;
+   size_t blocks = rate;
    const char* where;
    while ((where = strchr(s, sep)) != NULL) {
       size_t size = (size_t)(where - s);
@@ -177,6 +178,8 @@ char* String_getToken(const char* line, const unsigned short int numMatch) {
 
       if (inWord == 1) {
          if (count == numMatch && line[i] != ' ' && line[i] != '\0' && line[i] != '\n' && line[i] != (char)EOF) {
+            if (foundCount == sizeof(match) / sizeof(match[0]) - 1)
+               break;
             match[foundCount] = line[i];
             foundCount++;
          }
@@ -188,8 +191,8 @@ char* String_getToken(const char* line, const unsigned short int numMatch) {
 }
 
 char* String_readLine(FILE* fd) {
-   const unsigned int step = 1024;
-   unsigned int bufSize = step;
+   const size_t step = 1024;
+   size_t bufSize = step;
    char* buffer = xMalloc(step + 1);
    char* at = buffer;
    for (;;) {

--- a/XUtils.h
+++ b/XUtils.h
@@ -54,8 +54,6 @@ char** String_split(const char* s, char sep, size_t* n);
 
 void String_freeArray(char** s);
 
-char* String_getToken(const char* line, unsigned short int numMatch) ATTR_MALLOC;
-
 char* String_readLine(FILE* fd) ATTR_MALLOC;
 
 /* Always null-terminates dest. Caller must pass a strictly positive size. */


### PR DESCRIPTION
It is possible to exceed the unsigned int data type on 64 bit systems
with enough available RAM. Use size_t in all places instead.

Proof of Concept: Create a 4 GB line in .htoprc file and run htop

$ dd if=/dev/zero bs=1024 count=4194304 | tr '\0' 'a' > ~/.htoprc
$ htop
Segmentation fault

Also avoid overflow of stack based "match" array in String_getToken.