### PR TITLE
Add toggle to exclude hugepages from memory bar

### DIFF
--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -127,6 +127,7 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    Panel_add(super, (Object*) CheckItem_newByRef("- Try to strip exe from cmdline (when Command is merged)", &(settings->stripExeFromCmdline)));
    Panel_add(super, (Object*) CheckItem_newByRef("Highlight large numbers in memory counters", &(settings->highlightMegabytes)));
    Panel_add(super, (Object*) CheckItem_newByRef("Leave a margin around header", &(settings->headerMargin)));
+   Panel_add(super, (Object*) CheckItem_newByRef("Exclude HugePages from memory", &(settings->excludeHugepages)));
    Panel_add(super, (Object*) CheckItem_newByRef("Detailed CPU time (System/IO-Wait/Hard-IRQ/Soft-IRQ/Steal/Guest)", &(settings->detailedCPUTime)));
    Panel_add(super, (Object*) CheckItem_newByRef("Count CPUs from 1 instead of 0", &(settings->countCPUsFromOne)));
    Panel_add(super, (Object*) CheckItem_newByRef("Update process names on every refresh", &(settings->updateProcessNames)));

--- a/Settings.c
+++ b/Settings.c
@@ -412,6 +412,8 @@ static bool Settings_read(Settings* this, const char* fileName, unsigned int ini
          this->headerMargin = atoi(option[1]);
       } else if (String_eq(option[0], "screen_tabs")) {
          this->screenTabs = atoi(option[1]);
+      } else if (String_eq(option[0], "exclude_hugepages")) {
+         this->excludeHugepages = atoi(option[1]);
       } else if (String_eq(option[0], "expand_system_time")) {
          // Compatibility option.
          this->detailedCPUTime = atoi(option[1]);
@@ -593,6 +595,7 @@ int Settings_write(const Settings* this, bool onCrash) {
    printSettingInteger("show_merged_command", this->showMergedCommand);
    printSettingInteger("header_margin", this->headerMargin);
    printSettingInteger("screen_tabs", this->screenTabs);
+   printSettingInteger("exclude_hugepages", this->excludeHugepages);
    printSettingInteger("detailed_cpu_time", this->detailedCPUTime);
    printSettingInteger("cpu_count_from_one", this->countCPUsFromOne);
    printSettingInteger("show_cpu_usage", this->showCPUUsage);
@@ -676,6 +679,7 @@ Settings* Settings_new(unsigned int initialCpuCount, Hashtable* dynamicColumns) 
    this->highlightBaseName = false;
    this->highlightDeletedExe = true;
    this->highlightMegabytes = true;
+   this->excludeHugepages = false;
    this->detailedCPUTime = false;
    this->countCPUsFromOne = false;
    this->showCPUUsage = true;

--- a/Settings.h
+++ b/Settings.h
@@ -88,6 +88,7 @@ typedef struct Settings_ {
    bool accountGuestInCPUMeter;
    bool headerMargin;
    bool screenTabs;
+   bool excludeHugepages;
    #ifdef HAVE_GETMOUSE
    bool enableMouse;
    #endif

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -350,8 +350,13 @@ void Platform_setMemoryValues(Meter* this) {
    const ProcessList* pl = this->pl;
    const LinuxProcessList* lpl = (const LinuxProcessList*) pl;
 
-   this->total     = pl->totalMem;
-   this->values[0] = pl->usedMem;
+   if (this->pl->settings->excludeHugepages) {
+      this->total     = pl->totalMem > lpl->totalHugePageMem ? pl->totalMem - lpl->totalHugePageMem : pl->totalMem;
+      this->values[0] = pl->usedMem > lpl->totalHugePageMem ? pl->usedMem - lpl->totalHugePageMem : pl->usedMem;
+   } else {
+      this->total     = pl->totalMem;
+      this->values[0] = pl->usedMem;
+   }
    this->values[1] = pl->buffersMem;
    this->values[2] = pl->sharedMem;
    this->values[3] = pl->cachedMem;


### PR DESCRIPTION
This implements #858 what I completely forgot about. One addition one could do would be coloring the hugepages part of the memory bar when not excluding hugepages in a different color.