### PR TITLE
Linux: support openat() without readlinkat()

### DIFF
--- a/Compat.c
+++ b/Compat.c
@@ -11,11 +11,18 @@ in the source distribution for its full text.
 
 #include <errno.h>
 #include <fcntl.h> // IWYU pragma: keep
+#include <limits.h>
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h> // IWYU pragma: keep
 
 #include "XUtils.h" // IWYU pragma: keep
+
+
+/* GNU/Hurd does not have PATH_MAX in limits.h */
+#ifndef PATH_MAX
+# define PATH_MAX 4096
+#endif
 
 
 int Compat_faccessat(int dirfd,
@@ -116,4 +123,34 @@ ssize_t Compat_readlinkat(int dirfd,
    return readlink(path, buf, bufsize);
 
 #endif
+}
+
+ssize_t Compat_readlink(openat_arg_t dirfd,
+                        const char* pathname,
+                        char* buf,
+                        size_t bufsize) {
+
+#ifdef HAVE_OPENAT
+
+   char fdPath[32];
+   xSnprintf(fdPath, sizeof(fdPath), "/proc/self/fd/%d", dirfd);
+
+   char dirPath[PATH_MAX + 1];
+   ssize_t r = readlink(fdPath, dirPath, sizeof(dirPath) - 1);
+   if (r < 0)
+      return r;
+
+   dirPath[r] = '\0';
+
+   char linkPath[PATH_MAX + 1];
+   xSnprintf(linkPath, sizeof(linkPath), "%s/%s", dirPath, pathname);
+
+#else
+
+   char linkPath[PATH_MAX + 1];
+   xSnprintf(linkPath, sizeof(linkPath), "%s/%s", dirfd, pathname);
+
+#endif /* HAVE_OPENAT */
+
+   return readlink(linkPath, buf, bufsize);
 }

--- a/Compat.h
+++ b/Compat.h
@@ -56,4 +56,9 @@ ssize_t Compat_readlinkat(int dirfd,
                           char* buf,
                           size_t bufsize);
 
+ssize_t Compat_readlink(openat_arg_t dirfd,
+                        const char* pathname,
+                        char* buf,
+                        size_t bufsize);
+
 #endif /* HEADER_Compat */

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -1090,9 +1090,7 @@ static void LinuxProcessList_readCwd(LinuxProcess* process, openat_arg_t procFd)
 #if defined(HAVE_READLINKAT) && defined(HAVE_OPENAT)
    ssize_t r = readlinkat(procFd, "cwd", pathBuffer, sizeof(pathBuffer) - 1);
 #else
-   char filename[MAX_NAME + 1];
-   xSnprintf(filename, sizeof(filename), "%s/cwd", procFd);
-   ssize_t r = readlink(filename, pathBuffer, sizeof(pathBuffer) - 1);
+   ssize_t r = Compat_readlink(procFd, "cwd", pathBuffer, sizeof(pathBuffer) - 1);
 #endif
 
    if (r < 0) {
@@ -1329,9 +1327,7 @@ static bool LinuxProcessList_readCmdlineFile(Process* process, openat_arg_t proc
 #if defined(HAVE_READLINKAT) && defined(HAVE_OPENAT)
    amtRead = readlinkat(procFd, "exe", filename, sizeof(filename) - 1);
 #else
-   char path[4096];
-   xSnprintf(path, sizeof(path), "%s/exe", procFd);
-   amtRead = readlink(path, filename, sizeof(filename) - 1);
+   amtRead = Compat_readlink(procFd, "exe", filename, sizeof(filename) - 1);
 #endif
    if (amtRead > 0) {
       filename[amtRead] = 0;


### PR DESCRIPTION
    linux/LinuxProcessList.c:1094:52: error: format specifies type 'char *' but the argument has type 'openat_arg_t' (aka 'int') [-Werror,-Wformat]
       xSnprintf(filename, sizeof(filename), "%s/cwd", procFd);
                                              ~~       ^~~~~~
                                              %d
    linux/LinuxProcessList.c:1333:44: error: format specifies type 'char *' but the argument has type 'openat_arg_t' (aka 'int') [-Werror,-Wformat]
       xSnprintf(path, sizeof(path), "%s/exe", procFd);
                                      ~~       ^~~~~~
                                      %d

Supersedes: #1025