### PR TITLE
Restore functionality of stripExeFromCmdline setting

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -601,11 +601,15 @@ void Process_makeCommandStr(Process* this) {
    }
 
    if (matchLen) {
-      /* strip the matched exe prefix */
-      cmdline += matchLen;
+      if (stripExeFromCmdline) {
+         /* strip the matched exe prefix */
+         cmdline += matchLen;
 
-      commStart -= matchLen;
-      commEnd -= matchLen;
+         commStart -= matchLen;
+         commEnd -= matchLen;
+      } else {
+         matchLen = 0;
+      }
    }
 
    if (!matchLen || (haveCommField && *cmdline)) {


### PR DESCRIPTION
This was accidentally lost in fbec3e4005ee

Pre-requisite for #1029.