### PR TITLE
Remove LXC special handling for the CPU count

### DIFF
--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -210,28 +210,6 @@ static void LinuxProcessList_initNetlinkSocket(LinuxProcessList* this) {
 
 #endif
 
-static unsigned int scanAvailableCPUsFromCPUinfo(LinuxProcessList* this) {
-   FILE* file = fopen(PROCCPUINFOFILE, "r");
-   if (file == NULL)
-      return this->super.existingCPUs;
-
-   unsigned int availableCPUs = 0;
-
-   while (!feof(file)) {
-      char buffer[PROC_LINE_LENGTH];
-
-      if (fgets(buffer, PROC_LINE_LENGTH, file) == NULL)
-         break;
-
-      if (String_startsWith(buffer, "processor"))
-         availableCPUs++;
-   }
-
-   fclose(file);
-
-   return availableCPUs ? availableCPUs : 1;
-}
-
 static void LinuxProcessList_updateCPUcount(ProcessList* super) {
    /* Similar to get_nprocs_conf(3) / _SC_NPROCESSORS_CONF
     * https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/getsysstats.c;hb=HEAD
@@ -306,12 +284,6 @@ static void LinuxProcessList_updateCPUcount(ProcessList* super) {
    if (existing < 1)
       return;
 
-   if (Running_containerized) {
-      /* LXC munges /proc/cpuinfo but not the /sys/devices/system/cpu/ files,
-       * so limit the visible CPUs to what the guest has been configured to see: */
-      currExisting = active = scanAvailableCPUsFromCPUinfo(this);
-   }
-
 #ifdef HAVE_SENSORS_SENSORS_H
    /* When started with offline CPUs, libsensors does not monitor those,
     * even when they become online. */
@@ -320,7 +292,7 @@ static void LinuxProcessList_updateCPUcount(ProcessList* super) {
 #endif
 
    super->activeCPUs = active;
-   assert(Running_containerized || (existing == currExisting));
+   assert(existing == currExisting);
    super->existingCPUs = currExisting;
 }
 


### PR DESCRIPTION
LXC shows the real host CPU ids but can be limited in configuration as to which cores are used. Still the sysfs files are visible and the CPUs (stay) marked online. We will need to parse
/sys/devices/system/cpu/online to follow LXC's logic. Revert for now until we can come up with a better handling of the LXC hacks.

Cf. issue #1195
Essentially reverting 33973f7e and 0d53245c (#993, #995)