### PR TITLE
Annotate functions with access attribute

### DIFF
--- a/Macros.h
+++ b/Macros.h
@@ -61,6 +61,27 @@
 
 #endif /* HAVE_ATTR_ALLOC_SIZE */
 
+#ifdef HAVE_ATTR_ACCESS
+
+#define ATTR_ACCESS2(mode, ref)         __attribute__((access (mode, ref)))
+#define ATTR_ACCESS3(mode, ref, size)   __attribute__((access (mode, ref, size)))
+
+#else
+
+#define ATTR_ACCESS2(mode, ref)
+#define ATTR_ACCESS3(mode, ref, size)
+
+#endif /* HAVE_ATTR_ACCESS */
+
+#define ATTR_ACCESS2_R(ref)              ATTR_ACCESS2(read_only, ref)
+#define ATTR_ACCESS3_R(ref, size)        ATTR_ACCESS3(read_only, ref, size)
+
+#define ATTR_ACCESS2_RW(ref)             ATTR_ACCESS2(read_write, ref)
+#define ATTR_ACCESS3_RW(ref, size)       ATTR_ACCESS3(read_write, ref, size)
+
+#define ATTR_ACCESS2_W(ref)              ATTR_ACCESS2(write_only, ref)
+#define ATTR_ACCESS3_W(ref, size)        ATTR_ACCESS3(write_only, ref, size)
+
 // ignore casts discarding const specifier, e.g.
 //     const char []     ->  char * / void *
 //     const char *[2]'  ->  char *const *

--- a/XUtils.c
+++ b/XUtils.c
@@ -265,6 +265,7 @@ char* xStrndup(const char* str, size_t len) {
    return data;
 }
 
+ATTR_ACCESS3_W(2, 3)
 static ssize_t readfd_internal(int fd, void* buffer, size_t count) {
    if (!count) {
       close(fd);

--- a/XUtils.h
+++ b/XUtils.h
@@ -57,22 +57,29 @@ void String_freeArray(char** s);
 char* String_readLine(FILE* fd) ATTR_MALLOC;
 
 /* Always null-terminates dest. Caller must pass a strictly positive size. */
+ATTR_ACCESS3_W(1, 3)
+ATTR_ACCESS3_R(2, 3)
 size_t String_safeStrncpy(char* restrict dest, const char* restrict src, size_t size);
 
 ATTR_FORMAT(printf, 2, 3)
 int xAsprintf(char** strp, const char* fmt, ...);
 
 ATTR_FORMAT(printf, 3, 4)
+ATTR_ACCESS3_W(1, 2)
 int xSnprintf(char* buf, size_t len, const char* fmt, ...);
 
 char* xStrdup(const char* str) ATTR_NONNULL ATTR_MALLOC;
 void free_and_xStrdup(char** ptr, const char* str);
 
+ATTR_ACCESS3_R(1, 2)
 char* xStrndup(const char* str, size_t len) ATTR_NONNULL ATTR_MALLOC;
 
+ATTR_ACCESS3_W(2, 3)
 ssize_t xReadfile(const char* pathname, void* buffer, size_t count);
+ATTR_ACCESS3_W(3, 4)
 ssize_t xReadfileat(openat_arg_t dirfd, const char* pathname, void* buffer, size_t count);
 
+ATTR_ACCESS3_R(2, 3)
 ssize_t full_write(int fd, const void* buf, size_t count);
 
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -188,6 +188,20 @@ AC_COMPILE_IFELSE([
    AC_MSG_RESULT(no))
 CFLAGS="$old_CFLAGS"
 
+AC_MSG_CHECKING(for access)
+old_CFLAGS="$CFLAGS"
+CFLAGS="$CFLAGS -Wno-error -Werror=attributes"
+AC_COMPILE_IFELSE([
+   AC_LANG_SOURCE(
+      [
+         __attribute__((access(read_only, 1, 2))) extern int foo(const char* str, unsigned len);
+      ],[]
+   )],
+   AC_DEFINE([HAVE_ATTR_ACCESS], 1, [The access attribute is supported.])
+   AC_MSG_RESULT(yes),
+   AC_MSG_RESULT(no))
+CFLAGS="$old_CFLAGS"
+
 AC_MSG_CHECKING(for NaN support)
 AC_RUN_IFELSE([
    AC_LANG_PROGRAM(


### PR DESCRIPTION
Supported by GCC since version 10.