### PR TITLE
Fix locks screen

### DIFF
--- a/ProcessLocksScreen.c
+++ b/ProcessLocksScreen.c
@@ -27,7 +27,7 @@ ProcessLocksScreen* ProcessLocksScreen_new(const Process* process) {
       this->pid = process->tgid;
    else
       this->pid = process->pid;
-   return (ProcessLocksScreen*) InfoScreen_init(&this->super, process, NULL, LINES - 2, "        ID  TYPE       EXCLUSION  READ/WRITE DEVICE:INODE                              START                  END  FILENAME");
+   return (ProcessLocksScreen*) InfoScreen_init(&this->super, process, NULL, LINES - 2, "   FD TYPE       EXCLUSION  READ/WRITE DEVICE:INODE                              START                  END  FILENAME");
 }
 
 void ProcessLocksScreen_delete(Object* this) {
@@ -64,16 +64,16 @@ static void ProcessLocksScreen_scan(InfoScreen* this) {
 
          char entry[512];
          if (ULLONG_MAX == data->end) {
-            xSnprintf(entry, sizeof(entry), "%10d  %-10s %-10s %-10s %02x:%02x:%020"PRIu64" %20"PRIu64" %20s  %s",
-               data->id,
+            xSnprintf(entry, sizeof(entry), "%5d %-10s %-10s %-10s %02x:%02x:%020"PRIu64" %20"PRIu64" %20s  %s",
+               data->fd,
                data->locktype, data->exclusive, data->readwrite,
                data->dev[0], data->dev[1], data->inode,
                data->start, "<END OF FILE>",
                data->filename ? data->filename : "<N/A>"
             );
          } else {
-            xSnprintf(entry, sizeof(entry), "%10d  %-10s %-10s %-10s %02x:%02x:%020"PRIu64" %20"PRIu64" %20"PRIu64"  %s",
-               data->id,
+            xSnprintf(entry, sizeof(entry), "%5d %-10s %-10s %-10s %02x:%02x:%020"PRIu64" %20"PRIu64" %20"PRIu64"  %s",
+               data->fd,
                data->locktype, data->exclusive, data->readwrite,
                data->dev[0], data->dev[1], data->inode,
                data->start, data->end,

--- a/ProcessLocksScreen.c
+++ b/ProcessLocksScreen.c
@@ -27,7 +27,8 @@ ProcessLocksScreen* ProcessLocksScreen_new(const Process* process) {
       this->pid = process->tgid;
    else
       this->pid = process->pid;
-   return (ProcessLocksScreen*) InfoScreen_init(&this->super, process, NULL, LINES - 2, "   FD TYPE       EXCLUSION  READ/WRITE DEVICE:INODE                              START                  END  FILENAME");
+
+   return (ProcessLocksScreen*) InfoScreen_init(&this->super, process, NULL, LINES - 2, "   FD TYPE       EXCLUSION  READ/WRITE DEVICE       NODE               START                 END  FILENAME");
 }
 
 void ProcessLocksScreen_delete(Object* this) {
@@ -64,18 +65,18 @@ static void ProcessLocksScreen_scan(InfoScreen* this) {
 
          char entry[512];
          if (ULLONG_MAX == data->end) {
-            xSnprintf(entry, sizeof(entry), "%5d %-10s %-10s %-10s %02x:%02x:%020"PRIu64" %20"PRIu64" %20s  %s",
+            xSnprintf(entry, sizeof(entry), "%5d %-10s %-10s %-10s %#6"PRIx64" %10"PRIu64" %19"PRIu64" %19s  %s",
                data->fd,
                data->locktype, data->exclusive, data->readwrite,
-               data->dev[0], data->dev[1], data->inode,
+               (uint64_t) data->dev, data->inode,
                data->start, "<END OF FILE>",
                data->filename ? data->filename : "<N/A>"
             );
          } else {
-            xSnprintf(entry, sizeof(entry), "%5d %-10s %-10s %-10s %02x:%02x:%020"PRIu64" %20"PRIu64" %20"PRIu64"  %s",
+            xSnprintf(entry, sizeof(entry), "%5d %-10s %-10s %-10s %#6"PRIx64" %10"PRIu64" %19"PRIu64" %19"PRIu64"  %s",
                data->fd,
                data->locktype, data->exclusive, data->readwrite,
-               data->dev[0], data->dev[1], data->inode,
+               (uint64_t) data->dev, data->inode,
                data->start, data->end,
                data->filename ? data->filename : "<N/A>"
             );

--- a/ProcessLocksScreen.h
+++ b/ProcessLocksScreen.h
@@ -27,7 +27,7 @@ typedef struct FileLocks_Data_ {
    char* readwrite;
    char* filename;
    int fd;
-   unsigned int dev[2];
+   dev_t dev;
    uint64_t inode;
    uint64_t start;
    uint64_t end;

--- a/ProcessLocksScreen.h
+++ b/ProcessLocksScreen.h
@@ -26,7 +26,7 @@ typedef struct FileLocks_Data_ {
    char* exclusive;
    char* readwrite;
    char* filename;
-   int id;
+   int fd;
    unsigned int dev[2];
    uint64_t inode;
    uint64_t start;

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -344,12 +344,6 @@ char* Platform_getProcessEnv(pid_t pid) {
    return env;
 }
 
-char* Platform_getInodeFilename(pid_t pid, ino_t inode) {
-   (void)pid;
-   (void)inode;
-   return NULL;
-}
-
 FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid) {
    (void)pid;
    return NULL;

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -68,8 +68,6 @@ void Platform_setZfsCompressedArcValues(Meter* this);
 
 char* Platform_getProcessEnv(pid_t pid);
 
-char* Platform_getInodeFilename(pid_t pid, ino_t inode);
-
 FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 bool Platform_getDiskIO(DiskIOData* data);

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -228,12 +228,6 @@ char* Platform_getProcessEnv(pid_t pid) {
    return NULL;
 }
 
-char* Platform_getInodeFilename(pid_t pid, ino_t inode) {
-   (void)pid;
-   (void)inode;
-   return NULL;
-}
-
 FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid) {
    (void)pid;
    return NULL;

--- a/dragonflybsd/Platform.h
+++ b/dragonflybsd/Platform.h
@@ -59,8 +59,6 @@ void Platform_setSwapValues(Meter* this);
 
 char* Platform_getProcessEnv(pid_t pid);
 
-char* Platform_getInodeFilename(pid_t pid, ino_t inode);
-
 FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 bool Platform_getDiskIO(DiskIOData* data);

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -287,12 +287,6 @@ char* Platform_getProcessEnv(pid_t pid) {
    return env;
 }
 
-char* Platform_getInodeFilename(pid_t pid, ino_t inode) {
-   (void)pid;
-   (void)inode;
-   return NULL;
-}
-
 FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid) {
    (void)pid;
    return NULL;

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -59,8 +59,6 @@ void Platform_setZfsCompressedArcValues(Meter* this);
 
 char* Platform_getProcessEnv(pid_t pid);
 
-char* Platform_getInodeFilename(pid_t pid, ino_t inode);
-
 FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 bool Platform_getDiskIO(DiskIOData* data);

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -456,7 +456,7 @@ FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid) {
 
       errno = 0;
       char *end = de->d_name;
-      strtoull(de->d_name, &end, 10);
+      int file = strtoull(de->d_name, &end, 10);
       if (errno || *end)
          continue;
 
@@ -476,11 +476,11 @@ FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid) {
          if (strncmp(buffer, "lock:\t", strlen("lock:\t")))
             continue;
 
-         FileLocks_Data data = {0};
+         FileLocks_Data data = {.fd = file};
          int _;
          char lock_end[25], locktype[32], exclusive[32], readwrite[32];
          if (10 != sscanf(buffer + strlen("lock:\t"), "%d: %31s %31s %31s %d %x:%x:%"PRIu64" %"PRIu64" %24s",
-            &data.id, locktype, exclusive, readwrite, &_,
+            &_, locktype, exclusive, readwrite, &_,
             &data.dev[0], &data.dev[1], &data.inode,
             &data.start, lock_end))
             continue;

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -22,6 +22,7 @@ in the source distribution for its full text.
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+#include <sys/sysmacros.h>
 
 #include "BatteryMeter.h"
 #include "ClockMeter.h"
@@ -478,16 +479,18 @@ FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid) {
 
          FileLocks_Data data = {.fd = file};
          int _;
+         unsigned int maj, min;
          char lock_end[25], locktype[32], exclusive[32], readwrite[32];
          if (10 != sscanf(buffer + strlen("lock:\t"), "%d: %31s %31s %31s %d %x:%x:%"PRIu64" %"PRIu64" %24s",
             &_, locktype, exclusive, readwrite, &_,
-            &data.dev[0], &data.dev[1], &data.inode,
+            &maj, &min, &data.inode,
             &data.start, lock_end))
             continue;
 
          data.locktype = xStrdup(locktype);
          data.exclusive = xStrdup(exclusive);
          data.readwrite = xStrdup(readwrite);
+         data.dev = makedev(maj, min);
 
          if (String_eq(lock_end, "EOF"))
             data.end = ULLONG_MAX;

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -75,8 +75,6 @@ void Platform_setZfsCompressedArcValues(Meter* this);
 
 char* Platform_getProcessEnv(pid_t pid);
 
-char* Platform_getInodeFilename(pid_t pid, ino_t inode);
-
 FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 void Platform_getPressureStall(const char* file, bool some, double* ten, double* sixty, double* threehundred);

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -338,12 +338,6 @@ end:
    return env;
 }
 
-char* Platform_getInodeFilename(pid_t pid, ino_t inode) {
-   (void)pid;
-   (void)inode;
-   return NULL;
-}
-
 FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid) {
    (void)pid;
    return NULL;

--- a/netbsd/Platform.h
+++ b/netbsd/Platform.h
@@ -65,8 +65,6 @@ void Platform_setSwapValues(Meter* this);
 
 char* Platform_getProcessEnv(pid_t pid);
 
-char* Platform_getInodeFilename(pid_t pid, ino_t inode);
-
 FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 bool Platform_getDiskIO(DiskIOData* data);

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -296,12 +296,6 @@ end:
    return env;
 }
 
-char* Platform_getInodeFilename(pid_t pid, ino_t inode) {
-   (void)pid;
-   (void)inode;
-   return NULL;
-}
-
 FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid) {
    (void)pid;
    return NULL;

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -57,8 +57,6 @@ void Platform_setSwapValues(Meter* this);
 
 char* Platform_getProcessEnv(pid_t pid);
 
-char* Platform_getInodeFilename(pid_t pid, ino_t inode);
-
 FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 bool Platform_getDiskIO(DiskIOData* data);

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -669,12 +669,6 @@ char* Platform_getProcessEnv(pid_t pid) {
    return value.cp;
 }
 
-char* Platform_getInodeFilename(pid_t pid, ino_t inode) {
-   (void)pid;
-   (void)inode;
-   return NULL;
-}
-
 FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid) {
    (void)pid;
    return NULL;

--- a/pcp/Platform.h
+++ b/pcp/Platform.h
@@ -98,8 +98,6 @@ void Platform_setZfsCompressedArcValues(Meter* this);
 
 char* Platform_getProcessEnv(pid_t pid);
 
-char* Platform_getInodeFilename(pid_t pid, ino_t inode);
-
 FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 void Platform_getPressureStall(const char* file, bool some, double* ten, double* sixty, double* threehundred);

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -308,12 +308,6 @@ char* Platform_getProcessEnv(pid_t pid) {
    return xRealloc(envBuilder.env, envBuilder.size + 1);
 }
 
-char* Platform_getInodeFilename(pid_t pid, ino_t inode) {
-   (void)pid;
-   (void)inode;
-   return NULL;
-}
-
 FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid) {
    (void)pid;
    return NULL;

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -86,8 +86,6 @@ void Platform_setZfsCompressedArcValues(Meter* this);
 
 char* Platform_getProcessEnv(pid_t pid);
 
-char* Platform_getInodeFilename(pid_t pid, ino_t inode);
-
 FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 bool Platform_getDiskIO(DiskIOData* data);

--- a/unsupported/Platform.c
+++ b/unsupported/Platform.c
@@ -129,12 +129,6 @@ char* Platform_getProcessEnv(pid_t pid) {
    return NULL;
 }
 
-char* Platform_getInodeFilename(pid_t pid, ino_t inode) {
-   (void)pid;
-   (void)inode;
-   return NULL;
-}
-
 FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid) {
    (void)pid;
    return NULL;

--- a/unsupported/Platform.h
+++ b/unsupported/Platform.h
@@ -50,8 +50,6 @@ void Platform_setSwapValues(Meter* this);
 
 char* Platform_getProcessEnv(pid_t pid);
 
-char* Platform_getInodeFilename(pid_t pid, ino_t inode);
-
 FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid);
 
 bool Platform_getDiskIO(DiskIOData* data);


### PR DESCRIPTION
See commit messages, but in short, given:
```
$ head /proc/$$/fdinfo/{9,10,11}
==> /proc/797393/fdinfo/9 <==
pos:    0
flags:  0100000
mnt_id: 2775
lock:   1: FLOCK  ADVISORY  WRITE 818754 00:69:7 0 EOF

==> /proc/797393/fdinfo/10 <==
pos:    0
flags:  0100000
mnt_id: 127
lock:   1: FLOCK  ADVISORY  WRITE 828244 00:30:509028 0 EOF
lock:   2: OFDLCK ADVISORY  READ -1 00:30:509028 0 199

==> /proc/797393/fdinfo/11 <==
pos:    0
flags:  0100000
mnt_id: 2775
lock:   1: FLOCK  ADVISORY  WRITE 935925 00:69:1187 0 EOF
```

You get (before above, after below):
![](https://user-images.githubusercontent.com/6709544/204065414-ec651ad9-c43d-48e2-be55-6207816020d2.png)
