### PR TITLE
Avoid showing garbage values on startup (disk I/O).

### DIFF
--- a/DiskIOMeter.c
+++ b/DiskIOMeter.c
@@ -27,9 +27,9 @@ static const int DiskIOMeter_attributes[] = {
 };
 
 static MeterRateStatus status = RATESTATUS_INIT;
-static uint32_t cached_read_diff;
-static uint32_t cached_write_diff;
-static double cached_utilisation_diff;
+static uint32_t cached_read_diff = 0;
+static uint32_t cached_write_diff = 0;
+static double cached_utilisation_diff = 0.0;
 
 static void DiskIOMeter_updateValues(Meter* this) {
    const ProcessList* pl = this->pl;


### PR DESCRIPTION
Uninitialized "cached" values may be shown on startup.