### PR TITLE
Disable delayacct columns in I/O tab when unsupported

### DIFF
--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -95,7 +95,11 @@ const ScreenDefaults Platform_defaultScreens[] = {
    },
    {
       .name = "I/O",
-      .columns = "PID USER IO_PRIORITY IO_RATE IO_READ_RATE IO_WRITE_RATE PERCENT_SWAP_DELAY PERCENT_IO_DELAY Command",
+      .columns = "PID USER IO_PRIORITY IO_RATE IO_READ_RATE IO_WRITE_RATE"
+#ifdef HAVE_DELAYACCT
+         " PERCENT_SWAP_DELAY PERCENT_IO_DELAY"
+#endif
+         " Command",
       .sortKey = "IO_RATE",
    },
 };


### PR DESCRIPTION
Unsupported columns cause every column to their right to be missing. This results in a missing Command column in the default configuration, with no way to add it back short of creating a new tab.

See: https://github.com/NixOS/nixpkgs/pull/212134