### PR TITLE
Use of NULL in execlp() must have a pointer cast.

### DIFF
--- a/OpenFilesScreen.c
+++ b/OpenFilesScreen.c
@@ -120,7 +120,9 @@ static OpenFiles_ProcessData* OpenFilesScreen_getProcessData(pid_t pid) {
       close(fdnull);
       char buffer[32] = {0};
       xSnprintf(buffer, sizeof(buffer), "%d", pid);
-      execlp("lsof", "lsof", "-P", "-o", "-p", buffer, "-F", NULL);
+      // Use of NULL in variadic functions must have a pointer cast.
+      // The NULL constant is not required by standard to have a pointer type.
+      execlp("lsof", "lsof", "-P", "-o", "-p", buffer, "-F", (char *)NULL);
       exit(127);
    }
    close(fdpair[1]);

--- a/TraceScreen.c
+++ b/TraceScreen.c
@@ -90,7 +90,9 @@ bool TraceScreen_forkTracer(TraceScreen* this) {
 
       char buffer[32] = {0};
       xSnprintf(buffer, sizeof(buffer), "%d", this->super.process->pid);
-      execlp("strace", "strace", "-T", "-tt", "-s", "512", "-p", buffer, NULL);
+      // Use of NULL in variadic functions must have a pointer cast.
+      // The NULL constant is not required by standard to have a pointer type.
+      execlp("strace", "strace", "-T", "-tt", "-s", "512", "-p", buffer, (char *)NULL);
 
       // Should never reach here, unless execlp fails ...
       const char* message = "Could not execute 'strace'. Please make sure it is available in your $PATH.";

--- a/linux/SystemdMeter.c
+++ b/linux/SystemdMeter.c
@@ -219,6 +219,8 @@ static void updateViaExec(void) {
          exit(1);
       dup2(fdnull, STDERR_FILENO);
       close(fdnull);
+      // Use of NULL in variadic functions must have a pointer cast.
+      // The NULL constant is not required by standard to have a pointer type.
       execlp("systemctl",
              "systemctl",
              "show",
@@ -227,7 +229,7 @@ static void updateViaExec(void) {
              "--property=NNames",
              "--property=NJobs",
              "--property=NInstalledJobs",
-             NULL);
+             (char *)NULL);
       exit(127);
    }
    close(fdpair[1]);

--- a/linux/SystemdMeter.c
+++ b/linux/SystemdMeter.c
@@ -221,15 +221,16 @@ static void updateViaExec(void) {
       close(fdnull);
       // Use of NULL in variadic functions must have a pointer cast.
       // The NULL constant is not required by standard to have a pointer type.
-      execlp("systemctl",
-             "systemctl",
-             "show",
-             "--property=SystemState",
-             "--property=NFailedUnits",
-             "--property=NNames",
-             "--property=NJobs",
-             "--property=NInstalledJobs",
-             (char *)NULL);
+      execlp(
+         "systemctl",
+         "systemctl",
+         "show",
+         "--property=SystemState",
+         "--property=NFailedUnits",
+         "--property=NNames",
+         "--property=NJobs",
+         "--property=NInstalledJobs",
+         (char *)NULL);
       exit(127);
    }
    close(fdpair[1]);


### PR DESCRIPTION
See this article: https://ewontfix.com/11/
In short: The NULL constant is not required by the standards to have a pointer type. This was a design defect in C and C++ languages. In C++ before C++11, `NULL` has been traditionally defined as `0` (integer type, but conforming), which can cause problems when it's used as an argument in a variadic function. (C++11 introduced `nullptr` specifically to address this problem.) musl libc defines `NULL` as `0L` in the hopes of generating a compiler warning when `NULL` is used improperly (e.g. in a variadic function). We should solve this by always doing a pointer cast whenever we use `NULL` in a variadic function.

Note: [POSIX exec function](https://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html) example uses `(char *)0` as the terminating argument. [Linux exec(3) man page](https://man7.org/linux/man-pages/man3/exec.3.html) uses `(char *)NULL`. Both would work, but not plain `NULL` without a cast.