### PR TITLE
Hashtable: fix handling of NULL pointer in Hashtable_dump

### DIFF
--- a/Hashtable.c
+++ b/Hashtable.c
@@ -52,7 +52,7 @@ static void Hashtable_dump(const Hashtable* this) {
               i,
               this->buckets[i].key,
               this->buckets[i].probe,
-              this->buckets[i].value ? (const void*)this->buckets[i].value : "(nil)");
+              this->buckets[i].value);
 
       if (this->buckets[i].value)
          items++;


### PR DESCRIPTION
This fixes an issus in Hashtable_dump where `"(nil"` is passed as an
argument to `%p` in fprintf. This prints the static address of `"(nil)"`
not "(nil)". This commit changes the code to just pass the NULL pointer
to fprintf, which will consistently print "0x0".