### PR TITLE
Temperature reporting fix for AMD Zen CPUs

### DIFF
--- a/linux/LibSensors.c
+++ b/linux/LibSensors.c
@@ -249,6 +249,7 @@ void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, uns
       unsigned int count = 0;
       unsigned int coresInDie = existingCPUs / coreTempCount;
 
+      // Find package temps
       for (unsigned int i = 1; i <= existingCPUs; i++) {
          if (!isnan(data[i])) {
             temp[count] = data[i];
@@ -259,10 +260,11 @@ void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, uns
          }
       }
 
+      // Set Temperature
+      data[0] = temp[0];
       for (unsigned int die = 0; die < coreTempCount; die++) {
-         for (unsigned int i = 0; i <= coresInDie; i++) {
+         for (unsigned int i = 1; i <= coresInDie; i++) {
             data[(die*coresInDie)+i] = temp[die];
-            printf("data index: %d, die: %d\n", (die*coresInDie)+i, die);
          }
       }
 

--- a/linux/LibSensors.c
+++ b/linux/LibSensors.c
@@ -245,12 +245,13 @@ void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, uns
 
    /* Check AMD Zen CPUs packages, and mirror temps across packages */
    if (coreTempCount != existingCPUs) {
-      int coresInDie = existingCPUs / coreTempCount;
-      double temps[coreTempCount];
+      double temp[coreTempCount];
       unsigned int count = 0;
+      unsigned int coresInDie = existingCPUs / coreTempCount;
+
       for (unsigned int i = 1; i <= existingCPUs; i++) {
          if (!isnan(data[i])) {
-            temps[count] = data[i];
+            temp[count] = data[i];
             count++;
             if (count == coreTempCount) {
                break;
@@ -259,8 +260,9 @@ void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, uns
       }
 
       for (unsigned int die = 0; die < coreTempCount; die++) {
-         for (int i = 0; i <= coresInDie; i++) {
-            data[(die*coresInDie)+i] = temps[die];
+         for (unsigned int i = 0; i <= coresInDie; i++) {
+            data[(die*coresInDie)+i] = temp[die];
+            printf("data index: %d, die: %d\n", (die*coresInDie)+i);
          }
       }
 

--- a/linux/LibSensors.c
+++ b/linux/LibSensors.c
@@ -262,7 +262,7 @@ void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, uns
       for (unsigned int die = 0; die < coreTempCount; die++) {
          for (unsigned int i = 0; i <= coresInDie; i++) {
             data[(die*coresInDie)+i] = temp[die];
-            printf("data index: %d, die: %d\n", (die*coresInDie)+i);
+            printf("data index: %d, die: %d\n", (die*coresInDie)+i, die);
          }
       }
 

--- a/linux/LibSensors.c
+++ b/linux/LibSensors.c
@@ -243,13 +243,12 @@ void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, uns
       /* Check for further adjustments */
    }
 
-
    /* Check AMD Zen CPUs packages, and mirror temps across packages */
    if (coreTempCount != existingCPUs) {
       int coresInDie = existingCPUs / coreTempCount;
       double temps[coreTempCount];
       unsigned int count = 0;
-      for (unsigned int i = 0; i <= existingCPUs; i++) {
+      for (unsigned int i = 1; i <= existingCPUs; i++) {
          if (!isnan(data[i])) {
             temps[count] = data[i];
             count++;

--- a/linux/LibSensors.c
+++ b/linux/LibSensors.c
@@ -258,7 +258,8 @@ void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, uns
       unsigned int count = 0;
       unsigned int coresInDie = existingCPUs / coreTempCount;
 
-      // Find package temps
+      /* Find package temps */
+      temp[0] = NAN;
       for (unsigned int i = 1; i <= existingCPUs; i++) {
          if (!isnan(data[i])) {
             temp[count] = data[i];
@@ -282,7 +283,19 @@ void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, uns
          /* No further adjustments */
          goto out;
       }
+      /* AMD Zen CPU can report coreTempCount as 1 - returns if temps are not reported as expected */
    }
+
+   /* Fallback for single temperature count reporting */
+   if (coreTempCount == 1 && !isnan(data[0])) {
+      for (unsigned int i = 1; i <= existingCPUs; i++) {
+         data[i] = data[0];
+      }
+
+      /* No further adjustments */
+      goto out;
+   }
+
 
 out:
    for (unsigned int i = 0; i <= existingCPUs; i++)

--- a/linux/LibSensors.c
+++ b/linux/LibSensors.c
@@ -244,9 +244,9 @@ void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, uns
    }
 
    /* Only temperature for core 0, maybe Ryzen - copy to all other cores */
-   if (coreTempCount == 1 && !isnan(data[1])) {
-      for (unsigned int i = 2; i <= existingCPUs; i++)
-         data[i] = data[1];
+   if (coreTempCount == 1 && !isnan(data[0])) {
+      for (unsigned int i = 1; i <= existingCPUs; i++)
+         data[i] = data[0];
 
       /* No further adjustments */
       goto out;


### PR DESCRIPTION
Reports Package temperature across CPU dies for
AMD Zen CPU's. Temperature is now selected by
package die Tccd[X] for  for temperature reporting
and ignores the Tctl reporting.

Tested and Validated with:
Ryzen 3600 on Artix Linux
Ryzen Threadripper 3970x on Arch Linux