### PR TITLE
Rework ZramMeter and remove MeterClass.comprisedValues

### DIFF
--- a/Meter.c
+++ b/Meter.c
@@ -11,9 +11,9 @@ in the source distribution for its full text.
 
 #include <assert.h>
 #include <math.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
 
 #include "CRT.h"
 #include "Macros.h"

--- a/Meter.c
+++ b/Meter.c
@@ -225,8 +225,9 @@ static void BarMeterMode_draw(Meter* this, int x, int y, int w) {
    int offset = 0;
    for (uint8_t i = 0; i < this->curItems; i++) {
       double value = this->values[i];
-      value = CLAMP(value, 0.0, this->total);
-      if (value > 0) {
+      if (isPositive(value)) {
+         assert(this->total > 0.0);
+         value = MINIMUM(value, this->total);
          blockSizes[i] = ceil((value / this->total) * w);
       } else {
          blockSizes[i] = 0;

--- a/Meter.c
+++ b/Meter.c
@@ -219,7 +219,6 @@ static void BarMeterMode_draw(Meter* this, int x, int y, int w) {
    assert(startPos + w <= RichString_sizeVal(bar));
 
    int blockSizes[10];
-   int blockSizeSum = 0;
 
    // First draw in the bar[] buffer...
    int offset = 0;
@@ -232,12 +231,6 @@ static void BarMeterMode_draw(Meter* this, int x, int y, int w) {
       } else {
          blockSizes[i] = 0;
       }
-
-      if (Meter_comprisedValues(this)) {
-         blockSizes[i] = MAXIMUM(blockSizes[i] - blockSizeSum, 0);
-         blockSizeSum += blockSizes[i];
-      }
-
       int nextOffset = offset + blockSizes[i];
       // (Control against invalid values)
       nextOffset = CLAMP(nextOffset, 0, w);
@@ -331,11 +324,7 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
       for (int i = 0; i < nValues - 1; i++)
          data->values[i] = data->values[i + 1];
 
-      if (Meter_comprisedValues(this)) {
-         data->values[nValues - 1] = (this->curItems > 0) ? this->values[this->curItems - 1] : 0.0;
-      } else {
-         data->values[nValues - 1] = sumPositiveValues(this->values, this->curItems);
-      }
+      data->values[nValues - 1] = sumPositiveValues(this->values, this->curItems);
    }
 
    int i = nValues - (w * 2), k = 0;

--- a/Meter.h
+++ b/Meter.h
@@ -74,7 +74,6 @@ typedef struct MeterClass_ {
    const char* const description;          /* optional meter description in header setup menu */
    const uint8_t maxItems;
    const bool isMultiColumn;               /* whether the meter draws multiple sub-columns (defaults to false) */
-   const bool comprisedValues;             /* whether latter values comprise previous ones (defaults to false) */
 } MeterClass;
 
 #define As_Meter(this_)                ((const MeterClass*)((this_)->super.klass))
@@ -95,7 +94,6 @@ typedef struct MeterClass_ {
 #define Meter_name(this_)              As_Meter(this_)->name
 #define Meter_uiName(this_)            As_Meter(this_)->uiName
 #define Meter_isMultiColumn(this_)     As_Meter(this_)->isMultiColumn
-#define Meter_comprisedValues(this_)   As_Meter(this_)->comprisedValues
 
 typedef struct GraphData_ {
    struct timeval time;

--- a/linux/LinuxMachine.c
+++ b/linux/LinuxMachine.c
@@ -337,6 +337,9 @@ static void LinuxMachine_scanZramInfo(LinuxMachine* this) {
    this->zram.totalZram = totalZram / 1024;
    this->zram.usedZramComp = usedZramComp / 1024;
    this->zram.usedZramOrig = usedZramOrig / 1024;
+   if (this->zram.usedZramComp > this->zram.usedZramOrig) {
+      this->zram.usedZramComp = this->zram.usedZramOrig;
+   }
 }
 
 static void LinuxMachine_scanZfsArcstats(LinuxMachine* this) {

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -418,7 +418,7 @@ void Platform_setZramValues(Meter* this) {
 
    this->total = lhost->zram.totalZram;
    this->values[ZRAM_METER_COMPRESSED] = lhost->zram.usedZramComp;
-   this->values[ZRAM_METER_UNCOMPRESSED] = lhost->zram.usedZramOrig;
+   this->values[ZRAM_METER_UNCOMPRESSED] = lhost->zram.usedZramOrig - lhost->zram.usedZramComp;
 }
 
 void Platform_setZfsArcValues(Meter* this) {

--- a/linux/ZramMeter.c
+++ b/linux/ZramMeter.c
@@ -27,7 +27,8 @@ static void ZramMeter_updateValues(Meter* this) {
 
    METER_BUFFER_APPEND_CHR(buffer, size, '(');
 
-   written = Meter_humanUnit(buffer, this->values[ZRAM_METER_UNCOMPRESSED], size);
+   double uncompressed = this->values[ZRAM_METER_COMPRESSED] + this->values[ZRAM_METER_UNCOMPRESSED];
+   written = Meter_humanUnit(buffer, uncompressed, size);
    METER_BUFFER_CHECK(buffer, size, written);
 
    METER_BUFFER_APPEND_CHR(buffer, size, ')');
@@ -50,7 +51,8 @@ static void ZramMeter_display(const Object* cast, RichString* out) {
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " used:");
    RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
 
-   Meter_humanUnit(buffer, this->values[ZRAM_METER_UNCOMPRESSED], sizeof(buffer));
+   double uncompressed = this->values[ZRAM_METER_COMPRESSED] + this->values[ZRAM_METER_UNCOMPRESSED];
+   Meter_humanUnit(buffer, uncompressed, sizeof(buffer));
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " uncompressed:");
    RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
 }
@@ -64,7 +66,6 @@ const MeterClass ZramMeter_class = {
    .updateValues = ZramMeter_updateValues,
    .defaultMode = BAR_METERMODE,
    .maxItems = ZRAM_METER_ITEMCOUNT,
-   .comprisedValues = true,
    .total = 100.0,
    .attributes = ZramMeter_attributes,
    .name = "Zram",

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -593,9 +593,13 @@ void Platform_setZramValues(Meter* this) {
 
    free(values);
 
+   if (stats.usedZramComp > stats.usedZramOrig) {
+      stats.usedZramComp = stats.usedZramOrig;
+   }
+
    this->total = stats.totalZram;
    this->values[0] = stats.usedZramComp;
-   this->values[1] = stats.usedZramOrig;
+   this->values[1] = stats.usedZramOrig - stats.usedZramComp;
 }
 
 void Platform_setZfsArcValues(Meter* this) {


### PR DESCRIPTION
The `comprisedValues` boolean property unnecessarily complicates the drawing algorithms of Bar meters and Graph meters. Since the only user of `comprisedValues` is ZramMeter, it is better to rework the meter so that it no longer needs `comprisedValues`.

The `values[ZRAM_METER_UNCOMPRESSED]` now stores the difference between uncompressed and compressed data size.