### PR TITLE
Fix Linux running tasks count in the Tasks Meter, a recent regression

### DIFF
--- a/darwin/DarwinProcessList.c
+++ b/darwin/DarwinProcessList.c
@@ -86,12 +86,6 @@ void ProcessList_goThroughEntries(ProcessList* super) {
 
    const double time_interval_ns = Platform_schedulerTicksToNanoseconds(dpl->global_diff) / (double) host->activeCPUs;
 
-   /* Clear the thread counts */
-   super->kernelThreads = 0;
-   super->userlandThreads = 0;
-   super->totalTasks = 0;
-   super->runningTasks = 0;
-
    /* We use kinfo_procs for initial data since :
     *
     * 1) They always succeed.

--- a/linux/LinuxMachine.c
+++ b/linux/LinuxMachine.c
@@ -501,7 +501,7 @@ static void LinuxMachine_scanCPUTime(LinuxMachine* this) {
    char buffer[PROC_LINE_LENGTH + 1];
    while (fgets(buffer, sizeof(buffer), file)) {
       if (String_startsWith(buffer, "procs_running")) {
-         super->pl->runningTasks = strtoul(buffer + strlen("procs_running"), NULL, 10);
+         this->runningTasks = strtoul(buffer + strlen("procs_running"), NULL, 10);
          break;
       }
    }

--- a/linux/LinuxMachine.h
+++ b/linux/LinuxMachine.h
@@ -61,9 +61,12 @@ typedef struct LinuxMachine_ {
    Machine super;
 
    long jiffies;
-   long long boottime;
    int pageSize;
    int pageSizeKB;
+
+   /* see Linux kernel source for further detail, fs/proc/stat.c */
+   unsigned int runningTasks;   /* procs_running from /proc/stat */
+   long long boottime;   /* btime field from /proc/stat */
 
    double period;
 

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -1312,6 +1312,9 @@ static bool LinuxProcessList_recurseProcTree(LinuxProcessList* this, openat_arg_
    const ScreenSettings* ss = settings->ss;
    const struct dirent* entry;
 
+   /* set runningTasks from /proc/stat (from Machine_scanCPUTime) */
+   pl->runningTasks = lhost->runningTasks;
+
 #ifdef HAVE_OPENAT
    int dirFd = openat(parentFd, dirname, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
    if (dirFd < 0)


### PR DESCRIPTION
The recent split of machine-wide metric gathering from process metrics gathering introduced a regression in the Linux running task accounting. The way we extract this value from /proc/stat (which typically is used for machine-wide metrics) conspired with a now-incorrectly placed init- to-zero at the start of the per-process sampling, caused this value to always be zero by the time the Tasks Meter used it.

Fix this by making it much more clear that Linux has this special case handling of runningTasks.

Resolves #1256