### PR TITLE
CRT: print a warning when exiting on signal

### DIFF
--- a/CRT.c
+++ b/CRT.c
@@ -803,8 +803,16 @@ int CRT_scrollWheelVAmount = 10;
 ColorScheme CRT_colorScheme = COLORSCHEME_DEFAULT;
 
 ATTR_NORETURN
-static void CRT_handleSIGTERM(ATTR_UNUSED int sgn) {
+static void CRT_handleSIGTERM(int sgn) {
    CRT_done();
+
+   const char* signal_str = strsignal(sgn);
+   if (!signal_str)
+      signal_str = "unknown reason";
+
+   fprintf(stderr,
+           "A signal %d (%s) was received, exiting without persisting settings to htoprc.\n",
+           sgn, signal_str);
    _exit(0);
 }
 

--- a/CRT.c
+++ b/CRT.c
@@ -806,6 +806,9 @@ ATTR_NORETURN
 static void CRT_handleSIGTERM(int sgn) {
    CRT_done();
 
+   if (!CRT_crashSettings->changed)
+      _exit(0);
+
    const char* signal_str = strsignal(sgn);
    if (!signal_str)
       signal_str = "unknown reason";


### PR DESCRIPTION
Every now and then users complain about settings not being persisted. Most of the time this turns out to be caused by the user: Exiting with any signal causes `htop` not to save settings to `htoprc`.

Make `htop` print a warning when exiting on signal.