### PR TITLE
LXC: Limit CPU count to what is given in /proc/cpuinfo despite the container seeing the real host CPUs

### DIFF
--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -265,7 +265,7 @@ static void LinuxProcessList_updateCPUcount(ProcessList* super) {
    if (Running_containerized) {
 	   /* LXC munges /proc/cpuinfo but not the /sys/devices/system/cpu/ files,
 	    * so limit the visible CPUs to what the guest has been configured to see: */
-	   currExisting = scanAvailableCPUsFromCPUinfo(this);
+	   currExisting = active = scanAvailableCPUsFromCPUinfo(this);
    }
 
 #ifdef HAVE_SENSORS_SENSORS_H

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -51,6 +51,8 @@ extern const MeterClass* const Platform_meterTypes[];
 bool Platform_init(void);
 void Platform_done(void);
 
+extern bool Running_containerized;
+
 void Platform_setBindings(Htop_Action* keys);
 
 int Platform_getUptime(void);


### PR DESCRIPTION
Closes #993
