### PR TITLE
Show year as start time for processes older than a year

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -274,7 +274,7 @@ void Process_printTime(RichString* str, unsigned long long totalHundredths, bool
 
 void Process_fillStarttimeBuffer(Process* this) {
    struct tm date;
-   time_t now = time(NULL);
+   time_t now = this->host->realtime.tv_sec;
    (void) localtime_r(&this->starttime_ctime, &date);
 
    strftime(this->starttime_show,

--- a/Process.c
+++ b/Process.c
@@ -274,8 +274,13 @@ void Process_printTime(RichString* str, unsigned long long totalHundredths, bool
 
 void Process_fillStarttimeBuffer(Process* this) {
    struct tm date;
+   time_t now = time(NULL);
    (void) localtime_r(&this->starttime_ctime, &date);
-   strftime(this->starttime_show, sizeof(this->starttime_show) - 1, (this->starttime_ctime > (time(NULL) - 86400)) ? "%R " : "%b%d ", &date);
+
+   strftime(this->starttime_show,
+            sizeof(this->starttime_show) - 1,
+            (this->starttime_ctime > now - 86400) ? "%R " : (this->starttime_ctime > now - 364*86400) ? "%b%d " : " %Y ",
+            &date);
 }
 
 /*


### PR DESCRIPTION
Old format is month+day which can be ambiguous.

Not sure what to do with this compilation warning:
```make
Process.c: In function ‘Process_fillStarttimeBuffer’:                                                                                                    
Process.c:288:4: warning: format not a string literal, format string not checked [-Wformat-nonliteral]
  288 |    strftime(this->starttime_show, sizeof(this->starttime_show) - 1, fmt, &date);
```