### PR TITLE
Fix build failure on FreeBSD 10.* due to KERN_PROC_CWD unavailable

### DIFF
--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -397,6 +397,7 @@ static void FreeBSDProcessList_updateExe(const struct kinfo_proc* kproc, Process
 }
 
 static void FreeBSDProcessList_updateCwd(const struct kinfo_proc* kproc, Process* proc) {
+#ifdef KERN_PROC_CWD
    const int mib[] = { CTL_KERN, KERN_PROC, KERN_PROC_CWD, kproc->ki_pid };
    char buffer[2048];
    size_t size = sizeof(buffer);
@@ -414,6 +415,9 @@ static void FreeBSDProcessList_updateCwd(const struct kinfo_proc* kproc, Process
    }
 
    free_and_xStrdup(&proc->procCwd, buffer);
+#else
+   proc->procCwd = NULL;
+#endif
 }
 
 static void FreeBSDProcessList_updateProcessName(kvm_t* kd, const struct kinfo_proc* kproc, Process* proc) {


### PR DESCRIPTION
```
depbase=`echo freebsd/FreeBSDProcessList.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`; gcc -std=gnu99 -DHAVE_CONFIG_H -I.  -DNDEBUG   -Wall -Wcast-align -Wcast-qual -Wextra -Wfloat-equal -Wformat=2 -Winit-self -Wmissing-format-attribute -Wmissing-noreturn -Wmissing-prototypes -Wpointer-arith -Wshadow -Wstrict-prototypes -Wundef -Wunused -Wwrite-strings -Wno-c11-extensions -pedantic -std=c99 -D_XOPEN_SOURCE_EXTENDED  -DSYSCONFDIR="\"/etc\""  -I"./freebsd" -Os -fno-common -g -MT freebsd/FreeBSDProcessList.o -MD -MP -MF $depbase.Tpo -c -o freebsd/FreeBSDProcessList.o freebsd/FreeBSDProcessList.c && mv -f $depbase.Tpo $depbase.Po
freebsd/FreeBSDProcessList.c: In function 「FreeBSDProcessList_updateCwd」:
freebsd/FreeBSDProcessList.c:400:45: 錯誤：「KERN_PROC_CWD」 undeclared (first use in this function)
freebsd/FreeBSDProcessList.c:400:45: 附註：each undeclared identifier is reported only once for each function it appears in
freebsd/FreeBSDProcessList.c: 在頂層：
cc1: 警告：無法辨識的命令列選項「-Wno-c11-extensions」 [enabled by default]
*** Error code 1
...
```