### PR TITLE
ScreenPanel: handle quitting panel while renaming

### DIFF
--- a/CRT.c
+++ b/CRT.c
@@ -1096,7 +1096,7 @@ static void print_backtrace(void) {
       unw_get_proc_name(&cursor, symbolName, sizeof(symbolName), &offset);
 
       unw_proc_info_t pip;
-      pip.unwind_info = NULL;
+      pip.unwind_info = 0;
 
       const char* fname = "?";
       const void* ptr = 0;

--- a/ScreensPanel.h
+++ b/ScreensPanel.h
@@ -31,7 +31,7 @@ typedef struct ScreensPanel_ {
    char* saved;
    int cursor;
    bool moving;
-   bool renaming;
+   ListItem *renamingItem;
 } ScreensPanel;
 
 typedef struct ScreenListItem_ {


### PR DESCRIPTION
During renaming the ScreenPanel takes ownership of the text value of the screen entries ListItem (via its saved member) and replaces the pointer in the ListItem with a pointer to the ScreenPanel's static text buffer. Restore the ownership, similar to how it's done on ESC.

Fixes: #1147