### PR TITLE
Linux + PCP: Add private memory size column

### DIFF
--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -244,7 +244,7 @@ static void LinuxProcess_rowWriteField(const Row* super, RichString* str, Proces
       break;
    case M_TRS: Row_printBytes(str, lp->m_trs * lhost->pageSize, coloring); return;
    case M_SHARE: Row_printBytes(str, lp->m_share * lhost->pageSize, coloring); return;
-   case M_PRIV: Row_printBytes(str, lp->m_priv, coloring); return;
+   case M_PRIV: Row_printKBytes(str, lp->m_priv, coloring); return;
    case M_PSS: Row_printKBytes(str, lp->m_pss, coloring); return;
    case M_SWAP: Row_printKBytes(str, lp->m_swap, coloring); return;
    case M_PSSWP: Row_printKBytes(str, lp->m_psswp, coloring); return;

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -51,6 +51,7 @@ const ProcessFieldData Process_fields[LAST_PROCESSFIELD] = {
    [M_VIRT] = { .name = "M_VIRT", .title = " VIRT ", .description = "Total program size in virtual memory", .flags = 0, .defaultSortDesc = true, },
    [M_RESIDENT] = { .name = "M_RESIDENT", .title = "  RES ", .description = "Resident set size, size of the text and data sections, plus stack usage", .flags = 0, .defaultSortDesc = true, },
    [M_SHARE] = { .name = "M_SHARE", .title = "  SHR ", .description = "Size of the process's shared pages", .flags = 0, .defaultSortDesc = true, },
+   [M_PRIV] = { .name = "M_PRIV", .title = " PRIV ", .description = "The private memory size of the process - resident set size minus shared memory", .flags = 0, .defaultSortDesc = true, },
    [M_TRS] = { .name = "M_TRS", .title = " CODE ", .description = "Size of the .text segment of the process (CODE)", .flags = 0, .defaultSortDesc = true, },
    [M_DRS] = { .name = "M_DRS", .title = " DATA ", .description = "Size of the .data segment plus stack usage of the process (DATA)", .flags = 0, .defaultSortDesc = true, },
    [M_LRS] = { .name = "M_LRS", .title = "  LIB ", .description = "The library size of the process (calculated from memory maps)", .flags = PROCESS_FLAG_LINUX_LRS_FIX, .defaultSortDesc = true, },
@@ -243,6 +244,7 @@ static void LinuxProcess_rowWriteField(const Row* super, RichString* str, Proces
       break;
    case M_TRS: Row_printBytes(str, lp->m_trs * lhost->pageSize, coloring); return;
    case M_SHARE: Row_printBytes(str, lp->m_share * lhost->pageSize, coloring); return;
+   case M_PRIV: Row_printBytes(str, lp->m_priv, coloring); return;
    case M_PSS: Row_printKBytes(str, lp->m_pss, coloring); return;
    case M_SWAP: Row_printKBytes(str, lp->m_swap, coloring); return;
    case M_PSSWP: Row_printKBytes(str, lp->m_psswp, coloring); return;
@@ -339,6 +341,8 @@ static int LinuxProcess_compareByKey(const Process* v1, const Process* v2, Proce
       return SPACESHIP_NUMBER(p1->m_trs, p2->m_trs);
    case M_SHARE:
       return SPACESHIP_NUMBER(p1->m_share, p2->m_share);
+   case M_PRIV:
+      return SPACESHIP_NUMBER(p1->m_priv, p2->m_priv);
    case M_PSS:
       return SPACESHIP_NUMBER(p1->m_pss, p2->m_pss);
    case M_SWAP:

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -41,6 +41,7 @@ typedef struct LinuxProcess_ {
    unsigned long long int cutime;
    unsigned long long int cstime;
    long m_share;
+   long m_priv;
    long m_pss;
    long m_swap;
    long m_psswp;

--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -701,9 +701,9 @@ static bool LinuxProcessTable_readStatmFile(LinuxProcess* process, openat_arg_t 
    if (r == 7) {
       process->super.m_virt *= host->pageSizeKB;
       process->super.m_resident *= host->pageSizeKB;
-   }
 
-   process->m_priv = process->super.m_resident - (process->m_share * host->pageSizeKB);
+      process->m_priv = process->super.m_resident - (process->m_share * host->pageSizeKB);
+   }
 
    return r == 7;
 }

--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -703,6 +703,8 @@ static bool LinuxProcessTable_readStatmFile(LinuxProcess* process, openat_arg_t 
       process->super.m_resident *= host->pageSizeKB;
    }
 
+   process->m_priv = (process->super.m_resident - (process->m_share * host->pageSizeKB)) * ONE_K;
+
    return r == 7;
 }
 

--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -703,7 +703,7 @@ static bool LinuxProcessTable_readStatmFile(LinuxProcess* process, openat_arg_t 
       process->super.m_resident *= host->pageSizeKB;
    }
 
-   process->m_priv = (process->super.m_resident - (process->m_share * host->pageSizeKB)) * ONE_K;
+   process->m_priv = process->super.m_resident - (process->m_share * host->pageSizeKB);
 
    return r == 7;
 }

--- a/linux/ProcessField.h
+++ b/linux/ProcessField.h
@@ -46,6 +46,7 @@ in the source distribution for its full text.
    AUTOGROUP_ID = 127,           \
    AUTOGROUP_NICE = 128,         \
    CCGROUP = 129,                \
+   M_PRIV = 130,                 \
    // End of list
 
 

--- a/pcp/PCPProcess.c
+++ b/pcp/PCPProcess.c
@@ -49,6 +49,7 @@ const ProcessFieldData Process_fields[] = {
    [M_VIRT] = { .name = "M_VIRT", .title = " VIRT ", .description = "Total program size in virtual memory", .flags = 0, .defaultSortDesc = true, },
    [M_RESIDENT] = { .name = "M_RESIDENT", .title = "  RES ", .description = "Resident set size, size of the text and data sections, plus stack usage", .flags = 0, .defaultSortDesc = true, },
    [M_SHARE] = { .name = "M_SHARE", .title = "  SHR ", .description = "Size of the process's shared pages", .flags = 0, .defaultSortDesc = true, },
+   [M_PRIV] = { .name = "M_PRIV", .title = " PRIV ", .description = "The private memory size of the process - resident set size minus shared memory", .flags = 0, .defaultSortDesc = true, },
    [M_TRS] = { .name = "M_TRS", .title = " CODE ", .description = "Size of the text segment of the process", .flags = 0, .defaultSortDesc = true, },
    [M_DRS] = { .name = "M_DRS", .title = " DATA ", .description = "Size of the data segment plus stack usage of the process", .flags = 0, .defaultSortDesc = true, },
    [M_LRS] = { .name = "M_LRS", .title = "  LIB ", .description = "The library size of the process (unused since Linux 2.6; always 0)", .flags = 0, .defaultSortDesc = true, },
@@ -138,6 +139,7 @@ static void PCPProcess_rowWriteField(const Row* super, RichString* str, ProcessF
    case M_LRS: Row_printBytes(str, pp->m_lrs, coloring); return;
    case M_TRS: Row_printBytes(str, pp->m_trs, coloring); return;
    case M_SHARE: Row_printBytes(str, pp->m_share, coloring); return;
+   case M_PRIV: Row_printBytes(str, pp->m_priv, coloring); return;
    case M_PSS: Row_printKBytes(str, pp->m_pss, coloring); return;
    case M_SWAP: Row_printKBytes(str, pp->m_swap, coloring); return;
    case M_PSSWP: Row_printKBytes(str, pp->m_psswp, coloring); return;
@@ -214,6 +216,8 @@ static int PCPProcess_compareByKey(const Process* v1, const Process* v2, Process
       return SPACESHIP_NUMBER(p1->m_trs, p2->m_trs);
    case M_SHARE:
       return SPACESHIP_NUMBER(p1->m_share, p2->m_share);
+   case M_PRIV:
+      return SPACESHIP_NUMBER(p1->m_priv, p2->m_priv);
    case M_PSS:
       return SPACESHIP_NUMBER(p1->m_pss, p2->m_pss);
    case M_SWAP:

--- a/pcp/PCPProcess.h
+++ b/pcp/PCPProcess.h
@@ -38,6 +38,7 @@ typedef struct PCPProcess_ {
    unsigned long long int cutime;
    unsigned long long int cstime;
    long m_share;
+   long m_priv;
    long m_pss;
    long m_swap;
    long m_psswp;

--- a/pcp/PCPProcessTable.c
+++ b/pcp/PCPProcessTable.c
@@ -201,6 +201,7 @@ static void PCPProcessTable_updateMemory(PCPProcess* pp, int pid, int offset) {
    pp->super.m_virt = Metric_instance_u32(PCP_PROC_MEM_SIZE, pid, offset, 0);
    pp->super.m_resident = Metric_instance_u32(PCP_PROC_MEM_RSS, pid, offset, 0);
    pp->m_share = Metric_instance_u32(PCP_PROC_MEM_SHARE, pid, offset, 0);
+   pp->m_priv = pp->super.m_resident - pp->m_share;
    pp->m_trs = Metric_instance_u32(PCP_PROC_MEM_TEXTRS, pid, offset, 0);
    pp->m_lrs = Metric_instance_u32(PCP_PROC_MEM_LIBRS, pid, offset, 0);
    pp->m_drs = Metric_instance_u32(PCP_PROC_MEM_DATRS, pid, offset, 0);

--- a/pcp/ProcessField.h
+++ b/pcp/ProcessField.h
@@ -45,6 +45,7 @@ in the source distribution for its full text.
    SECATTR = 123,                \
    AUTOGROUP_ID = 127,           \
    AUTOGROUP_NICE = 128,         \
+   M_PRIV = 129,                 \
    // End of list
 
 

--- a/pcp/ProcessField.h
+++ b/pcp/ProcessField.h
@@ -45,7 +45,7 @@ in the source distribution for its full text.
    SECATTR = 123,                \
    AUTOGROUP_ID = 127,           \
    AUTOGROUP_NICE = 128,         \
-   M_PRIV = 129,                 \
+   M_PRIV = 130,                 \
    // End of list
 
 


### PR DESCRIPTION
Private memory size is a metric supported by other tools like [System Monitoring Center](https://github.com/hakandundar34coding/system-monitoring-center) and [System Informer](https://systeminformer.sourceforge.io/). It is also a decently close measurement of the "real" memory usage of a process, like PSS.

Note that it is calculated by subtracting the shared memory size from the RSS, which won't always provide the exact real value, but it is a very close estimation an overwhelming majority of the time. Getting the real value appears to involve some querying of the kernel which is very slow for heavy processes, which is just unnecessary.

Would appreciate some testing for PCP, I can't do it because I'm not on systemd, which it requires. Not sure if what I did for it works properly, considering I have to multiply the shared memory by the page size in the Linux code.