### PR TITLE
Improve code readability by creating constants for memory values

### DIFF
--- a/MemoryMeter.c
+++ b/MemoryMeter.c
@@ -29,14 +29,14 @@ static void MemoryMeter_updateValues(Meter* this) {
    int written;
 
    /* shared and available memory are not supported on all platforms */
-   this->values[2] = NAN;
-   this->values[4] = NAN;
+   this->values[MEMORY_METER_SHARED] = NAN;
+   this->values[MEMORY_METER_AVAILABLE] = NAN;
    Platform_setMemoryValues(this);
 
    /* Do not print available memory in bar mode */
    this->curItems = 4;
 
-   written = Meter_humanUnit(buffer, this->values[0], size);
+   written = Meter_humanUnit(buffer, this->values[MEMORY_METER_USED], size);
    METER_BUFFER_CHECK(buffer, size, written);
 
    METER_BUFFER_APPEND_CHR(buffer, size, '/');
@@ -52,28 +52,28 @@ static void MemoryMeter_display(const Object* cast, RichString* out) {
    Meter_humanUnit(buffer, this->total, sizeof(buffer));
    RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
 
-   Meter_humanUnit(buffer, this->values[0], sizeof(buffer));
+   Meter_humanUnit(buffer, this->values[MEMORY_METER_USED], sizeof(buffer));
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " used:");
    RichString_appendAscii(out, CRT_colors[MEMORY_USED], buffer);
 
-   Meter_humanUnit(buffer, this->values[1], sizeof(buffer));
+   Meter_humanUnit(buffer, this->values[MEMORY_METER_BUFFERS], sizeof(buffer));
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " buffers:");
    RichString_appendAscii(out, CRT_colors[MEMORY_BUFFERS_TEXT], buffer);
 
    /* shared memory is not supported on all platforms */
-   if (!isnan(this->values[2])) {
-      Meter_humanUnit(buffer, this->values[2], sizeof(buffer));
+   if (!isnan(this->values[MEMORY_METER_SHARED])) {
+      Meter_humanUnit(buffer, this->values[MEMORY_METER_SHARED], sizeof(buffer));
       RichString_appendAscii(out, CRT_colors[METER_TEXT], " shared:");
       RichString_appendAscii(out, CRT_colors[MEMORY_SHARED], buffer);
    }
 
-   Meter_humanUnit(buffer, this->values[3], sizeof(buffer));
+   Meter_humanUnit(buffer, this->values[MEMORY_METER_CACHE], sizeof(buffer));
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " cache:");
    RichString_appendAscii(out, CRT_colors[MEMORY_CACHE], buffer);
 
    /* available memory is not supported on all platforms */
-   if (!isnan(this->values[4])) {
-      Meter_humanUnit(buffer, this->values[4], sizeof(buffer));
+   if (!isnan(this->values[MEMORY_METER_AVAILABLE])) {
+      Meter_humanUnit(buffer, this->values[MEMORY_METER_AVAILABLE], sizeof(buffer));
       RichString_appendAscii(out, CRT_colors[METER_TEXT], " available:");
       RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
    }

--- a/MemoryMeter.h
+++ b/MemoryMeter.h
@@ -9,6 +9,14 @@ in the source distribution for its full text.
 
 #include "Meter.h"
 
+typedef enum {
+    MEMORY_METER_USED = 0,
+    MEMORY_METER_BUFFERS = 1,
+    MEMORY_METER_SHARED = 2,
+    MEMORY_METER_CACHE = 3,
+    MEMORY_METER_AVAILABLE = 4,
+    MEMORY_METER_ITEMCOUNT = 5, // number of entries in this enum
+} MemoryMeterValues;
 
 extern const MeterClass MemoryMeter_class;
 

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -264,11 +264,11 @@ void Platform_setMemoryValues(Meter* mtr) {
    double page_K = (double)vm_page_size / (double)1024;
 
    mtr->total = dpl->host_info.max_mem / 1024;
-   mtr->values[0] = (double)(vm->active_count + vm->wire_count) * page_K;
-   mtr->values[1] = (double)vm->purgeable_count * page_K;
-   // mtr->values[2] = "shared memory, like tmpfs and shm"
-   mtr->values[3] = (double)vm->inactive_count * page_K;
-   // mtr->values[4] = "available memory"
+   mtr->values[MEMORY_METER_USED] = (double)(vm->active_count + vm->wire_count) * page_K;
+   mtr->values[MEMORY_METER_BUFFERS] = (double)vm->purgeable_count * page_K;
+   // mtr->values[MEMORY_METER_SHARED] = "shared memory, like tmpfs and shm"
+   mtr->values[MEMORY_METER_CACHE] = (double)vm->inactive_count * page_K;
+   // mtr->values[MEMORY_METER_AVAILABLE] = "available memory"
 }
 
 void Platform_setSwapValues(Meter* mtr) {

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -208,11 +208,11 @@ void Platform_setMemoryValues(Meter* this) {
    const ProcessList* pl = this->pl;
 
    this->total = pl->totalMem;
-   this->values[0] = pl->usedMem;
-   this->values[1] = pl->buffersMem;
-   // this->values[2] = "shared memory, like tmpfs and shm"
-   this->values[3] = pl->cachedMem;
-   // this->values[4] = "available memory"
+   this->values[MEMORY_METER_USED] = pl->usedMem;
+   this->values[MEMORY_METER_BUFFERS] = pl->buffersMem;
+   // this->values[MEMORY_METER_SHARED] = "shared memory, like tmpfs and shm"
+   this->values[MEMORY_METER_CACHE] = pl->cachedMem;
+   // this->values[MEMORY_METER_AVAILABLE] = "available memory"
 }
 
 void Platform_setSwapValues(Meter* this) {

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -230,20 +230,20 @@ void Platform_setMemoryValues(Meter* this) {
    const FreeBSDProcessList* fpl = (const FreeBSDProcessList*) pl;
 
    this->total = pl->totalMem;
-   this->values[0] = pl->usedMem;
-   this->values[1] = pl->buffersMem;
-   // this->values[2] = "shared memory, like tmpfs and shm"
-   this->values[3] = pl->cachedMem;
-   // this->values[4] = "available memory"
+   this->values[MEMORY_METER_USED] = pl->usedMem;
+   this->values[MEMORY_METER_BUFFERS] = pl->buffersMem;
+   // this->values[MEMORY_METER_SHARED] = "shared memory, like tmpfs and shm"
+   this->values[MEMORY_METER_CACHE] = pl->cachedMem;
+   // this->values[MEMORY_METER_AVAILABLE] = "available memory"
 
    if (fpl->zfs.enabled) {
       // ZFS does not shrink below the value of zfs_arc_min.
       unsigned long long int shrinkableSize = 0;
       if (fpl->zfs.size > fpl->zfs.min)
          shrinkableSize = fpl->zfs.size - fpl->zfs.min;
-      this->values[0] -= shrinkableSize;
-      this->values[3] += shrinkableSize;
-      // this->values[4] += shrinkableSize;
+      this->values[MEMORY_METER_USED] -= shrinkableSize;
+      this->values[MEMORY_METER_CACHE] += shrinkableSize;
+      // this->values[MEMORY_METER_AVAILABLE] += shrinkableSize;
    }
 }
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -351,20 +351,20 @@ void Platform_setMemoryValues(Meter* this) {
    const LinuxProcessList* lpl = (const LinuxProcessList*) pl;
 
    this->total     = pl->totalMem;
-   this->values[0] = pl->usedMem;
-   this->values[1] = pl->buffersMem;
-   this->values[2] = pl->sharedMem;
-   this->values[3] = pl->cachedMem;
-   this->values[4] = pl->availableMem;
+   this->values[MEMORY_METER_USED] = pl->usedMem;
+   this->values[MEMORY_METER_BUFFERS] = pl->buffersMem;
+   this->values[MEMORY_METER_SHARED] = pl->sharedMem;
+   this->values[MEMORY_METER_CACHE] = pl->cachedMem;
+   this->values[MEMORY_METER_AVAILABLE] = pl->availableMem;
 
    if (lpl->zfs.enabled != 0 && !Running_containerized) {
       // ZFS does not shrink below the value of zfs_arc_min.
       unsigned long long int shrinkableSize = 0;
       if (lpl->zfs.size > lpl->zfs.min)
          shrinkableSize = lpl->zfs.size - lpl->zfs.min;
-      this->values[0] -= shrinkableSize;
-      this->values[3] += shrinkableSize;
-      this->values[4] += shrinkableSize;
+      this->values[MEMORY_METER_USED] -= shrinkableSize;
+      this->values[MEMORY_METER_CACHE] += shrinkableSize;
+      this->values[MEMORY_METER_AVAILABLE] += shrinkableSize;
    }
 }
 

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -270,11 +270,11 @@ double Platform_setCPUValues(Meter* this, int cpu) {
 void Platform_setMemoryValues(Meter* this) {
    const ProcessList* pl = this->pl;
    this->total = pl->totalMem;
-   this->values[0] = pl->usedMem;
-   this->values[1] = pl->buffersMem;
-   // this->values[2] = "shared memory, like tmpfs and shm"
-   this->values[3] = pl->cachedMem;
-   // this->values[4] = "available memory"
+   this->values[MEMORY_METER_USED] = pl->usedMem;
+   this->values[MEMORY_METER_BUFFERS] = pl->buffersMem;
+   // this->values[MEMORY_METER_SHARED] = "shared memory, like tmpfs and shm"
+   this->values[MEMORY_METER_CACHE] = pl->cachedMem;
+   // this->values[MEMORY_METER_AVAILABLE] = "available memory"
 }
 
 void Platform_setSwapValues(Meter* this) {

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -227,11 +227,11 @@ void Platform_setMemoryValues(Meter* this) {
    long int cachedMem = pl->cachedMem;
    usedMem -= buffersMem + cachedMem;
    this->total = pl->totalMem;
-   this->values[0] = usedMem;
-   this->values[1] = buffersMem;
-   // this->values[2] = "shared memory, like tmpfs and shm"
-   this->values[3] = cachedMem;
-   // this->values[4] = "available memory"
+   this->values[MEMORY_METER_USED] = usedMem;
+   this->values[MEMORY_METER_BUFFERS] = buffersMem;
+   // this->values[MEMORY_METER_SHARED] = "shared memory, like tmpfs and shm"
+   this->values[MEMORY_METER_CACHE] = cachedMem;
+   // this->values[MEMORY_METER_AVAILABLE] = "available memory"
 }
 
 void Platform_setSwapValues(Meter* this) {

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -528,20 +528,20 @@ void Platform_setMemoryValues(Meter* this) {
    const PCPProcessList* ppl = (const PCPProcessList*) pl;
 
    this->total     = pl->totalMem;
-   this->values[0] = pl->usedMem;
-   this->values[1] = pl->buffersMem;
-   this->values[2] = pl->sharedMem;
-   this->values[3] = pl->cachedMem;
-   this->values[4] = pl->availableMem;
+   this->values[MEMORY_METER_USED] = pl->usedMem;
+   this->values[MEMORY_METER_BUFFERS] = pl->buffersMem;
+   this->values[MEMORY_METER_SHARED] = pl->sharedMem;
+   this->values[MEMORY_METER_CACHE] = pl->cachedMem;
+   this->values[MEMORY_METER_AVAILABLE] = pl->availableMem;
 
    if (ppl->zfs.enabled != 0) {
       // ZFS does not shrink below the value of zfs_arc_min.
       unsigned long long int shrinkableSize = 0;
       if (ppl->zfs.size > ppl->zfs.min)
          shrinkableSize = ppl->zfs.size - ppl->zfs.min;
-      this->values[0] -= shrinkableSize;
-      this->values[3] += shrinkableSize;
-      this->values[4] += shrinkableSize;
+      this->values[MEMORY_METER_USED] -= shrinkableSize;
+      this->values[MEMORY_METER_CACHE] += shrinkableSize;
+      this->values[MEMORY_METER_AVAILABLE] += shrinkableSize;
    }
 }
 

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -237,11 +237,11 @@ double Platform_setCPUValues(Meter* this, unsigned int cpu) {
 void Platform_setMemoryValues(Meter* this) {
    const ProcessList* pl = this->pl;
    this->total = pl->totalMem;
-   this->values[0] = pl->usedMem;
-   this->values[1] = pl->buffersMem;
-   // this->values[2] = "shared memory, like tmpfs and shm"
-   this->values[3] = pl->cachedMem;
-   // this->values[4] = "available memory"
+   this->values[MEMORY_METER_USED] = pl->usedMem;
+   this->values[MEMORY_METER_BUFFERS] = pl->buffersMem;
+   // this->values[MEMORY_METER_SHARED] = "shared memory, like tmpfs and shm"
+   this->values[MEMORY_METER_CACHE] = pl->cachedMem;
+   // this->values[MEMORY_METER_AVAILABLE] = "available memory"
 }
 
 void Platform_setSwapValues(Meter* this) {


### PR DESCRIPTION
While browsing the code, I often had to look into a few places before being able to understand what the index was referring to. With this change, it's now directly obvious.

If this PR looks interesting to you, I also plan to send another one for SWAP values as well.