### PR TITLE
Prevent null pointer dereference on early error

### DIFF
--- a/CRT.c
+++ b/CRT.c
@@ -1013,9 +1013,11 @@ IGNORE_WCASTQUAL_END
 }
 
 void CRT_done() {
-   attron(CRT_colors[RESET_COLOR]);
+   int resetColor = CRT_colors ? CRT_colors[RESET_COLOR] : CRT_colorSchemes[COLORSCHEME_DEFAULT][RESET_COLOR];
+
+   attron(resetColor);
    mvhline(LINES - 1, 0, ' ', COLS);
-   attroff(CRT_colors[RESET_COLOR]);
+   attroff(resetColor);
    refresh();
 
    curs_set(1);


### PR DESCRIPTION
If a fatal error occurs before CRT_init has been called, CRT_done
dereferences NULL in CRT_colors.

Simply check if CRT_crashSettings is not NULL, which is eventually
set when CRT_init has been called.

If it is not set, then do not try to disable ncurses.

Proof of Concept (on Linux):

```
$ ./configure --with-proc=/var/empty
$ make
$ ./htop
```