### PR TITLE
Misc cleanup

### DIFF
--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -153,7 +153,7 @@ static void checkRecalculation(ScreenManager* this, double* oldTime, int* sortTi
    *rescan = false;
 }
 
-static inline bool drawTab(int* y, int* x, int l, const char* name, bool cur) {
+static inline bool drawTab(const int* y, int* x, int l, const char* name, bool cur) {
    attrset(CRT_colors[cur ? SCREENS_CUR_BORDER : SCREENS_OTH_BORDER]);
    mvaddch(*y, *x, '[');
    (*x)++;

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -64,7 +64,6 @@ in the source distribution for its full text.
 #include "zfs/ZfsCompressedArcMeter.h"
 
 #ifdef HAVE_LIBCAP
-#include <errno.h>
 #include <sys/capability.h>
 #endif
 
@@ -474,7 +473,7 @@ FileLocks_ProcessData* Platform_getProcessLocks(pid_t pid) {
          if (!strchr(buffer, '\n'))
             continue;
 
-         if (strncmp(buffer, "lock:\t", strlen("lock:\t")))
+         if (!String_startsWith(buffer, "lock:\t"))
             continue;
 
          FileLocks_Data data = {.fd = file};


### PR DESCRIPTION
* declare read-only pointer parameter const
* drop duplicate include of <errno.h>
* use String_startsWith