### PR TITLE
Settings: preserve empty header

### DIFF
--- a/Settings.c
+++ b/Settings.c
@@ -588,15 +588,25 @@ static void writeList(FILE* fd, char** list, int len, char separator) {
 }
 
 static void writeMeters(const Settings* this, FILE* fd, char separator, unsigned int column) {
-   writeList(fd, this->hColumns[column].names, this->hColumns[column].len, separator);
+   if (this->hColumns[column].len) {
+      writeList(fd, this->hColumns[column].names, this->hColumns[column].len, separator);
+   } else {
+      fputc('!', fd);
+      fputc(separator, fd);
+   }
 }
 
 static void writeMeterModes(const Settings* this, FILE* fd, char separator, unsigned int column) {
-   const char* sep = "";
-   for (size_t i = 0; i < this->hColumns[column].len; i++) {
-      fprintf(fd, "%s%d", sep, this->hColumns[column].modes[i]);
-      sep = " ";
+   if (this->hColumns[column].len) {
+      const char* sep = "";
+      for (size_t i = 0; i < this->hColumns[column].len; i++) {
+         fprintf(fd, "%s%d", sep, this->hColumns[column].modes[i]);
+         sep = " ";
+      }
+   } else {
+      fputc('!', fd);
    }
+
    fputc(separator, fd);
 }
 


### PR DESCRIPTION
If the user removes all meters from the header on exit htop will write no values for the settings column_meters_X and column_meter_modes_X. The parser skips all configuration settings with no value, so on the next start no header meter related key is processed and htop will add a set of default meters to the header.

Write instead an invalid value of `!`, so the keys are parsed and htop will not add the default meters back.

Closes: #1248