### PR TITLE
Linux: add IRQ PSI meter

### DIFF
--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -240,6 +240,7 @@ const MeterClass* const Platform_meterTypes[] = {
    &PressureStallCPUSomeMeter_class,
    &PressureStallIOSomeMeter_class,
    &PressureStallIOFullMeter_class,
+   &PressureStallIRQFullMeter_class,
    &PressureStallMemorySomeMeter_class,
    &PressureStallMemoryFullMeter_class,
    &ZfsArcMeter_class,

--- a/linux/PressureStallMeter.c
+++ b/linux/PressureStallMeter.c
@@ -31,6 +31,8 @@ static void PressureStallMeter_updateValues(Meter* this) {
       file = "cpu";
    } else if (strstr(Meter_name(this), "IO")) {
       file = "io";
+   } else if (strstr(Meter_name(this), "IRQ")) {
+      file = "irq";
    } else {
       file = "memory";
    }
@@ -112,6 +114,23 @@ const MeterClass PressureStallIOFullMeter_class = {
    .uiName = "PSI full IO",
    .caption = "PSI full IO:     ",
    .description = "Pressure Stall Information, full io"
+};
+
+const MeterClass PressureStallIRQFullMeter_class = {
+   .super = {
+      .extends = Class(Meter),
+      .delete = Meter_delete,
+      .display = PressureStallMeter_display,
+   },
+   .updateValues = PressureStallMeter_updateValues,
+   .defaultMode = TEXT_METERMODE,
+   .maxItems = 3,
+   .total = 100.0,
+   .attributes = PressureStallMeter_attributes,
+   .name = "PressureStallIRQFull",
+   .uiName = "PSI full IRQ",
+   .caption = "PSI full IRQ:    ",
+   .description = "Pressure Stall Information, full irq"
 };
 
 const MeterClass PressureStallMemorySomeMeter_class = {

--- a/linux/PressureStallMeter.h
+++ b/linux/PressureStallMeter.h
@@ -19,6 +19,8 @@ extern const MeterClass PressureStallIOSomeMeter_class;
 
 extern const MeterClass PressureStallIOFullMeter_class;
 
+extern const MeterClass PressureStallIRQFullMeter_class;
+
 extern const MeterClass PressureStallMemorySomeMeter_class;
 
 extern const MeterClass PressureStallMemoryFullMeter_class;


### PR DESCRIPTION
The linux kernel recently gained a new PSI meter, namely a new `/proc/pressure/irq` meter has been added [1]:
```
full avg10=0.00 avg60=0.00 avg300=0.00 total=100648410
```

This commit adds support for this PSI meter by adding a `PressureStallIRQFullMeter_class`.

[1] https://github.com/torvalds/linux/commit/52b1364ba0b105122d6de0e719b36db705011ac1