### PR TITLE
Machine class fixes (Darwin, *BSD)

### DIFF
--- a/darwin/DarwinMachine.c
+++ b/darwin/DarwinMachine.c
@@ -101,12 +101,12 @@ Machine* Machine_new(UsersTable* usersTable, uid_t userId) {
 }
 
 void Machine_delete(Machine* super) {
-   DarwinMachine* host = (DarwinMachine*) super;
+   DarwinMachine* this = (DarwinMachine*) super;
 
-   DarwinMachine_freeCPULoadInfo(&host->prev_load);
+   DarwinMachine_freeCPULoadInfo(&this->prev_load);
 
    Machine_done(super);
-   free(super);
+   free(this);
 }
 
 bool Machine_isCPUonline(const Machine* host, unsigned int id) {

--- a/dragonflybsd/DragonFlyBSDMachine.c
+++ b/dragonflybsd/DragonFlyBSDMachine.c
@@ -45,7 +45,7 @@ Machine* Machine_new(UsersTable* usersTable, uid_t userId) {
    DragonFlyBSDMachine* this = xCalloc(1, sizeof(DragonFlyBSDMachine));
    Machine* super = &this->super;
 
-   Machine_init(this, usersTable, userId);
+   Machine_init(super, usersTable, userId);
 
    // physical memory in system: hw.physmem
    // physical page size: hw.pagesize
@@ -119,9 +119,9 @@ Machine* Machine_new(UsersTable* usersTable, uid_t userId) {
 }
 
 void Machine_delete(Machine* super) {
-   const DragonFlyBSDMachine* this = (DragonFlyBSDProcessList*) super;
+   const DragonFlyBSDMachine* this = (const DragonFlyBSDMachine*) super;
 
-   Machine_done(this);
+   Machine_done(super);
 
    if (this->kd) {
       kvm_close(this->kd);

--- a/freebsd/FreeBSDMachine.c
+++ b/freebsd/FreeBSDMachine.c
@@ -59,7 +59,7 @@ Machine* Machine_new(UsersTable* usersTable, uid_t userId) {
    char errbuf[_POSIX2_LINE_MAX];
    size_t len;
 
-   Machine_init(this, usersTable, userId);
+   Machine_init(super, usersTable, userId);
 
    // physical memory in system: hw.physmem
    // physical page size: hw.pagesize
@@ -146,13 +146,13 @@ Machine* Machine_new(UsersTable* usersTable, uid_t userId) {
       CRT_fatalError("kvm_openfiles() failed");
    }
 
-   return this;
+   return super;
 }
 
 void Machine_delete(Machine* super) {
    FreeBSDMachine* this = (FreeBSDMachine*) super;
 
-   ProcessList_done(this);
+   Machine_done(super);
 
    if (this->kd) {
       kvm_close(this->kd);

--- a/freebsd/FreeBSDMachine.h
+++ b/freebsd/FreeBSDMachine.h
@@ -28,7 +28,7 @@ typedef struct CPUData_ {
    double temperature;
 } CPUData;
 
-typedef struct FreeBSDProcessList_ {
+typedef struct FreeBSDMachine_ {
    Machine super;
    kvm_t* kd;
 
@@ -49,6 +49,6 @@ typedef struct FreeBSDProcessList_ {
    unsigned long* cp_times_o;
    unsigned long* cp_times_n;
 
-} FreeBSDProcessList;
+} FreeBSDMachine;
 
 #endif

--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -29,7 +29,6 @@ in the source distribution for its full text.
 
 #include "CRT.h"
 #include "Compat.h"
-#include "FreeBSDProcess.h"
 #include "Macros.h"
 #include "Object.h"
 #include "Process.h"
@@ -38,6 +37,9 @@ in the source distribution for its full text.
 #include "Settings.h"
 #include "XUtils.h"
 
+#include "freebsd/FreeBSDMachine.h"
+#include "freebsd/FreeBSDProcess.h"
+
 
 ProcessList* ProcessList_new(Machine* host, Hashtable* pidMatchList) {
    FreeBSDProcessList* this = xCalloc(1, sizeof(FreeBSDProcessList));
@@ -45,7 +47,7 @@ ProcessList* ProcessList_new(Machine* host, Hashtable* pidMatchList) {
 
    ProcessList_init(super, Class(FreeBSDProcess), host, pidMatchList);
 
-   return this;
+   return super;
 }
 
 void ProcessList_delete(ProcessList* super) {
@@ -156,14 +158,13 @@ IGNORE_WCASTQUAL_END
 
 void ProcessList_goThroughEntries(ProcessList* super) {
    const Machine* host = super->host;
-   const FreeBSDMachine* fhost = (FreeBSDMachine*) host;
-   FreeBSDProcessList* fpl = (FreeBSDProcessList*) super;
+   const FreeBSDMachine* fhost = (const FreeBSDMachine*) host;
    const Settings* settings = host->settings;
    bool hideKernelThreads = settings->hideKernelThreads;
    bool hideUserlandThreads = settings->hideUserlandThreads;
 
    int count = 0;
-   const struct kinfo_proc* kprocs = kvm_getprocs(fpl->kd, KERN_PROC_PROC, 0, &count);
+   const struct kinfo_proc* kprocs = kvm_getprocs(fhost->kd, KERN_PROC_PROC, 0, &count);
 
    for (int i = 0; i < count; i++) {
       const struct kinfo_proc* kproc = &kprocs[i];

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -209,7 +209,7 @@ double Platform_setCPUValues(Meter* this, unsigned int cpu) {
 
    v[CPU_METER_NICE]   = cpuData->nicePercent;
    v[CPU_METER_NORMAL] = cpuData->userPercent;
-   if (super->settings->detailedCPUTime) {
+   if (host->settings->detailedCPUTime) {
       v[CPU_METER_KERNEL]  = cpuData->systemPercent;
       v[CPU_METER_IRQ]     = cpuData->irqPercent;
       this->curItems = 4;
@@ -240,11 +240,11 @@ void Platform_setMemoryValues(Meter* this) {
    this->values[MEMORY_METER_CACHE] = host->cachedMem;
    // this->values[MEMORY_METER_AVAILABLE] = "available memory"
 
-   if (dhost->zfs.enabled) {
+   if (fhost->zfs.enabled) {
       // ZFS does not shrink below the value of zfs_arc_min.
       unsigned long long int shrinkableSize = 0;
-      if (dhost->zfs.size > dhost->zfs.min)
-         shrinkableSize = dhost->zfs.size - dhost->zfs.min;
+      if (fhost->zfs.size > fhost->zfs.min)
+         shrinkableSize = fhost->zfs.size - fhost->zfs.min;
       this->values[MEMORY_METER_USED] -= shrinkableSize;
       this->values[MEMORY_METER_CACHE] += shrinkableSize;
       // this->values[MEMORY_METER_AVAILABLE] += shrinkableSize;

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -195,14 +195,9 @@ double Platform_setCPUValues(Meter* this, unsigned int cpu) {
    const Machine* host = this->host;
    const FreeBSDMachine* fhost = (const FreeBSDMachine*) host;
    unsigned int cpus = host->activeCPUs;
-   const CPUData* cpuData;
 
-   if (cpus == 1) {
-      // single CPU box has everything in fhost->cpus[0]
-      cpuData = &(fhost->cpus[0]);
-   } else {
-      cpuData = &(fhost->cpus[cpu]);
-   }
+   // single CPU box has everything in fhost->cpus[0]
+   const CPUData* cpuData = cpus == 1 ? &fhost->cpus[0] : &fhost->cpus[cpu];
 
    double  percent;
    double* v = this->values;

--- a/netbsd/NetBSDMachine.h
+++ b/netbsd/NetBSDMachine.h
@@ -40,8 +40,8 @@ typedef struct CPUData_ {
    double frequency;
 } CPUData;
 
-typedef struct NetBSDProcessList_ {
-   ProcessList super;
+typedef struct NetBSDMachine_ {
+   Machine super;
    kvm_t* kd;
 
    long fscale;
@@ -49,6 +49,6 @@ typedef struct NetBSDProcessList_ {
    int pageSizeKB;
 
    CPUData* cpuData;
-} NetBSDProcessList;
+} NetBSDMachine;
 
 #endif

--- a/openbsd/OpenBSDProcessList.c
+++ b/openbsd/OpenBSDProcessList.c
@@ -153,7 +153,7 @@ static void OpenBSDProcessList_scanProcs(OpenBSDProcessList* this) {
 
       bool preExisting = false;
       Process* proc = ProcessList_getProcess(&this->super, (kproc->p_tid == -1) ? kproc->p_pid : kproc->p_tid, &preExisting, OpenBSDProcess_new);
-      OpenBSDProcess* fp = (OpenBSDProcess*) proc;
+      OpenBSDProcess* op = (OpenBSDProcess*) proc;
 
       if (!preExisting) {
          proc->ppid = kproc->p_ppid;
@@ -187,7 +187,7 @@ static void OpenBSDProcessList_scanProcs(OpenBSDProcessList* this) {
          }
       }
 
-      fp->addr = kproc->p_addr;
+      op->addr = kproc->p_addr;
       proc->m_virt = kproc->p_vm_dsize * ohost->pageSizeKB;
       proc->m_resident = kproc->p_vm_rssize * ohost->pageSizeKB;
 


### PR DESCRIPTION
A series of changes to get rid of errors and warnings for FreeBSD and NetBSD, introduced by the new Machine class.