### PR TITLE
freebsd/dragonfly: Stop aligning equals signs in PLATFORM_PROCESS_FIELDS

### DIFF
--- a/dragonflybsd/ProcessField.h
+++ b/dragonflybsd/ProcessField.h
@@ -9,8 +9,8 @@ in the source distribution for its full text.
 
 
 #define PLATFORM_PROCESS_FIELDS  \
-   JID   = 100,                  \
-   JAIL  = 101,                  \
+   JID = 100,                    \
+   JAIL = 101,                   \
                                  \
    DUMMY_BUMP_FIELD = CWD,       \
    // End of list

--- a/freebsd/ProcessField.h
+++ b/freebsd/ProcessField.h
@@ -9,8 +9,8 @@ in the source distribution for its full text.
 
 
 #define PLATFORM_PROCESS_FIELDS  \
-   JID   = 100,                  \
-   JAIL  = 101,                  \
+   JID = 100,                    \
+   JAIL = 101,                   \
    EMULATION = 102,              \
                                  \
    DUMMY_BUMP_FIELD = CWD,       \


### PR DESCRIPTION
ProcessField doesn't do this, nor does any other OS, and it just makes
it more annoying to add a new field.