### PR TITLE
Linux: fix crash in LXD

### DIFF
--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -188,7 +188,7 @@ static void LinuxProcessList_updateCPUcount(ProcessList* super) {
 
    const struct dirent* entry;
    while ((entry = readdir(dir)) != NULL) {
-      if (entry->d_type != DT_DIR)
+      if (entry->d_type != DT_DIR && entry->d_type != DT_UNKNOWN)
          continue;
 
       if (!String_startsWith(entry->d_name, "cpu"))

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -176,7 +176,7 @@ static void LinuxProcessList_updateCPUcount(ProcessList* super) {
 
    // Initialize the cpuData array before anything else.
    if (!this->cpuData) {
-      this->cpuData = xReallocArrayZero(this->cpuData, super->existingCPUs ? (super->existingCPUs + 1) : 0, 2, sizeof(CPUData));
+      this->cpuData = xCalloc(2, sizeof(CPUData));
       this->cpuData[0].online = true; /* average is always "online" */
       this->cpuData[1].online = true;
       super->activeCPUs = 1;


### PR DESCRIPTION
Fixes #964.

I just changed the condition to also check for `DT_UNKNOWN`.
the directories in `/sys/devices/system/cpu` are reported as `DT_UNKNOWN` in LXD.

I also made it so that `cpuData` is allocated before actually searching for CPUs so we can just `return` in case of error.