### PR TITLE
Calculate 'percent_cpu' relative to a single processor on Solaris

### DIFF
--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -465,7 +465,7 @@ static int SolarisProcessList_walkproc(psinfo_t* _psinfo, lwpsinfo_t* _lwpsinfo,
       sproc->realtgid       = _psinfo->pr_ppid;
 
       // See note above (in common section) about this BINARY FRACTION
-      proc->percent_cpu     = ((uint16_t)_psinfo->pr_pctcpu / (double)32768) * (double)100.0;
+      proc->percent_cpu     = ((uint16_t)_psinfo->pr_pctcpu / (double)32768) * pl->cpuCount * 100.0;
       Process_updateCPUFieldWidths(proc->percent_cpu);
 
       proc->time            = _psinfo->pr_time.tv_sec * 100 + _psinfo->pr_time.tv_nsec / 10000000;
@@ -494,7 +494,7 @@ static int SolarisProcessList_walkproc(psinfo_t* _psinfo, lwpsinfo_t* _lwpsinfo,
       }
       proc->show = !(pl->settings->hideKernelThreads && proc->isKernelThread);
    } else { // We are not in the master LWP, so jump to the LWP handling code
-      proc->percent_cpu        = ((uint16_t)_lwpsinfo->pr_pctcpu / (double)32768) * (double)100.0;
+      proc->percent_cpu        = ((uint16_t)_lwpsinfo->pr_pctcpu / (double)32768) * pl->cpuCount * 100.0;
       Process_updateCPUFieldWidths(proc->percent_cpu);
 
       proc->time               = _lwpsinfo->pr_time.tv_sec * 100 + _lwpsinfo->pr_time.tv_nsec / 10000000;


### PR DESCRIPTION
The Solaris procfs reports `pr_pctcpu` relative to all on-line processors on the system (see <https://code.illumos.org/plugins/gitiles/illumos-gate/+/refs/heads/master/usr/src/uts/common/fs/proc/prsubr.c>, function `prgetpctcpu`), while htop's `percent_cpu` is based on a single processor; this caused the processor usage off processes be under-reported on SMP systems.

For example, a process with 4 busy threads, running on a Solaris system with at least 4 processors, I would expect the %CPU values be close to 400% and 100% for process and each thread display respectively.