### PR TITLE
Add option to hide processes running in a container

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -221,6 +221,11 @@ static Htop_Reaction actionToggleUserlandThreads(State* st) {
    return HTOP_RECALCULATE | HTOP_SAVE_SETTINGS | HTOP_KEEP_FOLLOWING;
 }
 
+static Htop_Reaction actionToggleRunningInContainer(State* st){
+   st->settings->hideRunningInContainer = !st->settings->hideRunningInContainer;
+   return HTOP_RECALCULATE | HTOP_SAVE_SETTINGS | HTOP_KEEP_FOLLOWING;
+}
+
 static Htop_Reaction actionToggleProgramPath(State* st) {
    st->settings->showProgramPath = !st->settings->showProgramPath;
    return HTOP_REFRESH | HTOP_SAVE_SETTINGS;
@@ -752,6 +757,7 @@ void Action_setBindings(Htop_Action* keys) {
    keys['K'] = actionToggleKernelThreads;
    keys['M'] = actionSortByMemory;
    keys['N'] = actionSortByPID;
+   keys['O'] = actionToggleRunningInContainer;
    keys['P'] = actionSortByCPU;
    keys['S'] = actionSetup;
    keys['T'] = actionSortByTime;

--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -116,6 +116,7 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    Panel_add(super, (Object*) CheckItem_newByRef("Shadow other users' processes", &(settings->shadowOtherUsers)));
    Panel_add(super, (Object*) CheckItem_newByRef("Hide kernel threads", &(settings->hideKernelThreads)));
    Panel_add(super, (Object*) CheckItem_newByRef("Hide userland process threads", &(settings->hideUserlandThreads)));
+   Panel_add(super, (Object*) CheckItem_newByRef("Hide processes running in containers", &(settings->hideRunningInContainer)));
    Panel_add(super, (Object*) CheckItem_newByRef("Display threads in a different color", &(settings->highlightThreads)));
    Panel_add(super, (Object*) CheckItem_newByRef("Show custom thread names", &(settings->showThreadNames)));
    Panel_add(super, (Object*) CheckItem_newByRef("Show program path", &(settings->showProgramPath)));

--- a/Process.h
+++ b/Process.h
@@ -134,6 +134,9 @@ typedef struct Process_ {
    /* This is a userland thread / LWP */
    bool isUserlandThread;
 
+   /* This process is running inside a container */
+   bool isRunningInContainer;
+
    /* Controlling terminal identifier of the process */
    unsigned long int tty_nr;
 

--- a/Settings.c
+++ b/Settings.c
@@ -381,6 +381,8 @@ static bool Settings_read(Settings* this, const char* fileName, unsigned int ini
          this->hideKernelThreads = atoi(option[1]);
       } else if (String_eq(option[0], "hide_userland_threads")) {
          this->hideUserlandThreads = atoi(option[1]);
+      } else if (String_eq(option[0], "hide_running_in_container")) {
+         this->hideRunningInContainer = atoi(option[1]);
       } else if (String_eq(option[0], "shadow_other_users")) {
          this->shadowOtherUsers = atoi(option[1]);
       } else if (String_eq(option[0], "show_thread_names")) {
@@ -575,6 +577,7 @@ int Settings_write(const Settings* this, bool onCrash) {
    fprintf(fd, "fields="); writeFields(fd, this->screens[0]->fields, this->dynamicColumns, false, separator);
    printSettingInteger("hide_kernel_threads", this->hideKernelThreads);
    printSettingInteger("hide_userland_threads", this->hideUserlandThreads);
+   printSettingInteger("hide_running_in_container", this->hideRunningInContainer);
    printSettingInteger("shadow_other_users", this->shadowOtherUsers);
    printSettingInteger("show_thread_names", this->showThreadNames);
    printSettingInteger("show_program_path", this->showProgramPath);
@@ -668,6 +671,7 @@ Settings* Settings_new(unsigned int initialCpuCount, Hashtable* dynamicColumns) 
    this->showThreadNames = false;
    this->hideKernelThreads = true;
    this->hideUserlandThreads = false;
+   this->hideRunningInContainer = false;
    this->highlightBaseName = false;
    this->highlightDeletedExe = true;
    this->highlightMegabytes = true;

--- a/Settings.h
+++ b/Settings.h
@@ -73,6 +73,7 @@ typedef struct Settings_ {
    bool shadowOtherUsers;
    bool showThreadNames;
    bool hideKernelThreads;
+   bool hideRunningInContainer;
    bool hideUserlandThreads;
    bool highlightBaseName;
    bool highlightDeletedExe;

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -779,15 +779,15 @@ static bool LinuxProcessList_checkPidNamespace(Process *process, openat_arg_t pr
 
       char *ptr = buffer;
       int pid_ns_count = 0;
-      while(*ptr != '\0' && *ptr != '\n' && !isdigit(*ptr))
+      while (*ptr && *ptr != '\n' && !isdigit(*ptr))
          ++ptr;
 
-      while(*ptr != '\0' && *ptr != '\n') {
+      while (*ptr && *ptr != '\n') {
          if (isdigit(*ptr))
             pid_ns_count++;
-         while(isdigit(*ptr))
+         while (isdigit(*ptr))
             ++ptr;
-         while(*ptr != '\0' && *ptr != '\n' && !isdigit(*ptr))
+         while (*ptr && *ptr != '\n' && !isdigit(*ptr))
             ++ptr;
       }
 
@@ -1550,11 +1550,12 @@ static bool LinuxProcessList_recurseProcTree(LinuxProcessList* this, openat_arg_
 
       LinuxProcessList_recurseProcTree(this, procFd, "task", proc, period);
 
-      if ((ss->flags & PROCESS_FLAG_LINUX_CGROUP) || hideRunningInContainer) {
+      if (ss->flags & PROCESS_FLAG_LINUX_CGROUP || hideRunningInContainer) {
          LinuxProcessList_readCGroupFile(lp, procFd);
-         if (hideRunningInContainer && lp->cgroup && isContainerOrVMSlice(lp -> cgroup)) {
-            if (!LinuxProcessList_checkPidNamespace(proc, procFd))
+         if (hideRunningInContainer && lp->cgroup && isContainerOrVMSlice(lp->cgroup)) {
+            if (!LinuxProcessList_checkPidNamespace(proc, procFd)) {
                goto errorReadingProcess;
+            }
          }
       }
 
@@ -1636,7 +1637,7 @@ static bool LinuxProcessList_recurseProcTree(LinuxProcessList* this, openat_arg_
       char statCommand[MAX_NAME + 1];
       unsigned long long int lasttimes = (lp->utime + lp->stime);
       unsigned long int tty_nr = proc->tty_nr;
-      if (! LinuxProcessList_readStatFile(proc, procFd, statCommand, sizeof(statCommand)))
+      if (!LinuxProcessList_readStatFile(proc, procFd, statCommand, sizeof(statCommand)))
          goto errorReadingProcess;
 
       if (lp->flags & PF_KTHREAD) {


### PR DESCRIPTION
Might close #1036

The patch makes use of NSpid to check whether a process runs inside a pid namespace that is different from the host's init process' pid namespace. If this check is true, the cgroup name is checked to ensure it isn't a process running on the host that happens to run in a different pid namespace.

