### PR TITLE
configure: support ceil builtin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -212,7 +212,7 @@ AC_RUN_IFELSE([
 # Checks for generic library functions.
 # ----------------------------------------------------------------------
 
-AC_CHECK_LIB([m], [ceil], [], [AC_MSG_ERROR([can not find required function ceil()])])
+AC_SEARCH_LIBS([ceil], [m], [], [AC_MSG_ERROR([can not find required function ceil()])])
 
 if test "$my_htop_platform" = dragonflybsd; then
    AC_SEARCH_LIBS([kvm_open], [kvm], [], [AC_MSG_ERROR([can not find required function kvm_open()])])


### PR DESCRIPTION
ceil(3) might be supplied by the compiler as a builtin.
Use AC_SEARCH_LIBS instead of AC_CHECK_LIB, see
https://www.gnu.org/software/autoconf/manual/autoconf-2.67/html_node/Libraries.html.

Related: #1054