### PR TITLE
Terminal mouse support is still active even with `enable_mouse=0` or `--no-mouse`

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -88,6 +88,7 @@ static void Action_runSetup(State* st) {
    ScreenManager_run(scr, NULL, NULL, "Setup");
    ScreenManager_delete(scr);
    if (st->settings->changed) {
+      CRT_setMouse(st->settings->enableMouse);
       Header_writeBackToSettings(st->header);
    }
 }

--- a/CRT.c
+++ b/CRT.c
@@ -900,6 +900,20 @@ void CRT_resetSignalHandlers(void) {
    signal(SIGQUIT, SIG_DFL);
 }
 
+void CRT_setMouse(bool enabled) {
+#ifdef HAVE_GETMOUSE
+   if (enabled) {
+#if NCURSES_MOUSE_VERSION > 1
+      mousemask(BUTTON1_RELEASED | BUTTON4_PRESSED | BUTTON5_PRESSED, NULL);
+#else
+      mousemask(BUTTON1_RELEASED, NULL);
+#endif
+   } else {
+      mousemask(0, NULL);
+   }
+#endif
+}
+
 void CRT_init(const Settings* settings, bool allowUnicode) {
    redirectStderr();
 
@@ -993,13 +1007,7 @@ IGNORE_WCASTQUAL_END
 #endif
       CRT_treeStrAscii;
 
-#ifdef HAVE_GETMOUSE
-#if NCURSES_MOUSE_VERSION > 1
-   mousemask(BUTTON1_RELEASED | BUTTON4_PRESSED | BUTTON5_PRESSED, NULL);
-#else
-   mousemask(BUTTON1_RELEASED, NULL);
-#endif
-#endif
+   CRT_setMouse(settings->enableMouse);
 
    CRT_degreeSign = initDegreeSign();
 }

--- a/CRT.h
+++ b/CRT.h
@@ -185,6 +185,8 @@ extern int CRT_scrollWheelVAmount;
 
 extern ColorScheme CRT_colorScheme;
 
+void CRT_setMouse(bool enabled);
+
 void CRT_init(const Settings* settings, bool allowUnicode);
 
 void CRT_done(void);


### PR DESCRIPTION
The current implementation just ignores any mouse events if mouse support is disabled by user, while still unconditionally enables ncurses mouse via **mousemask(3X)** on startup in `CRT_init`

This commit fixes the issue by calling **mousemask(3X)** with a conditional mask value on starting up as well as on changing settings.