### PR TITLE
FreeBSD: Add support for showing process emulation

### DIFF
--- a/freebsd/FreeBSDProcess.c
+++ b/freebsd/FreeBSDProcess.c
@@ -49,6 +49,7 @@ const ProcessFieldData Process_fields[LAST_PROCESSFIELD] = {
    [CWD] = { .name = "CWD", .title = "CWD                       ", .description = "The current working directory of the process", .flags = PROCESS_FLAG_CWD, },
    [JID] = { .name = "JID", .title = "JID", .description = "Jail prison ID", .flags = 0, .pidColumn = true, },
    [JAIL] = { .name = "JAIL", .title = "JAIL        ", .description = "Jail prison name", .flags = 0, },
+   [EMULATION] = { .name = "EMULATION", .title = "EMULATION        ", .description = "System call emulation environment (ABI)", .flags = 0, },
 };
 
 Process* FreeBSDProcess_new(const Settings* settings) {
@@ -77,6 +78,9 @@ static void FreeBSDProcess_writeField(const Process* this, RichString* str, Proc
    case JAIL:
       Process_printLeftAlignedField(str, attr, fp->jname ? fp->jname : "N/A", 11);
       return;
+   case EMULATION:
+      Process_printLeftAlignedField(str, attr, fp->emul ? fp->emul : "N/A", 16);
+      return;
    default:
       Process_writeField(this, str, field);
       return;
@@ -94,6 +98,8 @@ static int FreeBSDProcess_compareByKey(const Process* v1, const Process* v2, Pro
       return SPACESHIP_NUMBER(p1->jid, p2->jid);
    case JAIL:
       return SPACESHIP_NULLSTR(p1->jname, p2->jname);
+   case EMULATION:
+      return SPACESHIP_NULLSTR(p1->emul, p2->emul);
    default:
       return Process_compareByKey_Base(v1, v2, key);
    }

--- a/freebsd/FreeBSDProcess.h
+++ b/freebsd/FreeBSDProcess.h
@@ -18,6 +18,7 @@ typedef struct FreeBSDProcess_ {
    Process super;
    int   jid;
    char* jname;
+   char* emul;
 } FreeBSDProcess;
 
 extern const ProcessClass FreeBSDProcess_class;

--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -549,6 +549,8 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
          }
       }
 
+      free_and_xStrdup(&fp->emul, kproc->ki_emul);
+
       // from FreeBSD source /src/usr.bin/top/machine.c
       proc->m_virt = kproc->ki_size / ONE_K;
       proc->m_resident = kproc->ki_rssize * pageSizeKb;

--- a/freebsd/ProcessField.h
+++ b/freebsd/ProcessField.h
@@ -11,6 +11,7 @@ in the source distribution for its full text.
 #define PLATFORM_PROCESS_FIELDS  \
    JID   = 100,                  \
    JAIL  = 101,                  \
+   EMULATION = 102,              \
                                  \
    DUMMY_BUMP_FIELD = CWD,       \
    // End of list


### PR DESCRIPTION
This displays the same output as ps's -o emul, which is the system call
emulation environment, or ABI, in use. This will typically be FreeBSD
ELF32 or ELF64, but can also be Linux ELF32 or Linux ELF64 when running
Linux binaries under FreeBSD's Linuxulator binary compatibility layer.
The column width of 16 is chosen to match KI_EMULNAMELEN's value of 16,
most of which is normally used up as FreeBSD ELF32/64 is 13 characters.