### PR TITLE
Refresh settings

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -213,26 +213,36 @@ static Htop_Reaction actionSortByTime(State* st) {
 
 static Htop_Reaction actionToggleKernelThreads(State* st) {
    st->settings->hideKernelThreads = !st->settings->hideKernelThreads;
+   st->settings->lastUpdate++;
+
    return HTOP_RECALCULATE | HTOP_SAVE_SETTINGS | HTOP_KEEP_FOLLOWING;
 }
 
 static Htop_Reaction actionToggleUserlandThreads(State* st) {
    st->settings->hideUserlandThreads = !st->settings->hideUserlandThreads;
+   st->settings->lastUpdate++;
+
    return HTOP_RECALCULATE | HTOP_SAVE_SETTINGS | HTOP_KEEP_FOLLOWING;
 }
 
 static Htop_Reaction actionToggleRunningInContainer(State* st) {
    st->settings->hideRunningInContainer = !st->settings->hideRunningInContainer;
+   st->settings->lastUpdate++;
+
    return HTOP_RECALCULATE | HTOP_SAVE_SETTINGS | HTOP_KEEP_FOLLOWING;
 }
 
 static Htop_Reaction actionToggleProgramPath(State* st) {
    st->settings->showProgramPath = !st->settings->showProgramPath;
+   st->settings->lastUpdate++;
+
    return HTOP_REFRESH | HTOP_SAVE_SETTINGS | HTOP_KEEP_FOLLOWING;
 }
 
 static Htop_Reaction actionToggleMergedCommand(State* st) {
    st->settings->showMergedCommand = !st->settings->showMergedCommand;
+   st->settings->lastUpdate++;
+
    return HTOP_REFRESH | HTOP_SAVE_SETTINGS | HTOP_KEEP_FOLLOWING | HTOP_UPDATE_PANELHDR;
 }
 

--- a/Action.c
+++ b/Action.c
@@ -228,12 +228,12 @@ static Htop_Reaction actionToggleRunningInContainer(State* st) {
 
 static Htop_Reaction actionToggleProgramPath(State* st) {
    st->settings->showProgramPath = !st->settings->showProgramPath;
-   return HTOP_REFRESH | HTOP_SAVE_SETTINGS;
+   return HTOP_REFRESH | HTOP_SAVE_SETTINGS | HTOP_KEEP_FOLLOWING;
 }
 
 static Htop_Reaction actionToggleMergedCommand(State* st) {
    st->settings->showMergedCommand = !st->settings->showMergedCommand;
-   return HTOP_REFRESH | HTOP_SAVE_SETTINGS;
+   return HTOP_REFRESH | HTOP_SAVE_SETTINGS | HTOP_KEEP_FOLLOWING | HTOP_UPDATE_PANELHDR;
 }
 
 static Htop_Reaction actionToggleTreeView(State* st) {


### PR DESCRIPTION
This works around an issue where updated display settings are not considered because the display strings in the `Command` column are cached.

This also allows to keep following when changing the Merged Command view or display of full path names.