### PR TITLE
Implement shared memory for FreeBSD

### DIFF
--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -84,9 +84,7 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* dynamicMeters, H
    len = 4; sysctlnametomib("vm.stats.vm.v_cache_count", MIB_vm_stats_vm_v_cache_count, &len);
    len = 4; sysctlnametomib("vm.stats.vm.v_inactive_count", MIB_vm_stats_vm_v_inactive_count, &len);
    len = 4; sysctlnametomib("vm.stats.vm.v_free_count", MIB_vm_stats_vm_v_free_count, &len);
-   MIB_vm_vmtotal[0] = CTL_VM;
-   MIB_vm_vmtotal[1] = VM_TOTAL;
-
+   len = 2; sysctlnametomib("vm.vmtotal", MIB_vm_vmtotal, &len);
 
    len = 2; sysctlnametomib("vfs.bufspace", MIB_vfs_bufspace, &len);
 

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -232,7 +232,7 @@ void Platform_setMemoryValues(Meter* this) {
    this->total = pl->totalMem;
    this->values[MEMORY_METER_USED] = pl->usedMem;
    this->values[MEMORY_METER_BUFFERS] = pl->buffersMem;
-   // this->values[MEMORY_METER_SHARED] = "shared memory, like tmpfs and shm"
+   this->values[MEMORY_METER_SHARED] = pl->sharedMem;
    this->values[MEMORY_METER_CACHE] = pl->cachedMem;
    // this->values[MEMORY_METER_AVAILABLE] = "available memory"
 


### PR DESCRIPTION
Also fixes #1040.

This pull request adds shared memory support for FreeBSD as in https://github.com/htop-dev/htop/pull/1178#issuecomment-1416699092. I'm still not sure if we should add it to total used memory or not. 

Tested in `FreeBSD 13.1-RELEASE` and output seems constant with the output from `sysctl vm.vmtotal`.