### PR TITLE
Linux: `/proc/<pid>/status` refactor no2

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -736,7 +736,7 @@ void Process_writeField(const Process* this, RichString* str, RowField field) {
       }
       break;
    case USER:
-      if (this->elevated_priv)
+      if (this->elevated_priv == TRI_ON)
          attr = CRT_colors[PROCESS_PRIV];
       else if (host->htopUserId != this->st_uid)
          attr = CRT_colors[PROCESS_SHADOW];

--- a/Process.h
+++ b/Process.h
@@ -24,6 +24,13 @@ in the source distribution for its full text.
 
 #define DEFAULT_HIGHLIGHT_SECS 5
 
+typedef enum Tristate_ {
+   TRI_INITIAL = 0,
+   TRI_OFF = -1,
+   TRI_ON = 1,
+} Tristate;
+
+
 /* Core process states (shared by platforms)
  * NOTE: The enum has an ordering that is important!
  * See processStateChar in process.c for ProcessSate -> letter mapping */
@@ -106,7 +113,7 @@ typedef struct Process_ {
     *   - from file capabilities
     *   - inherited from the ambient set
     */
-   bool elevated_priv;
+   Tristate elevated_priv;
 
    /* Process runtime (in hundredth of a second) */
    unsigned long long int time;

--- a/Process.h
+++ b/Process.h
@@ -94,7 +94,7 @@ typedef struct Process_ {
    bool isUserlandThread;
 
    /* This process is running inside a container */
-   bool isRunningInContainer;
+   Tristate isRunningInContainer;
 
    /* Controlling terminal identifier of the process */
    unsigned long int tty_nr;

--- a/Scheduling.c
+++ b/Scheduling.c
@@ -156,6 +156,9 @@ const char* Scheduling_formatPolicy(int policy) {
    }
 }
 
+/*
+ * Gather scheduling policy (thread-specific data)
+ */
 void Scheduling_readProcessPolicy(Process* proc) {
    proc->scheduling_policy = sched_getscheduler(Process_getPid(proc));
 }

--- a/linux/LibNl.c
+++ b/linux/LibNl.c
@@ -193,6 +193,9 @@ static int handleNetlinkMsg(struct nl_msg* nlmsg, void* linuxProcess) {
    return NL_OK;
 }
 
+/*
+ * Gather delay-accounting information (thread-specific data)
+ */
 void LibNl_readDelayAcctData(LinuxProcessTable* this, LinuxProcess* process) {
    struct nl_msg* msg;
 

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -154,6 +154,9 @@ static int LinuxProcess_effectiveIOPriority(const LinuxProcess* this) {
 #define SYS_ioprio_set __NR_ioprio_set
 #endif
 
+/*
+ * Gather I/O scheduling class and priority (thread-specific data)
+ */
 IOPriority LinuxProcess_updateIOPriority(Process* p) {
    IOPriority ioprio = 0;
 // Other OSes masquerading as Linux (NetBSD?) don't have this syscall

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -106,6 +106,7 @@ const ProcessFieldData Process_fields[LAST_PROCESSFIELD] = {
    [CWD] = { .name = "CWD", .title = "CWD                       ", .description = "The current working directory of the process", .flags = PROCESS_FLAG_CWD, },
    [AUTOGROUP_ID] = { .name = "AUTOGROUP_ID", .title = "AGRP", .description = "The autogroup identifier of the process", .flags = PROCESS_FLAG_LINUX_AUTOGROUP, },
    [AUTOGROUP_NICE] = { .name = "AUTOGROUP_NICE", .title = " ANI", .description = "Nice value (the higher the value, the more other processes take priority) associated with the process autogroup", .flags = PROCESS_FLAG_LINUX_AUTOGROUP, },
+   [ISCONTAINER] = { .name = "ISCONTAINER", .title = "CONT ", .description = "Whether the process is running inside a child container", .flags = PROCESS_FLAG_LINUX_CONTAINER, },
 #ifdef SCHEDULER_SUPPORT
    [SCHEDULERPOLICY] = { .name = "SCHEDULERPOLICY", .title = "SCHED ", .description = "Current scheduling policy of the process", .flags = PROCESS_FLAG_SCHEDPOL, },
 #endif
@@ -336,6 +337,19 @@ static void LinuxProcess_rowWriteField(const Row* super, RichString* str, Proces
          xSnprintf(buffer, n, "N/A ");
       }
       break;
+   case ISCONTAINER:
+      switch (this->isRunningInContainer) {
+      case TRI_ON:
+         xSnprintf(buffer, n, "YES  ");
+         break;
+      case TRI_OFF:
+         xSnprintf(buffer, n, "NO   ");
+         break;
+      default:
+         attr = CRT_colors[PROCESS_SHADOW];
+         xSnprintf(buffer, n, "N/A  ");
+      }
+      break;
    default:
       Process_writeField(this, str, field);
       return;
@@ -438,6 +452,8 @@ static int LinuxProcess_compareByKey(const Process* v1, const Process* v2, Proce
    }
    case GPU_TIME:
       return SPACESHIP_NUMBER(p1->gpu_time, p2->gpu_time);
+   case ISCONTAINER:
+      return SPACESHIP_NUMBER(v1->isRunningInContainer, v2->isRunningInContainer);
    default:
       return Process_compareByKey_Base(v1, v2, key);
    }

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -30,6 +30,7 @@ in the source distribution for its full text.
 #define PROCESS_FLAG_LINUX_DELAYACCT 0x00040000
 #define PROCESS_FLAG_LINUX_AUTOGROUP 0x00080000
 #define PROCESS_FLAG_LINUX_GPU       0x00100000
+#define PROCESS_FLAG_LINUX_CONTAINER 0x00200000
 
 typedef struct LinuxProcess_ {
    Process super;

--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -1590,7 +1590,7 @@ static bool LinuxProcessTable_recurseProcTree(LinuxProcessTable* this, openat_ar
       }
 
       if (ss->flags & PROCESS_FLAG_LINUX_CTXT
-         || (hideRunningInContainer && proc->isRunningInContainer == TRI_INITIAL)
+         || ((hideRunningInContainer || ss->flags & PROCESS_FLAG_LINUX_CONTAINER) && proc->isRunningInContainer == TRI_INITIAL)
 #ifdef HAVE_VSERVER
          || ss->flags & PROCESS_FLAG_LINUX_VSERVER
 #endif

--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -1525,8 +1525,15 @@ static bool LinuxProcessTable_recurseProcTree(LinuxProcessTable* this, openat_ar
       if (!LinuxProcessTable_updateUser(host, proc, procFd, mainTask))
          goto errorReadingProcess;
 
-      if (!LinuxProcessTable_readStatusFile(proc, procFd))
-         goto errorReadingProcess;
+      if (ss->flags & PROCESS_FLAG_LINUX_CTXT
+          || hideRunningInContainer
+#ifdef HAVE_VSERVER
+          || ss->flags & PROCESS_FLAG_LINUX_VSERVER
+#endif
+         ) {
+         if (!LinuxProcessTable_readStatusFile(proc, procFd))
+            goto errorReadingProcess;
+      }
 
       if (!preExisting) {
 

--- a/linux/ProcessField.h
+++ b/linux/ProcessField.h
@@ -50,6 +50,7 @@ in the source distribution for its full text.
    M_PRIV = 131,                 \
    GPU_TIME = 132,               \
    GPU_PERCENT = 133,            \
+   ISCONTAINER = 134,            \
    // End of list
 
 


### PR DESCRIPTION
#1211 showed reading `/proc/<pid>/status` might have a significant
performance impact.  Do not read by default only if actually needed,
since the permitted capabilities are no longer gather from it.

Improves: https://github.com/htop-dev/htop/commit/8ea144df7494bad0c46d3bf4f16c9a6556c500d2 ("Linux: Refactor /proc/<pid>/status parsing")
Improves: https://github.com/htop-dev/htop/issues/1211