### PR TITLE
Linux/LibSensors: adjust data for k10temp

### DIFF
--- a/linux/LibSensors.c
+++ b/linux/LibSensors.c
@@ -153,7 +153,7 @@ void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, uns
    assert(existingCPUs > 0 && existingCPUs < 16384);
 
    double* data = xMallocArray(existingCPUs + 1, sizeof(double));
-   for (size_t i = 0; i < existingCPUs + 1; i++)
+   for (size_t i = 0; i <= existingCPUs; i++)
       data[i] = NAN;
 
 #ifndef BUILD_STATIC

--- a/linux/LibSensors.c
+++ b/linux/LibSensors.c
@@ -29,12 +29,12 @@ in the source distribution for its full text.
 
 #ifdef BUILD_STATIC
 
-#define sym_sensors_init sensors_init
-#define sym_sensors_cleanup sensors_cleanup
+#define sym_sensors_init               sensors_init
+#define sym_sensors_cleanup            sensors_cleanup
 #define sym_sensors_get_detected_chips sensors_get_detected_chips
-#define sym_sensors_get_features sensors_get_features
-#define sym_sensors_get_subfeature sensors_get_subfeature
-#define sym_sensors_get_value sensors_get_value
+#define sym_sensors_get_features       sensors_get_features
+#define sym_sensors_get_subfeature     sensors_get_subfeature
+#define sym_sensors_get_value          sensors_get_value
 
 #else
 

--- a/linux/LibSensors.c
+++ b/linux/LibSensors.c
@@ -152,7 +152,7 @@ static int tempDriverPriority(const sensors_chip_name* chip) {
 void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, unsigned int activeCPUs) {
    assert(existingCPUs > 0 && existingCPUs < 16384);
 
-   double* data = xMallocArray(existingCPUs + 1, sizeof(double));
+   float* data = xMallocArray(existingCPUs + 1, sizeof(float));
    for (size_t i = 0; i <= existingCPUs; i++)
       data[i] = NAN;
 
@@ -239,7 +239,7 @@ void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, uns
 
    /* No package temperature - set to max core temperature */
    if (coreTempCount > 0 && isNaN(data[0])) {
-      double maxTemp = -HUGE_VAL;
+      float maxTemp = -HUGE_VALF;
       for (size_t i = 1; i <= existingCPUs; i++) {
          if (isgreater(data[i], maxTemp)) {
             maxTemp = data[i];

--- a/linux/LibSensors.h
+++ b/linux/LibSensors.h
@@ -14,6 +14,6 @@ int LibSensors_init(void);
 void LibSensors_cleanup(void);
 int LibSensors_reload(void);
 
-void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, unsigned int activeCPUs);
+void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, unsigned int activeCPUs, unsigned short maxCoreId);
 
 #endif /* HEADER_LibSensors */

--- a/linux/LinuxMachine.c
+++ b/linux/LinuxMachine.c
@@ -657,7 +657,7 @@ void Machine_scan(Machine* super) {
 
    #ifdef HAVE_SENSORS_SENSORS_H
    if (settings->showCPUTemperature)
-      LibSensors_getCPUTemperatures(this->cpuData, super->existingCPUs, super->activeCPUs);
+      LibSensors_getCPUTemperatures(this->cpuData, super->existingCPUs, super->activeCPUs, this->maxCoreId);
    #endif
 }
 

--- a/linux/LinuxMachine.h
+++ b/linux/LinuxMachine.h
@@ -50,6 +50,7 @@ typedef struct CPUData_ {
    double temperature;
    #endif
 
+   unsigned short coreId;  /* Note: might be higer than core count, due to disabled ones */
    bool online;
 } CPUData;
 
@@ -73,6 +74,7 @@ typedef struct LinuxMachine_ {
    double period;
 
    CPUData* cpuData;
+   unsigned short maxCoreId;  /* Note: might be higer than core count, due to disabled ones */
 
    memory_t totalHugePageMem;
    memory_t usedHugePageMem[HTOP_HUGEPAGE_COUNT];


### PR DESCRIPTION
Adjust the temperature data gathered from the k10temp driver. 
Only a control value, an optional die value, and one value per CCD are provided.

See https://www.kernel.org/doc/html/latest/hwmon/k10temp.html for details.