### PR TITLE
Allocate GraphData buffer dynamically

### DIFF
--- a/Meter.h
+++ b/Meter.h
@@ -20,7 +20,6 @@ in the source distribution for its full text.
 
 
 #define METER_TXTBUFFER_LEN 256
-#define METER_GRAPHDATA_SIZE 256
 
 #define METER_BUFFER_CHECK(buffer, size, written)          \
    do {                                                    \
@@ -97,7 +96,8 @@ typedef struct MeterClass_ {
 
 typedef struct GraphData_ {
    struct timeval time;
-   double values[METER_GRAPHDATA_SIZE];
+   size_t nValues;
+   double* values;
 } GraphData;
 
 struct Meter_ {
@@ -108,7 +108,7 @@ struct Meter_ {
    char* caption;
    int mode;
    unsigned int param;
-   GraphData* drawData;
+   GraphData drawData;
    int h;
    int columnWidthCount;      /**< only used internally by the Header */
    uint8_t curItems;


### PR DESCRIPTION
I occasionally run htop in a full-screen terminal on a wide monitor, which had been producing a clunkily truncated CPU graph in the header section:

![htop](https://user-images.githubusercontent.com/384597/169676781-d6fb7dff-2c20-44af-9f9e-0cd8c6b0c1c3.png)

Bumping `METER_GRAPHDATA_SIZE` up to 1024 resolves the problem.