### PR TITLE
Fix format specifier warning on 32 bit

### DIFF
--- a/OpenFilesScreen.c
+++ b/OpenFilesScreen.c
@@ -226,7 +226,7 @@ static OpenFiles_ProcessData* OpenFilesScreen_getProcessData(pid_t pid) {
       struct stat st;
       if (stat(filename, &st) == 0) {
          char fileSizeBuf[21]; /* 20 (long long) + 1 (NULL) */
-         xSnprintf(fileSizeBuf, sizeof(fileSizeBuf), "%"PRIu64, st.st_size); /* st.st_size is long long on macOS, long on linux */
+         xSnprintf(fileSizeBuf, sizeof(fileSizeBuf), "%"PRIu64, (uint64_t)st.st_size); /* st.st_size is long long on macOS, long on linux */
          free_and_xStrdup(&item->data[fileSizeIndex], fileSizeBuf);
       }
    }


### PR DESCRIPTION
    OpenFilesScreen.c:229:65: error: format specifies type 'unsigned long long' but the argument has type '__off_t' (aka 'long') [-Werror,-Wformat]
             xSnprintf(fileSizeBuf, sizeof(fileSizeBuf), "%"PRIu64, st.st_size); /* st.st_size is long long on macOS, long on linux */
                                                          ~~~~~~~~  ^~~~~~~~~~