### PR TITLE
Ignore NaN values when drawing graphs

### DIFF
--- a/Meter.c
+++ b/Meter.c
@@ -325,7 +325,7 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
 
       double value = 0.0;
       for (uint8_t i = 0; i < this->curItems; i++)
-         value += this->values[i];
+         value += !isnan(this->values[i]) ? this->values[i] : 0;
       data->values[nValues - 1] = value;
    }
 


### PR DESCRIPTION
Fixes #1040.

The issue was that shared memory is not supported in FreeBSD and thus its value was NaN, When drawing a graph it's adding all the values together and that makes `values` also NaN. I added a check to see if a value is NaN or not when adding it.
This issue must've affected all platforms that don't support shared memory but I did not find any other related issues.