### PR TITLE
Update fdstat_sysctl.c

### DIFF
--- a/generic/fdstat_sysctl.c
+++ b/generic/fdstat_sysctl.c
@@ -11,8 +11,8 @@ in the source distribution for its full text.
 #include <stddef.h>
 #include <stdint.h>
 
+#include <sys/types.h> // Shitty FreeBSD upstream headers
 #include <sys/sysctl.h>
-#include <sys/types.h>
 
 #include "config.h"
 


### PR DESCRIPTION
It's always a good idea to include sys/types.h before any other sys headers, at least on FreeBSD.