### PR TITLE
Toggle the header meters with pound key

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -245,6 +245,11 @@ static Htop_Reaction actionToggleTreeView(State* st) {
    return HTOP_REFRESH | HTOP_SAVE_SETTINGS | HTOP_KEEP_FOLLOWING | HTOP_REDRAW_BAR | HTOP_UPDATE_PANELHDR;
 }
 
+static Htop_Reaction actionToggleHideMeters(State* st) {
+   st->hideMeters = !st->hideMeters;
+   return HTOP_RESIZE | HTOP_KEEP_FOLLOWING;
+}
+
 static Htop_Reaction actionExpandOrCollapseAllBranches(State* st) {
    ScreenSettings* ss = st->settings->ss;
    if (!ss->treeView) {
@@ -514,6 +519,7 @@ static const struct {
    bool roInactive;
    const char* info;
 } helpLeft[] = {
+   { .key = "      #: ",  .roInactive = false, .info = "hide/show header meters" },
    { .key = "    Tab: ",  .roInactive = false, .info = "switch to next screen tab" },
    { .key = " Arrows: ",  .roInactive = false, .info = "scroll process list" },
    { .key = " Digits: ",  .roInactive = false, .info = "incremental PID search" },
@@ -740,6 +746,7 @@ static Htop_Reaction actionShowCommandScreen(State* st) {
 
 void Action_setBindings(Htop_Action* keys) {
    keys[' '] = actionTag;
+   keys['#'] = actionToggleHideMeters;
    keys['*'] = actionExpandOrCollapseAllBranches;
    keys['+'] = actionExpandOrCollapse;
    keys[','] = actionSetSortColumn;

--- a/Action.h
+++ b/Action.h
@@ -43,6 +43,7 @@ typedef struct State_ {
    Header* header;
    bool pauseProcessUpdate;
    bool hideProcessSelection;
+   bool hideMeters;
 } State;
 
 static inline bool State_hideFunctionBar(const State* st) {

--- a/CommandLine.c
+++ b/CommandLine.c
@@ -371,6 +371,7 @@ int CommandLine_run(const char* name, int argc, char** argv) {
       .header = header,
       .pauseProcessUpdate = false,
       .hideProcessSelection = false,
+      .hideMeters = false,
    };
 
    MainPanel_setState(panel, &state);

--- a/Panel.c
+++ b/Panel.c
@@ -443,6 +443,9 @@ bool Panel_onKey(Panel* this, int key) {
 HandlerResult Panel_selectByTyping(Panel* this, int ch) {
    int size = Panel_size(this);
 
+   if (ch == '#')
+      return IGNORED;
+
    if (!this->eventHandlerState)
       this->eventHandlerState = xCalloc(100, sizeof(char));
    char* buffer = this->eventHandlerState;

--- a/ScreenManager.h
+++ b/ScreenManager.h
@@ -26,11 +26,11 @@ typedef struct ScreenManager_ {
    int panelCount;
    Header* header;
    const Settings* settings;
-   const State* state;
+   State* state;
    bool allowFocusChange;
 } ScreenManager;
 
-ScreenManager* ScreenManager_new(Header* header, const Settings* settings, const State* state, bool owner);
+ScreenManager* ScreenManager_new(Header* header, const Settings* settings, State* state, bool owner);
 
 void ScreenManager_delete(ScreenManager* this);
 


### PR DESCRIPTION
Show/hide the header meters with the pound ('#') key.  Useful in cases where the header is too large and occupies essential parts of the screen, especially in settings (see #1108).

It is only stored as a runtime state, not a persistent setting; to remove the header permanently one can delete all active meters.