### PR TITLE
fix typo (dist -> disk)

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -629,7 +629,7 @@ static Htop_Reaction actionHelp(State* st) {
    addattrstatestr(CRT_colors[PROCESS_SHADOW], "S", "sleeping; ");
    addattrstatestr(CRT_colors[PROCESS_RUN_STATE], "t", "traced/stopped; ");
    addattrstatestr(CRT_colors[PROCESS_D_STATE], "Z", "zombie; ");
-   addattrstatestr(CRT_colors[PROCESS_D_STATE], "D", "dist sleep");
+   addattrstatestr(CRT_colors[PROCESS_D_STATE], "D", "disk sleep");
    attrset(CRT_colors[DEFAULT_COLOR]);
 
 #undef addattrstatestr


### PR DESCRIPTION
This was changed in commit 37e01cbe33714c8fde72220555b92c7d8585d127,
probably unintentional.