### PR TITLE
Fix incorrect processor time of processes on DragonFly BSD

### DIFF
--- a/dragonflybsd/DragonFlyBSDProcessList.c
+++ b/dragonflybsd/DragonFlyBSDProcessList.c
@@ -509,7 +509,7 @@ void ProcessList_goThroughEntries(ProcessList* super, bool pauseProcessUpdate) {
       proc->m_virt = kproc->kp_vm_map_size / ONE_K;
       proc->m_resident = kproc->kp_vm_rssize * pageSizeKb;
       proc->nlwp = kproc->kp_nthreads;		// number of lwp thread
-      proc->time = (kproc->kp_swtime + 5000) / 10000;
+      proc->time = (kproc->kp_lwp.kl_uticks + kproc->kp_lwp.kl_sticks + kproc->kp_lwp.kl_iticks) / 10000;
 
       proc->percent_cpu = 100.0 * ((double)kproc->kp_lwp.kl_pctcpu / (double)kernelFScale);
       proc->percent_mem = 100.0 * proc->m_resident / (double)(super->totalMem);


### PR DESCRIPTION
I have no idea how can this error be introduced, but according to DragonFly BSD kernel source, `kp_swtime` indicates how many times the process scheduling statistics get recalculated, not the processor time the process spends.

Should partially fix <https://github.com/hishamhm/htop/issues/975/>, while I guess the other issue mentioned in that report is due to htop didn't account `kl_pctcpu` for all threads of a multi-threaded process.