### PR TITLE
Add "Automatically save configuration/view on exit" option

### DIFF
--- a/CategoriesPanel.c
+++ b/CategoriesPanel.c
@@ -29,7 +29,7 @@ in the source distribution for its full text.
 #include "XUtils.h"
 
 
-static const char* const CategoriesFunctions[] = {"      ", "      ", "      ", "      ", "      ", "      ", "      ", "      ", "      ", "Done  ", NULL};
+static const char* const CategoriesFunctions[] = {"      ", "      ", "      ", "Save  ", "      ", "      ", "      ", "      ", "      ", "Done  ", NULL};
 
 static void CategoriesPanel_delete(Object* object) {
    Panel* super = (Panel*) object;

--- a/ColorsPanel.c
+++ b/ColorsPanel.c
@@ -26,7 +26,7 @@ in the source distribution for its full text.
 // * Add the colors in CRT_setColors
 
 
-static const char* const ColorsFunctions[] = {"      ", "      ", "      ", "      ", "      ", "      ", "      ", "      ", "      ", "Done  ", NULL};
+static const char* const ColorsFunctions[] = {"      ", "      ", "      ", "Save  ", "      ", "      ", "      ", "      ", "      ", "Done  ", NULL};
 
 static const char* const ColorSchemeNames[] = {
    "Default",

--- a/CommandLine.c
+++ b/CommandLine.c
@@ -397,7 +397,7 @@ int CommandLine_run(const char* name, int argc, char** argv) {
 
    CRT_done();
 
-   if (settings->changed) {
+   if (settings->changed && settings->saveOnExit) {
       int r = Settings_write(settings, false);
       if (r < 0)
          fprintf(stderr, "Can not save configuration to %s: %s\n", settings->filename, strerror(-r));

--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -21,7 +21,7 @@ in the source distribution for its full text.
 #include "ScreensPanel.h"
 
 
-static const char* const DisplayOptionsFunctions[] = {"      ", "      ", "      ", "      ", "      ", "      ", "      ", "      ", "      ", "Done  ", NULL};
+static const char* const DisplayOptionsFunctions[] = {"      ", "      ", "      ", "Save  ", "      ", "      ", "      ", "      ", "      ", "Done  ", NULL};
 
 static void DisplayOptionsPanel_delete(Object* object) {
    Panel* super = (Panel*) object;
@@ -112,6 +112,7 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    Panel_add(super, (Object*) CheckItem_newByRef("- Tree view is always sorted by PID (htop 2 behavior)", &(settings->ss->treeViewAlwaysByPID)));
    Panel_add(super, (Object*) CheckItem_newByRef("- Tree view is collapsed by default", &(settings->ss->allBranchesCollapsed)));
    Panel_add(super, (Object*) TextItem_new("Global options:"));
+   Panel_add(super, (Object*) CheckItem_newByRef("Automatically save configuration/view on exit", &(settings->saveOnExit)));
    Panel_add(super, (Object*) CheckItem_newByRef("Show tabs for screens", &(settings->screenTabs)));
    Panel_add(super, (Object*) CheckItem_newByRef("Shadow other users' processes", &(settings->shadowOtherUsers)));
    Panel_add(super, (Object*) CheckItem_newByRef("Hide kernel threads", &(settings->hideKernelThreads)));

--- a/HeaderOptionsPanel.c
+++ b/HeaderOptionsPanel.c
@@ -20,7 +20,7 @@ in the source distribution for its full text.
 #include "ProvideCurses.h"
 
 
-static const char* const HeaderOptionsFunctions[] = {"      ", "      ", "      ", "      ", "      ", "      ", "      ", "      ", "      ", "Done  ", NULL};
+static const char* const HeaderOptionsFunctions[] = {"      ", "      ", "      ", "Save  ", "      ", "      ", "      ", "      ", "      ", "Done  ", NULL};
 
 static void HeaderOptionsPanel_delete(Object* object) {
    Panel* super = (Panel*) object;

--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -397,6 +397,22 @@ tryRight:
       case KEY_F(10):
          quit = true;
          continue;
+      case KEY_F(4):
+         redraw = false;
+         char msg[1024];
+         int saveOk = Settings_write(this->settings, false);
+         if (saveOk < 0) {
+            xSnprintf(msg, 1024, "Error saving to %s: %s", this->settings->filename, strerror(-saveOk));
+            attrset(CRT_colors[FAILED_SEARCH]);
+         } else {
+            xSnprintf(msg, 1024, "Saved to %s", this->settings->filename);
+            attrset(CRT_colors[FUNCTION_BAR]);
+         }
+
+         mvhline(LINES - 1, 0, ' ', COLS);
+         mvaddstr(LINES - 1, 0, msg);
+         attrset(CRT_colors[RESET_COLOR]);
+         break;
       default:
 defaultHandler:
          sortTimeout = resetSortTimeout;

--- a/ScreensPanel.c
+++ b/ScreensPanel.c
@@ -42,7 +42,7 @@ ScreenListItem* ScreenListItem_new(const char* value, ScreenSettings* ss) {
    return this;
 }
 
-static const char* const ScreensFunctions[] = {"      ", "Rename", "      ", "      ", "New   ", "      ", "MoveUp", "MoveDn", "Remove", "Done  ", NULL};
+static const char* const ScreensFunctions[] = {"      ", "Rename", "      ", "Save  ", "New   ", "      ", "MoveUp", "MoveDn", "Remove", "Done  ", NULL};
 
 static void ScreensPanel_delete(Object* object) {
    Panel* super = (Panel*) object;

--- a/Settings.c
+++ b/Settings.c
@@ -377,6 +377,8 @@ static bool Settings_read(Settings* this, const char* fileName, unsigned int ini
          // old (no screen) naming also supported for backwards compatibility
          screen = Settings_defaultScreens(this);
          screen->allBranchesCollapsed = atoi(option[1]);
+      } else if (String_eq(option[0], "save_on_exit")) {
+         this->saveOnExit = atoi(option[1]);
       } else if (String_eq(option[0], "hide_kernel_threads")) {
          this->hideKernelThreads = atoi(option[1]);
       } else if (String_eq(option[0], "hide_userland_threads")) {
@@ -579,6 +581,7 @@ int Settings_write(const Settings* this, bool onCrash) {
    printSettingString("htop_version", VERSION);
    printSettingInteger("config_reader_min_version", CONFIG_READER_MIN_VERSION);
    fprintf(fd, "fields="); writeFields(fd, this->screens[0]->fields, this->dynamicColumns, false, separator);
+   printSettingInteger("save_on_exit", this->saveOnExit);
    printSettingInteger("hide_kernel_threads", this->hideKernelThreads);
    printSettingInteger("hide_userland_threads", this->hideUserlandThreads);
    printSettingInteger("hide_running_in_container", this->hideRunningInContainer);
@@ -700,6 +703,7 @@ Settings* Settings_new(unsigned int initialCpuCount, Hashtable* dynamicColumns) 
    #ifdef HAVE_LIBHWLOC
    this->topologyAffinity = false;
    #endif
+   this->saveOnExit = true;
 
    this->screens = xCalloc(Platform_numberOfDefaultScreens * sizeof(ScreenSettings*), 1);
    this->nScreens = 0;

--- a/Settings.h
+++ b/Settings.h
@@ -95,6 +95,7 @@ typedef struct Settings_ {
    #ifdef HAVE_LIBHWLOC
    bool topologyAffinity;
    #endif
+   bool saveOnExit;
 
    bool changed;
    uint64_t lastUpdate;


### PR DESCRIPTION
I've long since been annoyed by htop's automatic saving of everything I do, and much prefer it to always open it to the default view I configured.

This adds a new option to disable this. Because you still want to be able to save the configuration file it also adds F4 to save the file. The error message or some feedback is displayed until the next redraw in the function bar; this was the best place I could figure out to draw this.