### PR TITLE
Meter_humanUnit() rewrite and *IOMeter code improvements

### DIFF
--- a/DiskIOMeter.c
+++ b/DiskIOMeter.c
@@ -27,8 +27,8 @@ static const int DiskIOMeter_attributes[] = {
 };
 
 static MeterRateStatus status = RATESTATUS_INIT;
-static uint32_t cached_read_diff;
-static uint32_t cached_write_diff;
+static char cached_read_diff_str[6];
+static char cached_write_diff_str[6];
 static double cached_utilisation_diff;
 
 static void DiskIOMeter_updateValues(Meter* this) {
@@ -67,19 +67,19 @@ static void DiskIOMeter_updateValues(Meter* this) {
             diff = data.totalBytesRead - cached_read_total;
             diff = (1000 * diff) / passedTimeInMs; /* convert to B/s */
             diff /= ONE_K; /* convert to KiB/s */
-            cached_read_diff = (uint32_t)diff;
          } else {
-            cached_read_diff = 0;
+            diff = 0;
          }
+         Meter_humanUnit(cached_read_diff_str, diff, sizeof(cached_read_diff_str));
 
          if (data.totalBytesWritten > cached_write_total) {
             diff = data.totalBytesWritten - cached_write_total;
             diff = (1000 * diff) / passedTimeInMs; /* convert to B/s */
             diff /= ONE_K; /* convert to KiB/s */
-            cached_write_diff = (uint32_t)diff;
          } else {
-            cached_write_diff = 0;
+            diff = 0;
          }
+         Meter_humanUnit(cached_write_diff_str, diff, sizeof(cached_write_diff_str));
 
          if (data.totalMsTimeSpend > cached_msTimeSpend_total) {
             diff = data.totalMsTimeSpend - cached_msTimeSpend_total;
@@ -110,10 +110,7 @@ static void DiskIOMeter_updateValues(Meter* this) {
       return;
    }
 
-   char bufferRead[12], bufferWrite[12];
-   Meter_humanUnit(bufferRead, cached_read_diff, sizeof(bufferRead));
-   Meter_humanUnit(bufferWrite, cached_write_diff, sizeof(bufferWrite));
-   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "r:%siB/s w:%siB/s %.1f%%", bufferRead, bufferWrite, cached_utilisation_diff);
+   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "r:%siB/s w:%siB/s %.1f%%", cached_read_diff_str, cached_write_diff_str, cached_utilisation_diff);
 }
 
 static void DiskIOMeter_display(ATTR_UNUSED const Object* cast, RichString* out) {
@@ -139,13 +136,11 @@ static void DiskIOMeter_display(ATTR_UNUSED const Object* cast, RichString* out)
    RichString_appendnAscii(out, CRT_colors[color], buffer, len);
 
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " read: ");
-   Meter_humanUnit(buffer, cached_read_diff, sizeof(buffer));
-   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOREAD], buffer);
+   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOREAD], cached_read_diff_str);
    RichString_appendAscii(out, CRT_colors[METER_VALUE_IOREAD], "iB/s");
 
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " write: ");
-   Meter_humanUnit(buffer, cached_write_diff, sizeof(buffer));
-   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], buffer);
+   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], cached_write_diff_str);
    RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], "iB/s");
 }
 

--- a/DiskIOMeter.c
+++ b/DiskIOMeter.c
@@ -85,6 +85,7 @@ static void DiskIOMeter_updateValues(Meter* this) {
       if (data.totalMsTimeSpend > cached_msTimeSpend_total) {
          diff = data.totalMsTimeSpend - cached_msTimeSpend_total;
          cached_utilisation_diff = 100.0 * (double)diff / passedTimeInMs;
+         cached_utilisation_diff = MINIMUM(cached_utilisation_diff, 100.0);
       } else {
          cached_utilisation_diff = 0.0;
       }
@@ -101,7 +102,6 @@ static void DiskIOMeter_updateValues(Meter* this) {
    }
 
    this->values[0] = cached_utilisation_diff;
-   this->total = MAXIMUM(this->values[0], 100.0); /* fix total after (initial) spike */
 
    char bufferRead[12], bufferWrite[12];
    Meter_humanUnit(bufferRead, cached_read_diff, sizeof(bufferRead));

--- a/DiskIOMeter.c
+++ b/DiskIOMeter.c
@@ -106,7 +106,7 @@ static void DiskIOMeter_updateValues(Meter* this) {
    char bufferRead[12], bufferWrite[12];
    Meter_humanUnit(bufferRead, cached_read_diff, sizeof(bufferRead));
    Meter_humanUnit(bufferWrite, cached_write_diff, sizeof(bufferWrite));
-   snprintf(this->txtBuffer, sizeof(this->txtBuffer), "r:%siB/s w:%siB/s %.1f%%", bufferRead, bufferWrite, cached_utilisation_diff);
+   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "r:%siB/s w:%siB/s %.1f%%", bufferRead, bufferWrite, cached_utilisation_diff);
 }
 
 static void DiskIOMeter_display(ATTR_UNUSED const Object* cast, RichString* out) {

--- a/Meter.c
+++ b/Meter.c
@@ -60,7 +60,7 @@ int Meter_humanUnit(char* buffer, double value, size_t size) {
    while (value >= ONE_K) {
       if (i >= ARRAYSIZE(unitPrefixes) - 1) {
          if (value > 9999.0) {
-            return snprintf(buffer, size, "inf");
+            return xSnprintf(buffer, size, "inf");
          }
          break;
       }
@@ -84,7 +84,7 @@ int Meter_humanUnit(char* buffer, double value, size_t size) {
       }
    }
 
-   return snprintf(buffer, size, "%.*f%c", precision, value, unitPrefixes[i]);
+   return xSnprintf(buffer, size, "%.*f%c", precision, value, unitPrefixes[i]);
 }
 
 void Meter_delete(Object* cast) {

--- a/Meter.h
+++ b/Meter.h
@@ -146,7 +146,9 @@ extern const MeterClass Meter_class;
 
 Meter* Meter_new(const Machine* host, unsigned int param, const MeterClass* type);
 
-int Meter_humanUnit(char* buffer, unsigned long int value, size_t size);
+/* Converts 'value' in kibibytes into a human readable string.
+   Example output strings: "0K", "1023K", "98.7M" and "1.23G" */
+int Meter_humanUnit(char* buffer, double value, size_t size);
 
 void Meter_delete(Object* cast);
 

--- a/NetworkIOMeter.c
+++ b/NetworkIOMeter.c
@@ -70,12 +70,11 @@ static void NetworkIOMeter_updateValues(Meter* this) {
          if (data.bytesReceived > cached_rxb_total) {
             diff = data.bytesReceived - cached_rxb_total;
             diff = (1000 * diff) / passedTimeInMs; /* convert to B/s */
-            diff /= ONE_K; /* convert to KiB/s */
             cached_rxb_diff = diff;
          } else {
             cached_rxb_diff = 0;
          }
-         Meter_humanUnit(cached_rxb_diff_str, cached_rxb_diff, sizeof(cached_rxb_diff_str));
+         Meter_humanUnit(cached_rxb_diff_str, cached_rxb_diff / ONE_K, sizeof(cached_rxb_diff_str));
 
          if (data.packetsReceived > cached_rxp_total) {
             diff = data.packetsReceived - cached_rxp_total;
@@ -88,12 +87,11 @@ static void NetworkIOMeter_updateValues(Meter* this) {
          if (data.bytesTransmitted > cached_txb_total) {
             diff = data.bytesTransmitted - cached_txb_total;
             diff = (1000 * diff) / passedTimeInMs; /* convert to B/s */
-            diff /= ONE_K; /* convert to KiB/s */
             cached_txb_diff = diff;
          } else {
             cached_txb_diff = 0;
          }
-         Meter_humanUnit(cached_txb_diff_str, cached_txb_diff, sizeof(cached_txb_diff_str));
+         Meter_humanUnit(cached_txb_diff_str, cached_txb_diff / ONE_K, sizeof(cached_txb_diff_str));
 
          if (data.packetsTransmitted > cached_txp_total) {
             diff = data.packetsTransmitted - cached_txp_total;

--- a/NetworkIOMeter.c
+++ b/NetworkIOMeter.c
@@ -27,10 +27,10 @@ static const int NetworkIOMeter_attributes[] = {
 };
 
 static MeterRateStatus status = RATESTATUS_INIT;
-static uint32_t cached_rxb_diff;
+static double cached_rxb_diff;
 static char cached_rxb_diff_str[6];
 static uint32_t cached_rxp_diff;
-static uint32_t cached_txb_diff;
+static double cached_txb_diff;
 static char cached_txb_diff_str[6];
 static uint32_t cached_txp_diff;
 
@@ -71,7 +71,7 @@ static void NetworkIOMeter_updateValues(Meter* this) {
             diff = data.bytesReceived - cached_rxb_total;
             diff = (1000 * diff) / passedTimeInMs; /* convert to B/s */
             diff /= ONE_K; /* convert to KiB/s */
-            cached_rxb_diff = (uint32_t)diff;
+            cached_rxb_diff = diff;
          } else {
             cached_rxb_diff = 0;
          }
@@ -89,7 +89,7 @@ static void NetworkIOMeter_updateValues(Meter* this) {
             diff = data.bytesTransmitted - cached_txb_total;
             diff = (1000 * diff) / passedTimeInMs; /* convert to B/s */
             diff /= ONE_K; /* convert to KiB/s */
-            cached_txb_diff = (uint32_t)diff;
+            cached_txb_diff = diff;
          } else {
             cached_txb_diff = 0;
          }

--- a/NetworkIOMeter.c
+++ b/NetworkIOMeter.c
@@ -76,7 +76,7 @@ static void NetworkIOMeter_updateValues(Meter* this) {
 
       if (data.packetsReceived > cached_rxp_total) {
          diff = data.packetsReceived - cached_rxp_total;
-         diff = (1000 * diff) / passedTimeInMs; /* convert to B/s */
+         diff = (1000 * diff) / passedTimeInMs; /* convert to pkts/s */
          cached_rxp_diff = (uint32_t)diff;
       } else {
          cached_rxp_diff = 0;
@@ -95,7 +95,7 @@ static void NetworkIOMeter_updateValues(Meter* this) {
 
       if (data.packetsTransmitted > cached_txp_total) {
          diff = data.packetsTransmitted - cached_txp_total;
-         diff = (1000 * diff) / passedTimeInMs; /* convert to B/s */
+         diff = (1000 * diff) / passedTimeInMs; /* convert to pkts/s */
          cached_txp_diff = (uint32_t)diff;
       } else {
          cached_txp_diff = 0;
@@ -121,7 +121,7 @@ static void NetworkIOMeter_updateValues(Meter* this) {
    char bufferBytesReceived[12], bufferBytesTransmitted[12];
    Meter_humanUnit(bufferBytesReceived, cached_rxb_diff, sizeof(bufferBytesReceived));
    Meter_humanUnit(bufferBytesTransmitted, cached_txb_diff, sizeof(bufferBytesTransmitted));
-   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "rx:%siB/s tx:%siB/s %d/%dpkts/s",
+   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "rx:%siB/s tx:%siB/s %u/%upkts/s",
       bufferBytesReceived, bufferBytesTransmitted, cached_rxp_diff, cached_txp_diff);
 }
 

--- a/NetworkIOMeter.c
+++ b/NetworkIOMeter.c
@@ -28,8 +28,10 @@ static const int NetworkIOMeter_attributes[] = {
 
 static MeterRateStatus status = RATESTATUS_INIT;
 static uint32_t cached_rxb_diff;
+static char cached_rxb_diff_str[6];
 static uint32_t cached_rxp_diff;
 static uint32_t cached_txb_diff;
+static char cached_txb_diff_str[6];
 static uint32_t cached_txp_diff;
 
 static void NetworkIOMeter_updateValues(Meter* this) {
@@ -73,6 +75,7 @@ static void NetworkIOMeter_updateValues(Meter* this) {
          } else {
             cached_rxb_diff = 0;
          }
+         Meter_humanUnit(cached_rxb_diff_str, cached_rxb_diff, sizeof(cached_rxb_diff_str));
 
          if (data.packetsReceived > cached_rxp_total) {
             diff = data.packetsReceived - cached_rxp_total;
@@ -90,6 +93,7 @@ static void NetworkIOMeter_updateValues(Meter* this) {
          } else {
             cached_txb_diff = 0;
          }
+         Meter_humanUnit(cached_txb_diff_str, cached_txb_diff, sizeof(cached_txb_diff_str));
 
          if (data.packetsTransmitted > cached_txp_total) {
             diff = data.packetsTransmitted - cached_txp_total;
@@ -125,11 +129,8 @@ static void NetworkIOMeter_updateValues(Meter* this) {
       return;
    }
 
-   char bufferBytesReceived[12], bufferBytesTransmitted[12];
-   Meter_humanUnit(bufferBytesReceived, cached_rxb_diff, sizeof(bufferBytesReceived));
-   Meter_humanUnit(bufferBytesTransmitted, cached_txb_diff, sizeof(bufferBytesTransmitted));
    xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "rx:%siB/s tx:%siB/s %u/%upkts/s",
-      bufferBytesReceived, bufferBytesTransmitted, cached_rxp_diff, cached_txp_diff);
+      cached_rxb_diff_str, cached_txb_diff_str, cached_rxp_diff, cached_txp_diff);
 }
 
 static void NetworkIOMeter_display(ATTR_UNUSED const Object* cast, RichString* out) {
@@ -151,13 +152,11 @@ static void NetworkIOMeter_display(ATTR_UNUSED const Object* cast, RichString* o
    int len;
 
    RichString_writeAscii(out, CRT_colors[METER_TEXT], "rx: ");
-   Meter_humanUnit(buffer, cached_rxb_diff, sizeof(buffer));
-   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOREAD], buffer);
+   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOREAD], cached_rxb_diff_str);
    RichString_appendAscii(out, CRT_colors[METER_VALUE_IOREAD], "iB/s");
 
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " tx: ");
-   Meter_humanUnit(buffer, cached_txb_diff, sizeof(buffer));
-   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], buffer);
+   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], cached_txb_diff_str);
    RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], "iB/s");
 
    len = xSnprintf(buffer, sizeof(buffer), " (%u/%u pkts/s) ", cached_rxp_diff, cached_txp_diff);

--- a/XUtils.h
+++ b/XUtils.h
@@ -111,4 +111,7 @@ int compareRealNumbers(double a, double b);
    nonnegative. */
 double sumPositiveValues(const double* array, size_t count);
 
+/* IEC unit prefixes */
+static const char unitPrefixes[] = { 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y', 'R', 'Q' };
+
 #endif

--- a/pcp/PCPDynamicMeter.c
+++ b/pcp/PCPDynamicMeter.c
@@ -351,27 +351,27 @@ void PCPDynamicMeter_updateValues(PCPDynamicMeter* this, Meter* meter) {
             break;
          case PM_TYPE_32:
             bytes += conv.dimSpace ?
-               Meter_humanUnit(buffer + bytes, atom.l, size - bytes) :
+               Meter_humanUnit(buffer + bytes, (double) atom.l, size - bytes) :
                xSnprintf(buffer + bytes, size - bytes, "%d", atom.l);
             break;
          case PM_TYPE_U32:
             bytes += conv.dimSpace ?
-               Meter_humanUnit(buffer + bytes, atom.ul, size - bytes) :
+               Meter_humanUnit(buffer + bytes, (double) atom.ul, size - bytes) :
                xSnprintf(buffer + bytes, size - bytes, "%u", atom.ul);
             break;
          case PM_TYPE_64:
             bytes += conv.dimSpace ?
-               Meter_humanUnit(buffer + bytes, atom.ll, size - bytes) :
+               Meter_humanUnit(buffer + bytes, (double) atom.ll, size - bytes) :
                xSnprintf(buffer + bytes, size - bytes, "%lld", (long long) atom.ll);
             break;
          case PM_TYPE_U64:
             bytes += conv.dimSpace ?
-               Meter_humanUnit(buffer + bytes, atom.ull, size - bytes) :
+               Meter_humanUnit(buffer + bytes, (double) atom.ull, size - bytes) :
                xSnprintf(buffer + bytes, size - bytes, "%llu", (unsigned long long) atom.ull);
             break;
          case PM_TYPE_FLOAT:
             bytes += conv.dimSpace ?
-               Meter_humanUnit(buffer + bytes, atom.f, size - bytes) :
+               Meter_humanUnit(buffer + bytes, (double) atom.f, size - bytes) :
                xSnprintf(buffer + bytes, size - bytes, "%.2f", (double) atom.f);
             break;
          case PM_TYPE_DOUBLE:
@@ -427,27 +427,27 @@ void PCPDynamicMeter_display(PCPDynamicMeter* this, ATTR_UNUSED const Meter* met
             break;
          case PM_TYPE_32:
             len = conv.dimSpace ?
-               Meter_humanUnit(buffer, atom.l, sizeof(buffer)) :
+               Meter_humanUnit(buffer, (double) atom.l, sizeof(buffer)) :
                xSnprintf(buffer, sizeof(buffer), "%d", atom.l);
             break;
          case PM_TYPE_U32:
             len = conv.dimSpace ?
-               Meter_humanUnit(buffer, atom.ul, sizeof(buffer)) :
+               Meter_humanUnit(buffer, (double) atom.ul, sizeof(buffer)) :
                xSnprintf(buffer, sizeof(buffer), "%u", atom.ul);
             break;
          case PM_TYPE_64:
             len = conv.dimSpace ?
-               Meter_humanUnit(buffer, atom.ll, sizeof(buffer)) :
+               Meter_humanUnit(buffer, (double) atom.ll, sizeof(buffer)) :
                xSnprintf(buffer, sizeof(buffer), "%lld", (long long) atom.ll);
             break;
          case PM_TYPE_U64:
             len = conv.dimSpace ?
-               Meter_humanUnit(buffer, atom.ull, sizeof(buffer)) :
+               Meter_humanUnit(buffer, (double) atom.ull, sizeof(buffer)) :
                xSnprintf(buffer, sizeof(buffer), "%llu", (unsigned long long) atom.ull);
             break;
          case PM_TYPE_FLOAT:
             len = conv.dimSpace ?
-               Meter_humanUnit(buffer, atom.f, sizeof(buffer)) :
+               Meter_humanUnit(buffer, (double) atom.f, sizeof(buffer)) :
                xSnprintf(buffer, sizeof(buffer), "%.2f", (double) atom.f);
             break;
          case PM_TYPE_DOUBLE:


### PR DESCRIPTION
1. Rewrite `Meter_humanUnit()` to make it work with `double` (floating point) values.
2. `DiskIOMeter` and `NetworkIOMeter` code improvements to work with the new `Meter_humanUnit()` function. See commit description for details.