### PR TITLE
Add nonnull attribute to various String_* functions

### DIFF
--- a/Macros.h
+++ b/Macros.h
@@ -42,7 +42,6 @@ in the source distribution for its full text.
 #ifdef  __GNUC__  // defined by GCC and Clang
 
 #define ATTR_FORMAT(type, index, check) __attribute__((format (type, index, check)))
-#define ATTR_NONNULL                    __attribute__((nonnull))
 #define ATTR_NORETURN                   __attribute__((noreturn))
 #define ATTR_UNUSED                     __attribute__((unused))
 #define ATTR_MALLOC                     __attribute__((malloc))
@@ -50,12 +49,23 @@ in the source distribution for its full text.
 #else /* __GNUC__ */
 
 #define ATTR_FORMAT(type, index, check)
-#define ATTR_NONNULL
 #define ATTR_NORETURN
 #define ATTR_UNUSED
 #define ATTR_MALLOC
 
 #endif /* __GNUC__ */
+
+#ifdef HAVE_ATTR_NONNULL
+
+#define ATTR_NONNULL                    __attribute__((nonnull))
+#define ATTR_NONNULL_N(...)             __attribute__((nonnull(__VA_ARGS__)))
+
+#else
+
+#define ATTR_NONNULL
+#define ATTR_NONNULL_N(...)
+
+#endif /* HAVE_ATTR_NONNULL */
 
 #ifdef HAVE_ATTR_ALLOC_SIZE
 

--- a/XUtils.h
+++ b/XUtils.h
@@ -36,26 +36,33 @@ void* xReallocArrayZero(void* ptr, size_t prevmemb, size_t newmemb, size_t size)
  * String_startsWith gives better performance if strlen(match) can be computed
  * at compile time (e.g. when they are immutable string literals). :)
  */
+ATTR_NONNULL
 static inline bool String_startsWith(const char* s, const char* match) {
    return strncmp(s, match, strlen(match)) == 0;
 }
 
 bool String_contains_i(const char* s1, const char* s2, bool multi);
 
+ATTR_NONNULL
 static inline bool String_eq(const char* s1, const char* s2) {
    return strcmp(s1, s2) == 0;
 }
 
+ATTR_NONNULL
 char* String_cat(const char* s1, const char* s2) ATTR_MALLOC;
 
+ATTR_NONNULL
 char* String_trim(const char* in) ATTR_MALLOC;
 
+ATTR_NONNULL_N(1)
 char** String_split(const char* s, char sep, size_t* n);
 
 void String_freeArray(char** s);
 
+ATTR_NONNULL
 char* String_readLine(FILE* fd) ATTR_MALLOC;
 
+ATTR_NONNULL
 static inline char* String_strchrnul(const char* s, int c) {
 #ifdef HAVE_STRCHRNUL
    return strchrnul(s, c);
@@ -73,6 +80,7 @@ ATTR_ACCESS3_R(2, 3)
 size_t String_safeStrncpy(char* restrict dest, const char* restrict src, size_t size);
 
 ATTR_FORMAT(printf, 2, 3)
+ATTR_NONNULL_N(1, 2)
 int xAsprintf(char** strp, const char* fmt, ...);
 
 ATTR_FORMAT(printf, 3, 4)

--- a/configure.ac
+++ b/configure.ac
@@ -202,6 +202,22 @@ AC_COMPILE_IFELSE([
    AC_MSG_RESULT(no))
 CFLAGS="$old_CFLAGS"
 
+AC_MSG_CHECKING(for nonnull)
+old_CFLAGS="$CFLAGS"
+CFLAGS="$CFLAGS -Wno-error -Werror=attributes"
+AC_COMPILE_IFELSE([
+   AC_LANG_SOURCE(
+      [[
+         /* Attribute supported in GCC 3.3 or later */
+         __attribute__((nonnull)) int my_strcmp(const char* a, const char* b);
+         __attribute__((nonnull(1))) long my_strtol(const char* str, char** endptr, int base);
+      ]]
+   )],
+   AC_DEFINE([HAVE_ATTR_NONNULL], 1, [The nonnull attribute is supported.])
+   AC_MSG_RESULT(yes),
+   AC_MSG_RESULT(no))
+CFLAGS="$old_CFLAGS"
+
 AC_MSG_CHECKING(for NaN support)
 dnl Note: AC_RUN_IFELSE does not try compiling the program at all when
 dnl $cross_compiling is 'yes'.


### PR DESCRIPTION
This is a follow-up to PR #1312. In particular `String_strchrnul` is better to have this attribute added.

Note that this not the best position to specify the function attributes in a function definition. I just wrote it to match the style of other function definitions in htop's headers.

The recommend placement of the function attributes, according to various documentation, is immediately before the function name, after the return type (and _before_ the function pointer asterisks, if any):
```c
static inline char* ATTR_NONNULL String_strchrnul(const char* s, int c) {
   ...
}
int (ATTR_NONNULL *sortCompare) (const void* a, const void* b);
```

This is the current style in htop (still works):
```c
ATTR_NONNULL
static inline char* String_strchrnul(const char* s, int c) {
   ...
}
```

The technical difference is minor, but according to gcc documentation, when multiple functions are declared in a comma-separated list, the attributes specified before the return type specifier would apply to all function declared in the list.

The [example in gcc documentation](https://gcc.gnu.org/onlinedocs/gcc/Attribute-Syntax.html) states that the `noreturn` attribute would apply to both `d1` and `d2`:
```c
__attribute__((noreturn)) void d0 (void),
    __attribute__((format(printf, 1, 2))) d1 (const char *, ...),
     d2 (void);
```