### PR TITLE
darwin: lazily set process TTY name

### DIFF
--- a/darwin/DarwinProcess.h
+++ b/darwin/DarwinProcess.h
@@ -13,6 +13,8 @@ in the source distribution for its full text.
 #include "darwin/DarwinProcessList.h"
 
 
+#define PROCESS_FLAG_TTY 0x00000100
+
 typedef struct DarwinProcess_ {
    Process super;
 


### PR DESCRIPTION
Fetching the TTY name of a process is extremely expensive on darwin and
the call to devname accounts for 95% of htop's CPU usage when there is
high process turnover (this is mostly due to devname calling lstat,
which is incredibly slow). This can make htop unresponsive.

To mitigate this only set the TTY name if the TTY ProcessField is
enabled in the Settings, which by default it is not.

This commit also adds the Settings_hasField helper function, which
returns true if a field is set.

This can be reproduced with the below script:

```sh

set -e

NUM_PROCS=2048
SLEEP_DUR=2

trap 'pkill -P $$' TERM INT
trap 'pkill -P $$' EXIT

while true; do
    echo "info: $NUM_PROCS procs: starting"
    for i in $(seq 1 $NUM_PROCS); do
        sleep 3600 &
    done
    echo "info: $NUM_PROCS procs: complete"
    sleep $SLEEP_DUR
    pkill -P "$$"
done
```