### PR TITLE
Fix a compile warning: missing field 'commFilter' initializer

### DIFF
--- a/CommandLine.c
+++ b/CommandLine.c
@@ -291,7 +291,7 @@ int CommandLine_run(const char* name, int argc, char** argv) {
       setlocale(LC_CTYPE, "");
 
    CommandLineStatus status = STATUS_OK;
-   CommandLineSettings flags = { 0 };
+   CommandLineSettings flags;
 
    if ((status = parseArguments(name, argc, argv, &flags)) != STATUS_OK)
       return status != STATUS_OK_EXIT ? 1 : 0;


### PR DESCRIPTION
Get this warning when compiling CommandLine.c on the Mac OS X with clang-800.0.42.1.
CommandLine.c:294:36: warning: missing field 'commFilter' initializer [-Wmissing-field-initializers]
   CommandLineSettings flags = { 0 };
                                   ^

This patch fixes the problem.
Remove the initializer since the following function call parseArguments() will
assign default values for all fields of the structure.