### PR TITLE
Check for action flags correctly

### DIFF
--- a/MainPanel.c
+++ b/MainPanel.c
@@ -122,28 +122,28 @@ static HandlerResult MainPanel_eventHandler(Panel* super, int ch) {
       }
    }
 
-   if (reaction & HTOP_REDRAW_BAR) {
+   if ((reaction & HTOP_REDRAW_BAR) == HTOP_REDRAW_BAR) {
       MainPanel_updateLabels(this, settings->ss->treeView, this->state->pl->incFilter);
    }
-   if (reaction & HTOP_RESIZE) {
+   if ((reaction & HTOP_RESIZE) == HTOP_RESIZE) {
       result |= RESIZE;
    }
-   if (reaction & HTOP_UPDATE_PANELHDR) {
+   if ((reaction & HTOP_UPDATE_PANELHDR) == HTOP_UPDATE_PANELHDR) {
       result |= REDRAW;
    }
-   if (reaction & HTOP_REFRESH) {
+   if ((reaction & HTOP_REFRESH) == HTOP_REFRESH) {
       result |= REFRESH;
    }
-   if (reaction & HTOP_RECALCULATE) {
+   if ((reaction & HTOP_RECALCULATE) == HTOP_RECALCULATE) {
       result |= RESCAN;
    }
-   if (reaction & HTOP_SAVE_SETTINGS) {
+   if ((reaction & HTOP_SAVE_SETTINGS) == HTOP_SAVE_SETTINGS) {
       this->state->settings->changed = true;
    }
-   if (reaction & HTOP_QUIT) {
+   if ((reaction & HTOP_QUIT) == HTOP_QUIT) {
       return BREAK_LOOP;
    }
-   if (!(reaction & HTOP_KEEP_FOLLOWING)) {
+   if ((reaction & HTOP_KEEP_FOLLOWING) != HTOP_KEEP_FOLLOWING) {
       this->state->pl->following = -1;
       Panel_setSelectionColor(super, PANEL_SELECTION_FOCUS);
    }


### PR DESCRIPTION
Actions are not simple flags with a single bit set, but might have multiple bits set for implying actions.  Do not handle an action if only an implying bit is set.

Fixes: edc3de7cb597 ("Action: specify implication in code not in comments")