### PR TITLE
CI: drop non existent labels from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,3 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    labels:
-      - 'type: dependencies'
-      - 'github-actions'


### PR DESCRIPTION
See https://github.com/htop-dev/htop/pull/1129#issuecomment-1312868152