### PR TITLE
Short-term fix for docker container detection

### DIFF
--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -1067,7 +1067,7 @@ bool Platform_init(void) {
       char lineBuffer[256];
       while (fgets(lineBuffer, sizeof(lineBuffer), fd)) {
          // detect lxc or overlayfs and guess that this means we are running containerized
-         if (String_startsWith(lineBuffer, "lxcfs /proc") || String_startsWith(lineBuffer, "overlay ")) {
+         if (String_startsWith(lineBuffer, "lxcfs /proc") || String_startsWith(lineBuffer, "overlay / overlay")) {
             Running_containerized = true;
             break;
          }


### PR DESCRIPTION
https://github.com/htop-dev/htop/issues/1223
I have a linux host with docker and zfs installed. The MEMORY_METER_USED, MEMORY_METER_CACHE are incorrect due to this commit https://github.com/htop-dev/htop/commit/7039abe109956852b8fd8d04eea81a1c4581535e#diff-9eb5c93741c46d7cff31a254ef7bc1871308ea110152c007ade91db11985976dR360