### PR TITLE
GraphMeterMode_draw() code cleanup 

### DIFF
--- a/Meter.c
+++ b/Meter.c
@@ -299,14 +299,19 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
       return;
 
    GraphData* data = &this->drawData;
-   if ((size_t)w * 2 > data->nValues) {
+   if ((size_t)w * 2 > data->nValues && MAX_METER_GRAPHDATA_VALUES > data->nValues) {
       size_t oldNValues = data->nValues;
-      data->nValues = MAXIMUM(oldNValues + (oldNValues / 2), (size_t)w * 2);
+      data->nValues = MAXIMUM(oldNValues + oldNValues / 2, (size_t)w * 2);
+      data->nValues = MINIMUM(data->nValues, MAX_METER_GRAPHDATA_VALUES);
       data->values = xReallocArray(data->values, data->nValues, sizeof(*data->values));
       memmove(data->values + (data->nValues - oldNValues), data->values, oldNValues * sizeof(*data->values));
       memset(data->values, 0, (data->nValues - oldNValues) * sizeof(*data->values));
    }
    const size_t nValues = data->nValues;
+   if ((size_t)w * 2 > nValues) {
+      x += w - nValues / 2;
+      w = nValues / 2;
+   }
 
    const Machine* host = this->host;
    if (!timercmp(&host->realtime, &(data->time), <)) {

--- a/Meter.c
+++ b/Meter.c
@@ -333,14 +333,8 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
       GraphMeterMode_pixPerRow = PIXPERROW_ASCII;
    }
 
-   assert(nValues <= SSIZE_MAX);
-   ssize_t i = (ssize_t)nValues - (w * 2);
-   ssize_t k = 0;
-   if (i < 0) {
-      k = -i / 2;
-      i = 0;
-   }
-   for (; i < (ssize_t)nValues - 1; i += 2, k++) {
+   size_t i = nValues - (size_t)w * 2;
+   for (int col = 0; i < nValues - 1; i += 2, col++) {
       int pix = GraphMeterMode_pixPerRow * GRAPH_HEIGHT;
       if (this->total < 1)
          this->total = 1;
@@ -353,7 +347,7 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
          int line2 = CLAMP(v2 - (GraphMeterMode_pixPerRow * (GRAPH_HEIGHT - 1 - line)), 0, GraphMeterMode_pixPerRow);
 
          attrset(CRT_colors[colorIdx]);
-         mvaddstr(y + line, x + k, GraphMeterMode_dots[line1 * (GraphMeterMode_pixPerRow + 1) + line2]);
+         mvaddstr(y + line, x + col, GraphMeterMode_dots[line1 * (GraphMeterMode_pixPerRow + 1) + line2]);
          colorIdx = GRAPH_2;
       }
    }

--- a/Meter.c
+++ b/Meter.c
@@ -289,10 +289,18 @@ static const char* const GraphMeterMode_dotsAscii[] = {
 };
 
 static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
+   const char* caption = Meter_getCaption(this);
+   attrset(CRT_colors[METER_TEXT]);
+   const int captionLen = 3;
+   mvaddnstr(y, x, caption, captionLen);
+   x += captionLen;
+   w -= captionLen;
+   if (w <= 0)
+      return;
+
    const Machine* host = this->host;
    GraphData* data = &this->drawData;
 
-   assert(w > 0);
    if ((size_t)w * 2 > data->nValues) {
       size_t oldNValues = data->nValues;
       data->nValues = MAXIMUM(oldNValues + (oldNValues / 2), (size_t)w * 2);
@@ -314,13 +322,6 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
       GraphMeterMode_dots = GraphMeterMode_dotsAscii;
       GraphMeterMode_pixPerRow = PIXPERROW_ASCII;
    }
-
-   const char* caption = Meter_getCaption(this);
-   attrset(CRT_colors[METER_TEXT]);
-   int captionLen = 3;
-   mvaddnstr(y, x, caption, captionLen);
-   x += captionLen;
-   w -= captionLen;
 
    if (!timercmp(&host->realtime, &(data->time), <)) {
       int globalDelay = this->host->settings->delay;

--- a/Meter.h
+++ b/Meter.h
@@ -20,6 +20,7 @@ in the source distribution for its full text.
 
 
 #define METER_TXTBUFFER_LEN 256
+#define MAX_METER_GRAPHDATA_VALUES 32768
 
 #define METER_BUFFER_CHECK(buffer, size, written)          \
    do {                                                    \


### PR DESCRIPTION
A follow up of PR #1024.

1. In `GraphMeterMode_draw()`, `w` can be less than zero when called from the draw routines of e.g. CPU meters, when the terminal window size is very small.
2. The last commit "Cap the maximum size of GraphData buffer" is optional. I can remove it upon request.