### PR TITLE
Improve MainPanel Label on active inc filter (Filter <-> FILTER)

### DIFF
--- a/CommandLine.c
+++ b/CommandLine.c
@@ -347,7 +347,7 @@ int CommandLine_run(const char* name, int argc, char** argv) {
    MainPanel* panel = MainPanel_new();
    ProcessList_setPanel(pl, (Panel*) panel);
 
-   MainPanel_updateTreeFunctions(panel, settings->ss->treeView);
+   MainPanel_updateLabels(panel, settings->ss->treeView, flags.commFilter);
 
    State state = {
       .settings = settings,

--- a/MainPanel.c
+++ b/MainPanel.c
@@ -24,9 +24,10 @@ in the source distribution for its full text.
 static const char* const MainFunctions[]     = {"Help  ", "Setup ", "Search", "Filter", "Tree  ", "SortBy", "Nice -", "Nice +", "Kill  ", "Quit  ", NULL};
 static const char* const MainFunctions_ro[]  = {"Help  ", "Setup ", "Search", "Filter", "Tree  ", "SortBy", "      ", "      ", "      ", "Quit  ", NULL};
 
-void MainPanel_updateTreeFunctions(MainPanel* this, bool mode) {
+void MainPanel_updateLabels(MainPanel* this, bool list, bool filter) {
    FunctionBar* bar = MainPanel_getFunctionBar(this);
-   FunctionBar_setLabel(bar, KEY_F(5), mode ? "List  " : "Tree  ");
+   FunctionBar_setLabel(bar, KEY_F(5), list   ? "List  " : "Tree  ");
+   FunctionBar_setLabel(bar, KEY_F(4), filter ? "FILTER" : "Filter");
 }
 
 static void MainPanel_pidSearch(MainPanel* this, int ch) {
@@ -122,7 +123,7 @@ static HandlerResult MainPanel_eventHandler(Panel* super, int ch) {
    }
 
    if (reaction & HTOP_REDRAW_BAR) {
-      MainPanel_updateTreeFunctions(this, settings->ss->treeView);
+      MainPanel_updateLabels(this, settings->ss->treeView, this->state->pl->incFilter);
    }
    if (reaction & HTOP_RESIZE) {
       result |= RESIZE;

--- a/MainPanel.h
+++ b/MainPanel.h
@@ -32,7 +32,8 @@ typedef bool(*MainPanel_ForeachProcessFn)(Process*, Arg);
 
 #define MainPanel_getFunctionBar(this_) (((Panel*)(this_))->defaultBar)
 
-void MainPanel_updateTreeFunctions(MainPanel* this, bool mode);
+// update the Label Keys in the MainPanel bar, list: list / tree mode, filter: filter (inc) active / inactive
+void MainPanel_updateLabels(MainPanel* this, bool list, bool filter);
 
 int MainPanel_selectedPid(MainPanel* this);
 


### PR DESCRIPTION
Allow to see active filtering by changing the corresponding panel label to uppercase (using color as in PAUSED would be too visibly distracting imho).
/DLange
