### PR TITLE
Remove redundant sscanf calls (in (s)scanf a blank validates _zero_ or more whitespace)

### DIFF
--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -2101,16 +2101,11 @@ static void scanCPUFrequencyFromCPUinfo(LinuxProcessList* this) {
       if (fgets(buffer, PROC_LINE_LENGTH, file) == NULL)
          break;
 
-      if (
-         (sscanf(buffer, "processor : %d", &cpuid) == 1) ||
-         (sscanf(buffer, "processor: %d", &cpuid) == 1)
-      ) {
+      if (sscanf(buffer, "processor : %d", &cpuid) == 1) {
          continue;
       } else if (
          (sscanf(buffer, "cpu MHz : %lf", &frequency) == 1) ||
-         (sscanf(buffer, "cpu MHz: %lf", &frequency) == 1) ||
-         (sscanf(buffer, "clock : %lfMHz", &frequency) == 1) ||
-         (sscanf(buffer, "clock: %lfMHz", &frequency) == 1)
+         (sscanf(buffer, "clock : %lfMHz", &frequency) == 1)
       ) {
          if (cpuid < 0 || (unsigned int)cpuid > (existingCPUs - 1)) {
             continue;


### PR DESCRIPTION
man sscanf(3):
A sequence of white-space characters (space, tab, newline, etc.; see isspace(3)).
This directive matches any amount of white space, including none, in the input.