### PR TITLE
consider only shrinkable ZFS ARC as cache

### DIFF
--- a/generic/openzfs_sysctl.c
+++ b/generic/openzfs_sysctl.c
@@ -15,6 +15,7 @@ in the source distribution for its full text.
 
 
 static int MIB_kstat_zfs_misc_arcstats_size[5];
+static int MIB_kstat_zfs_misc_arcstats_c_min[5];
 static int MIB_kstat_zfs_misc_arcstats_c_max[5];
 static int MIB_kstat_zfs_misc_arcstats_mfu_size[5];
 static int MIB_kstat_zfs_misc_arcstats_mru_size[5];
@@ -35,6 +36,7 @@ void openzfs_sysctl_init(ZfsArcStats* stats) {
       len = 5;
       sysctlnametomib("kstat.zfs.misc.arcstats.size", MIB_kstat_zfs_misc_arcstats_size, &len);
 
+      sysctlnametomib("kstat.zfs.misc.arcstats.c_min", MIB_kstat_zfs_misc_arcstats_c_min, &len);
       sysctlnametomib("kstat.zfs.misc.arcstats.c_max", MIB_kstat_zfs_misc_arcstats_c_max, &len);
       sysctlnametomib("kstat.zfs.misc.arcstats.mfu_size", MIB_kstat_zfs_misc_arcstats_mfu_size, &len);
       sysctlnametomib("kstat.zfs.misc.arcstats.mru_size", MIB_kstat_zfs_misc_arcstats_mru_size, &len);
@@ -60,6 +62,10 @@ void openzfs_sysctl_updateArcStats(ZfsArcStats* stats) {
       len = sizeof(stats->size);
       sysctl(MIB_kstat_zfs_misc_arcstats_size, 5, &(stats->size), &len, NULL, 0);
       stats->size /= 1024;
+
+      len = sizeof(stats->min);
+      sysctl(MIB_kstat_zfs_misc_arcstats_c_min, 5, &(stats->min), &len, NULL, 0);
+      stats->min /= 1024;
 
       len = sizeof(stats->max);
       sysctl(MIB_kstat_zfs_misc_arcstats_c_max, 5, &(stats->max), &len, NULL, 0);

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -1922,6 +1922,7 @@ static inline void LinuxProcessList_scanZfsArcstats(LinuxProcessList* lpl) {
 
       switch (buffer[0]) {
       case 'c':
+         tryRead("c_min", &lpl->zfs.min);
          tryRead("c_max", &lpl->zfs.max);
          tryReadFlag("compressed_size", &lpl->zfs.compressed, lpl->zfs.isCompressed);
          break;
@@ -1956,6 +1957,7 @@ static inline void LinuxProcessList_scanZfsArcstats(LinuxProcessList* lpl) {
 
    lpl->zfs.enabled = (lpl->zfs.size > 0 ? 1 : 0);
    lpl->zfs.size    /= 1024;
+   lpl->zfs.min    /= 1024;
    lpl->zfs.max    /= 1024;
    lpl->zfs.MFU    /= 1024;
    lpl->zfs.MRU    /= 1024;

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -358,8 +358,13 @@ void Platform_setMemoryValues(Meter* this) {
    this->values[4] = pl->availableMem;
 
    if (lpl->zfs.enabled != 0 && !Running_containerized) {
-      this->values[0] -= lpl->zfs.size;
-      this->values[3] += lpl->zfs.size;
+      // ZFS does not shrink below the value of zfs_arc_min.
+      unsigned long long int shrinkableSize = 0;
+      if (lpl->zfs.size > lpl->zfs.min)
+         shrinkableSize = lpl->zfs.size - lpl->zfs.min;
+      this->values[0] -= shrinkableSize;
+      this->values[3] += shrinkableSize;
+      this->values[4] += shrinkableSize;
    }
 }
 

--- a/pcp/PCPMetric.h
+++ b/pcp/PCPMetric.h
@@ -81,6 +81,7 @@ typedef enum PCPMetric_ {
    PCP_ZFS_ARC_BONUS_SIZE,      /* zfs.arc.bonus_size */
    PCP_ZFS_ARC_COMPRESSED_SIZE, /* zfs.arc.compressed_size */
    PCP_ZFS_ARC_UNCOMPRESSED_SIZE, /* zfs.arc.uncompressed_size */
+   PCP_ZFS_ARC_C_MIN,           /* zfs.arc.c_min */
    PCP_ZFS_ARC_C_MAX,           /* zfs.arc.c_max */
    PCP_ZFS_ARC_DBUF_SIZE,       /* zfs.arc.dbuf_size */
    PCP_ZFS_ARC_DNODE_SIZE,      /* zfs.arc.dnode_size */

--- a/pcp/PCPProcessList.c
+++ b/pcp/PCPProcessList.c
@@ -601,6 +601,8 @@ static inline void PCPProcessList_scanZfsArcstats(PCPProcessList* this) {
    memset(&this->zfs, 0, sizeof(ZfsArcStats));
    if (PCPMetric_values(PCP_ZFS_ARC_ANON_SIZE, &value, 1, PM_TYPE_U64))
       this->zfs.anon = value.ull / ONE_K;
+   if (PCPMetric_values(PCP_ZFS_ARC_C_MIN, &value, 1, PM_TYPE_U64))
+      this->zfs.min = value.ull / ONE_K;
    if (PCPMetric_values(PCP_ZFS_ARC_C_MAX, &value, 1, PM_TYPE_U64))
       this->zfs.max = value.ull / ONE_K;
    if (PCPMetric_values(PCP_ZFS_ARC_BONUS_SIZE, &value, 1, PM_TYPE_U64))

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -178,6 +178,7 @@ static const char* Platform_metricNames[] = {
    [PCP_ZFS_ARC_BONUS_SIZE] = "zfs.arc.bonus_size",
    [PCP_ZFS_ARC_COMPRESSED_SIZE] = "zfs.arc.compressed_size",
    [PCP_ZFS_ARC_UNCOMPRESSED_SIZE] = "zfs.arc.uncompressed_size",
+   [PCP_ZFS_ARC_C_MIN] = "zfs.arc.c_min",
    [PCP_ZFS_ARC_C_MAX] = "zfs.arc.c_max",
    [PCP_ZFS_ARC_DBUF_SIZE] = "zfs.arc.dbuf_size",
    [PCP_ZFS_ARC_DNODE_SIZE] = "zfs.arc.dnode_size",
@@ -510,8 +511,13 @@ void Platform_setMemoryValues(Meter* this) {
    this->values[4] = pl->availableMem;
 
    if (ppl->zfs.enabled != 0) {
-      this->values[0] -= ppl->zfs.size;
-      this->values[3] += ppl->zfs.size;
+      // ZFS does not shrink below the value of zfs_arc_min.
+      unsigned long long int shrinkableSize = 0;
+      if (ppl->zfs.size > ppl->zfs.min)
+         shrinkableSize = ppl->zfs.size - ppl->zfs.min;
+      this->values[0] -= shrinkableSize;
+      this->values[3] += shrinkableSize;
+      this->values[4] += shrinkableSize;
    }
 }
 

--- a/zfs/ZfsArcStats.h
+++ b/zfs/ZfsArcStats.h
@@ -10,6 +10,7 @@ in the source distribution for its full text.
 typedef struct ZfsArcStats_ {
    int enabled;
    int isCompressed;
+   unsigned long long int min;
    unsigned long long int max;
    unsigned long long int size;
    unsigned long long int MFU;


### PR DESCRIPTION
Fixes: #1002

[ZFS does not shrink](https://docs.oracle.com/cd/E26505_01/html/E37386/chapterzfs-3.html#gjheb) below the value of `zfs_arc_min`.

I think we need to use the shrinkable ZFS ARC cache size when calculating memory usage, not the total ZFS ARC cache size.

The changes:

- remove ZFS ARC shrinkable cache size from `usedMem`.
- add ZFS ARC shrinkable cache size to `cachedMem`.
- add ZFS ARC shrinkable cache size to `availableMem`.

I did the same changes in netdata/netdata#12847. See [before/after screenshots](https://github.com/netdata/netdata/issues/12843#issuecomment-1120421003).

---

I tested this change on my server with ZFS.