### PR TITLE
ProcessList: fix quadratic process removal when scanning

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -1095,13 +1095,6 @@ bool Process_sendSignal(Process* this, Arg sgn) {
    return kill(this->pid, sgn.i) == 0;
 }
 
-int Process_pidCompare(const void* v1, const void* v2) {
-   const Process* p1 = (const Process*)v1;
-   const Process* p2 = (const Process*)v2;
-
-   return SPACESHIP_NUMBER(p1->pid, p2->pid);
-}
-
 int Process_compare(const void* v1, const void* v2) {
    const Process* p1 = (const Process*)v1;
    const Process* p2 = (const Process*)v2;

--- a/Process.h
+++ b/Process.h
@@ -394,7 +394,11 @@ bool Process_changePriorityBy(Process* this, Arg delta);
 
 bool Process_sendSignal(Process* this, Arg sgn);
 
-int Process_pidCompare(const void* v1, const void* v2);
+static inline int Process_pidEqualCompare(const void* v1, const void* v2) {
+   const pid_t p1 = ((const Process*)v1)->pid;
+   const pid_t p2 = ((const Process*)v2)->pid;
+   return p1 != p2; /* return zero when equal */
+}
 
 int Process_compareByKey_Base(const Process* p1, const Process* p2, ProcessField key);
 

--- a/Vector.c
+++ b/Vector.c
@@ -29,6 +29,8 @@ Vector* Vector_new(const ObjectClass* type, bool owner, int size) {
    this->items = 0;
    this->type = type;
    this->owner = owner;
+   this->dirty_index = -1;
+   this->dirty_count = 0;
    return this;
 }
 
@@ -44,10 +46,21 @@ void Vector_delete(Vector* this) {
    free(this);
 }
 
+static inline bool Vector_isDirty(const Vector* this) {
+   if (this->dirty_count > 0) {
+      assert(0 <= this->dirty_index && this->dirty_index < this->items);
+      assert(this->dirty_count <= this->items);
+      return true;
+   }
+   assert(this->dirty_index == -1);
+   return false;
+}
+
 #ifndef NDEBUG
 
 static bool Vector_isConsistent(const Vector* this) {
    assert(this->items <= this->arraySize);
+   assert(!Vector_isDirty(this));
 
    if (this->owner) {
       for (int i = 0; i < this->items; i++) {
@@ -60,15 +73,14 @@ static bool Vector_isConsistent(const Vector* this) {
    return true;
 }
 
-unsigned int Vector_count(const Vector* this) {
-   unsigned int items = 0;
+bool Vector_countEquals(const Vector* this, unsigned int expectedCount) {
+   unsigned int n = 0;
    for (int i = 0; i < this->items; i++) {
       if (this->array[i]) {
-         items++;
+         n++;
       }
    }
-   assert(items == (unsigned int)this->items);
-   return items;
+   return n == expectedCount;
 }
 
 Object* Vector_get(const Vector* this, int idx) {
@@ -88,13 +100,16 @@ int Vector_size(const Vector* this) {
 void Vector_prune(Vector* this) {
    assert(Vector_isConsistent(this));
    if (this->owner) {
-      for (int i = 0; i < this->items; i++)
+      for (int i = 0; i < this->items; i++) {
          if (this->array[i]) {
             Object_delete(this->array[i]);
-            //this->array[i] = NULL;
+            this->array[i] = NULL;
          }
+      }
    }
    this->items = 0;
+   this->dirty_index = -1;
+   this->dirty_count = 0;
 }
 
 //static int comparisons = 0;
@@ -240,6 +255,58 @@ Object* Vector_remove(Vector* this, int idx) {
    } else {
       return removed;
    }
+}
+
+Object* Vector_softRemove(Vector* this, int idx) {
+   assert(idx >= 0 && idx < this->items);
+
+   Object* removed = this->array[idx];
+   assert(removed);
+   if (removed) {
+      this->array[idx] = NULL;
+
+      this->dirty_count++;
+      if (this->dirty_index < 0 || idx < this->dirty_index) {
+         this->dirty_index = idx;
+      }
+
+      if (this->owner) {
+         Object_delete(removed);
+         return NULL;
+      }
+   }
+
+   return removed;
+}
+
+void Vector_compact(Vector* this) {
+   if (!Vector_isDirty(this)) {
+      return;
+   }
+
+   const int size = this->items;
+   assert(0 <= this->dirty_index && this->dirty_index < size);
+   assert(this->array[this->dirty_index] == NULL);
+
+   int idx = this->dirty_index;
+
+   /* one deletion: use memmove, which should be faster */
+   if (this->dirty_count == 1) {
+      memmove(&this->array[idx], &this->array[idx + 1], (this->items - idx) * sizeof(this->array[0]));
+   } else {
+      /* multiple deletions */
+      for (int i = idx + 1; i < size; i++) {
+         if (this->array[i]) {
+            this->array[idx++] = this->array[i];
+         }
+      }
+   }
+
+   this->items -= this->dirty_count;
+   this->dirty_index = -1;
+   this->dirty_count = 0;
+
+   assert(Vector_isConsistent(this));
 }
 
 void Vector_moveUp(Vector* this, int idx) {

--- a/Vector.h
+++ b/Vector.h
@@ -22,6 +22,11 @@ typedef struct Vector_ {
    int arraySize;
    int growthRate;
    int items;
+   /* lowest index of a pending soft remove/delete operation,
+      used to speed up compaction */
+   int dirty_index;
+   /* count of soft deletes, required for Vector_count to work in debug mode */
+   int dirty_count;
    bool owner;
 } Vector;
 
@@ -44,6 +49,15 @@ Object* Vector_take(Vector* this, int idx);
 
 Object* Vector_remove(Vector* this, int idx);
 
+/* Vector_softRemove marks the item at index idx for deletion without
+   reclaiming any space. If owned, the item is immediately freed.
+
+   Vector_compact must be called to reclaim space.*/
+Object* Vector_softRemove(Vector* this, int idx);
+
+/* Vector_compact reclaims space free'd up by Vector_softRemove, if any. */
+void Vector_compact(Vector* this);
+
 void Vector_moveUp(Vector* this, int idx);
 
 void Vector_moveDown(Vector* this, int idx);
@@ -54,7 +68,11 @@ void Vector_set(Vector* this, int idx, void* data_);
 
 Object* Vector_get(const Vector* this, int idx);
 int Vector_size(const Vector* this);
-unsigned int Vector_count(const Vector* this);
+
+/* Vector_countEquals returns true if the number of non-NULL items
+   in the Vector is equal to expectedCount. This is only for debugging
+   and consistency checks. */
+bool Vector_countEquals(const Vector* this, unsigned int expectedCount);
 
 #else /* NDEBUG */
 


### PR DESCRIPTION
This commit changes ProcessList_scan to remove Processes by index, which
is known, instead of performing a brute-force search by pid.

Searching by pid is potentially quadratic (worst case is: O(n^2)/2) in
ProcessList_scan because the process we are searching for is always the
last process in the vector (the scan starts from the back of the
vector).

This commit also adds a new ProcessList_indexOf function to search for
processes by pid. This is more efficient than Vector_indexOf as it does
not require a comparison function, which cannot be inlined. The now
unused Vector_indexOf and Process_pidCompare functions have been
removed.