### PR TITLE
Process: Show only integer value when CPU% more than 99.9%

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -741,7 +741,9 @@ void Process_printPercentage(float val, char* buffer, int n, int* attr) {
          xSnprintf(buffer, n, "%4.1f ", val);
       } else {
          *attr = CRT_colors[PROCESS_MEGABYTES];
-         xSnprintf(buffer, n, "%4d ", (int)val);
+         if (val < 100.0F)
+            val = 100.0F; // Don't round down and display "val" as "99".
+         xSnprintf(buffer, n, "%4.0f ", val);
       }
    } else {
       *attr = CRT_colors[PROCESS_SHADOW];

--- a/Process.c
+++ b/Process.c
@@ -739,9 +739,6 @@ void Process_printPercentage(float val, char* buffer, int n, int* attr) {
             *attr = CRT_colors[PROCESS_SHADOW];
          }
          xSnprintf(buffer, n, "%4.1f ", val);
-      } else if (val < 999) {
-         *attr = CRT_colors[PROCESS_MEGABYTES];
-         xSnprintf(buffer, n, "%3d. ", (int)val);
       } else {
          *attr = CRT_colors[PROCESS_MEGABYTES];
          xSnprintf(buffer, n, "%4d ", (int)val);


### PR DESCRIPTION
When we run a process which utilizes CPU between 100.0% and 999.9%, htop
shows an unnecessary decimal character at the end of the value. For
example, '100.x' and '247.x' become '100.' and '247.' respectively.

When CPU utilization is less than and equal to '99.9%', show the result
with single digit precision and if result is less than four characters,
pad it with the blank space. When CPU utilization is greater than
'99.9%', show only integral part of the result and if it's less than
four characters, pad it with the blank space.

Closes: #946

### Screenshots
**Before:**
![before](https://user-images.githubusercontent.com/28824347/154099865-1e899965-41aa-47e6-9681-e110d76e36f9.png)

**After:**
![after2](https://user-images.githubusercontent.com/28824347/154099939-dc0c4f97-954b-4b1e-9a49-4b0e7f6b2bfd.png)