### PR TITLE
GH: add dependabot for GitHub actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+---
+
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - 'type: dependencies'
+      - 'github-actions'


### PR DESCRIPTION
Add dependabot configuration that scans for updates in GitHub actions every week.