### PR TITLE
Fix check "whether running in an LXC container"

### DIFF
--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -1035,7 +1035,7 @@ bool Platform_init(void) {
       char lineBuffer[256];
       while (fgets(lineBuffer, sizeof(lineBuffer), fd)) {
          // detect lxc or overlayfs and guess that this means we are running containerized
-         if (String_startsWith(lineBuffer, "lxcfs ") || String_startsWith(lineBuffer, "overlay ")) {
+         if (String_startsWith(lineBuffer, "lxcfs /proc") || String_startsWith(lineBuffer, "overlay ")) {
             Running_containerized = true;
             break;
          }


### PR DESCRIPTION
Was surprised to find that `htop` thinks that it is inside a container when testing #1003 on a Proxmox host.

---

Checking for `lxcfs ` prefix is not reliable. This PR changes the prefix to `lxcfs /proc`.

- host

  ```cmd
  $ grep ^lxcfs /proc/1/mounts
  lxcfs /var/lib/lxcfs fuse.lxcfs 
  rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other 0 0
  ```

- LXC container

  ```cmd
  grep ^lxcfs /proc/1/mounts
  lxcfs /proc/cpuinfo fuse.lxcfs rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other 0 0
  lxcfs /proc/diskstats fuse.lxcfs rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other 0 0
  lxcfs /proc/loadavg fuse.lxcfs rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other 0 0
  lxcfs /proc/meminfo fuse.lxcfs rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other 0 0
  lxcfs /proc/stat fuse.lxcfs rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other 0 0
  lxcfs /proc/swaps fuse.lxcfs rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other 0 0
  lxcfs /proc/uptime fuse.lxcfs rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other 0 0
  lxcfs /sys/devices/system/cpu/online fuse.lxcfs rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other 0 0
  ```