### PR TITLE
Improve child handling

### DIFF
--- a/CRT.c
+++ b/CRT.c
@@ -880,6 +880,7 @@ static void CRT_installSignalHandlers(void) {
    sigaction (SIGSYS, &act, &old_sig_handler[SIGSYS]);
    sigaction (SIGABRT, &act, &old_sig_handler[SIGABRT]);
 
+   signal(SIGCHLD, SIG_DFL);
    signal(SIGINT, CRT_handleSIGTERM);
    signal(SIGTERM, CRT_handleSIGTERM);
    signal(SIGQUIT, CRT_handleSIGTERM);

--- a/OpenFilesScreen.c
+++ b/OpenFilesScreen.c
@@ -9,6 +9,7 @@ in the source distribution for its full text.
 
 #include "OpenFilesScreen.h"
 
+#include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
 #include <stdio.h>
@@ -197,10 +198,11 @@ static OpenFiles_ProcessData* OpenFilesScreen_getProcessData(pid_t pid) {
    fclose(fd);
 
    int wstatus;
-   if (waitpid(child, &wstatus, 0) == -1) {
-      pdata->error = 1;
-      return pdata;
-   }
+   while (waitpid(child, &wstatus, 0) == -1)
+      if (errno != EINTR) {
+         pdata->error = 1;
+         return pdata;
+      }
 
    if (!WIFEXITED(wstatus)) {
       pdata->error = 1;

--- a/TraceScreen.c
+++ b/TraceScreen.c
@@ -10,6 +10,7 @@ in the source distribution for its full text.
 #include "TraceScreen.h"
 
 #include <assert.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
 #include <stdbool.h>
@@ -47,7 +48,9 @@ void TraceScreen_delete(Object* cast) {
    TraceScreen* this = (TraceScreen*) cast;
    if (this->child > 0) {
       kill(this->child, SIGTERM);
-      waitpid(this->child, NULL, 0);
+      while (waitpid(this->child, NULL, 0) == -1)
+         if (errno != EINTR)
+            break;
    }
 
    if (this->strace) {


### PR DESCRIPTION
Always reset SIGCHLD to SIG_DFL because we never know if the parent process modified SIGCHLD handling. Some systems like OpenBSD reset this automatically, but others like Linux do not.

Also keep in mind that system calls can be interrupted by signal handlers. SIGWINCH is handled by ncurses to handle terminal size changes. If waitpid is interrupted then running lsof instances can become and stay zombie processes until htop exits.

Please see commit messages for proof of concepts.

Since system calls are all over the place and we cannot set SA_RESTART for all signal handlers of our curses library without ugly hacks, I suppose that more system calls might have to be properly checked for EINTR...