### PR TITLE
Fix a compile warning: comparison of unsigned enum expression < 0 is …

### DIFF
--- a/HeaderLayout.h
+++ b/HeaderLayout.h
@@ -18,6 +18,7 @@ in the source distribution for its full text.
 
 
 typedef enum HeaderLayout_ {
+   HF_INVALID = -1,
    HF_TWO_50_50,
    HF_TWO_33_67,
    HF_TWO_67_33,


### PR DESCRIPTION
…always false

Get this warning when compiling Settings.c on the Mac OS X with clang-800.0.42.1.
Settings.c:447:28: warning: comparison of unsigned enum expression < 0 is always false [-Wtautological-compare]
         if (this->hLayout < 0 || this->hLayout >= LAST_HEADER_LAYOUT)
             ~~~~~~~~~~~~~ ^ ~

This patch fixes the problem.