### PR TITLE
LinuxProcessTree: avoid immediate removal

### DIFF
--- a/ProcessList.c
+++ b/ProcessList.c
@@ -176,6 +176,7 @@ void ProcessList_add(ProcessList* this, Process* p) {
 // ProcessList_removeIndex removes Process p from the list's map and soft deletes
 // it from its vector. Vector_compact *must* be called once the caller is done
 // removing items.
+// Should only be called from ProcessList_scan to avoid breaking dying process highlighting.
 static void ProcessList_removeIndex(ProcessList* this, const Process* p, int idx) {
    pid_t pid = p->pid;
 
@@ -192,16 +193,6 @@ static void ProcessList_removeIndex(ProcessList* this, const Process* p, int idx
 
    assert(Hashtable_get(this->processTable, pid) == NULL);
    assert(Vector_countEquals(this->processes, Hashtable_count(this->processTable)));
-}
-
-void ProcessList_remove(ProcessList* this, const Process* p) {
-   int idx = Vector_indexOf(this->processes, p, Process_pidEqualCompare);
-   assert(0 <= idx && idx < Vector_size(this->processes));
-   if (idx >= 0) {
-      ProcessList_removeIndex(this, p, idx);
-      // This function is public so must not require callers to compact the Vector
-      Vector_compact(this->processes);
-   }
 }
 
 static void ProcessList_buildTreeBranch(ProcessList* this, pid_t pid, int level, int indent, bool show) {

--- a/ProcessList.h
+++ b/ProcessList.h
@@ -106,8 +106,6 @@ void ProcessList_printHeader(const ProcessList* this, RichString* header);
 
 void ProcessList_add(ProcessList* this, Process* p);
 
-void ProcessList_remove(ProcessList* this, const Process* p);
-
 void ProcessList_updateDisplayList(ProcessList* this);
 
 ProcessField ProcessList_keyAt(const ProcessList* this, int at);

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -1653,8 +1653,13 @@ errorReadingProcess:
 #endif
 
          if (preExisting) {
-            ProcessList_remove(pl, proc);
+            /*
+             * The only real reason for coming here (apart from Linux violating the /proc API)
+             * would be the process going away with its /proc files disappearing (!HAVE_OPENAT).
+             * However, we want to keep in the process list for now for the "highlight dying" mode.
+             */
          } else {
+            /* A really short-lived process that we don't have full info about */
             Process_delete((Object*)proc);
          }
       }


### PR DESCRIPTION
A process dying while being scanned can cause it to be removed from the process list immediately, which violates the "highlight dying processes" mode (if active) and can break the process tree structure due to deceased-but-still-displayed children missing a parent.

This PR closes the race window for `HAVE_OPENAT` systems (assuming that keeping a `/proc/$pid` directory FD causes the expected files in it to be present too) and keeps partially updated processes for `!HAVE_OPENAT` systems.