### PR TITLE
Process: Fix PID & UID column widths off-by-one error

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -54,7 +54,7 @@ void Process_setupColumnWidths() {
       return;
    }
 
-   Process_pidDigits = ceil(log10(maxPid));
+   Process_pidDigits = (int)log10(maxPid) + 1;
    assert(Process_pidDigits <= PROCESS_MAX_PID_DIGITS);
 }
 
@@ -64,7 +64,7 @@ void Process_setUidColumnWidth(uid_t maxUid) {
       return;
    }
 
-   Process_uidDigits = ceil(log10(maxUid));
+   Process_uidDigits = (int)log10(maxUid) + 1;
    assert(Process_uidDigits <= PROCESS_MAX_UID_DIGITS);
 }
 


### PR DESCRIPTION
If the max PID or UID value for a platform is exactly a power of ten
(10000, 100000, etc.) the column widths of PID and UID would be 1 char
less than the correct number of digits. This is caused by the wrong
rounding function (ceil(x)); change to the correct one (trunc(x) + 1).