### PR TITLE
Remove VLA

### DIFF
--- a/OpenFilesScreen.c
+++ b/OpenFilesScreen.c
@@ -252,10 +252,8 @@ static void OpenFilesScreen_scan(InfoScreen* this) {
       OpenFiles_FileData* fdata = pdata->files;
       while (fdata) {
          OpenFiles_Data* data = &fdata->data;
-         size_t lenN = strlen(getDataForType(data, 'n'));
-         size_t sizeEntry = 5 + 7 + 4 + 10 + 10 + 10 + 10 + lenN + 8 /*spaces*/ + 1 /*null*/;
-         char entry[sizeEntry];
-         xSnprintf(entry, sizeof(entry), "%5.5s %-7.7s %-4.4s %-10.10s %10.10s %10.10s %10.10s  %s",
+         char* entry = NULL;
+         xAsprintf(&entry, "%5.5s %-7.7s %-4.4s %-10.10s %10.10s %10.10s %10.10s  %s",
                    getDataForType(data, 'f'),
                    getDataForType(data, 't'),
                    getDataForType(data, 'a'),
@@ -265,6 +263,7 @@ static void OpenFilesScreen_scan(InfoScreen* this) {
                    getDataForType(data, 'i'),
                    getDataForType(data, 'n'));
          InfoScreen_addLine(this, entry);
+         free(entry);
          OpenFiles_Data_clear(data);
          OpenFiles_FileData* old = fdata;
          fdata = fdata->next;

--- a/darwin/PlatformHelpers.c
+++ b/darwin/PlatformHelpers.c
@@ -103,9 +103,8 @@ double Platform_calculateNanosecondsPerMachTick(void) {
     *    the "Apple M1" chip specifically when running under Rosetta 2.
     */
 
-   size_t cpuBrandStringSize = 1024;
-   char cpuBrandString[cpuBrandStringSize];
-   Platform_getCPUBrandString(cpuBrandString, cpuBrandStringSize);
+   char cpuBrandString[1024] = "";
+   Platform_getCPUBrandString(cpuBrandString, sizeof(cpuBrandString));
 
    bool isRunningUnderRosetta2 = Platform_isRunningTranslated();
 

--- a/linux/LibSensors.c
+++ b/linux/LibSensors.c
@@ -143,7 +143,8 @@ static int tempDriverPriority(const sensors_chip_name* chip) {
 
 void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, unsigned int activeCPUs) {
    assert(existingCPUs > 0 && existingCPUs < 16384);
-   double data[existingCPUs + 1];
+
+   double* data = xMallocArray(existingCPUs + 1, sizeof(double));
    for (size_t i = 0; i < existingCPUs + 1; i++)
       data[i] = NAN;
 
@@ -264,6 +265,8 @@ void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, uns
 out:
    for (unsigned int i = 0; i <= existingCPUs; i++)
       cpus[i].temperature = data[i];
+
+   free(data);
 }
 
 #endif /* HAVE_SENSORS_SENSORS_H */

--- a/linux/LibSensors.c
+++ b/linux/LibSensors.c
@@ -9,9 +9,10 @@
 #include <errno.h>
 #include <limits.h>
 #include <math.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+
 #include <sensors/sensors.h>
 
 #include "Macros.h"

--- a/openbsd/OpenBSDMachine.c
+++ b/openbsd/OpenBSDMachine.c
@@ -163,7 +163,7 @@ static void OpenBSDMachine_scanMemoryInfo(OpenBSDMachine* this) {
     */
    int nswap = swapctl(SWAP_NSWAP, 0, 0);
    if (nswap > 0) {
-      struct swapent swdev[nswap];
+      struct swapent* swdev = xMallocArray(nswap, sizeof(struct swapent));
       int rnswap = swapctl(SWAP_STATS, swdev, nswap);
 
       /* Total things up */
@@ -177,6 +177,8 @@ static void OpenBSDMachine_scanMemoryInfo(OpenBSDMachine* this) {
 
       super->totalSwap = total;
       super->usedSwap = used;
+
+      free(swdev);
    } else {
       super->totalSwap = super->usedSwap = 0;
    }


### PR DESCRIPTION
This removes various instances of VLA in the code.

The two instances in `RichString.c` (`RichString_writeFromWide` & `RichString_appendnWideColumns`) have been kept intentionally, for performance reasons AND the alternatives (like `alloca`) would be less clear.

Those cases aside, I hope I caught all the other instances of VLA in the code.