### PR TITLE
Initialize user ID

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -844,6 +844,7 @@ void Process_init(Process* this, const Machine* host) {
    Row_init(&this->super, host);
 
    this->cmdlineBasenameEnd = -1;
+   this->st_uid = (uid_t)-1;
 }
 
 static bool Process_setPriority(Process* this, int priority) {


### PR DESCRIPTION
Set the process user ID to an invalid value of -1 to trigger a name lookup for IDs with the value 0 ("root").  This initialization was dropped in commit 0f751e99 ("Introduce Row and Table classes for screens beyond top-processes").

Fixes: 0f751e99 ("Introduce Row and Table classes for screens beyond top-processes")