### PR TITLE
Help: Linux swap consistency

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -603,7 +603,7 @@ static Htop_Reaction actionHelp(State* st) {
    addattrstr(CRT_colors[BAR_BORDER], "[");
    addattrstr(CRT_colors[SWAP], "used");
 #ifdef HTOP_LINUX
-   addattrstr(CRT_colors[BAR_SHADOW], "/");
+   addstr("/");
    addattrstr(CRT_colors[SWAP_CACHE], "cache");
    addattrstr(CRT_colors[BAR_SHADOW], "                                    used/total");
 #else


### PR DESCRIPTION
On the help screen's depiction of the swap bar, the `/` separator between used and cache should be coloured for consistency with the other bars.

I tried removing the coloured `/`s from the other bars to make them consistent, but found that less visually appealing.