### PR TITLE
Fix build errors and warnings in NetBSD.

### DIFF
--- a/netbsd/NetBSDMachine.c
+++ b/netbsd/NetBSDMachine.c
@@ -81,7 +81,7 @@ static void NetBSDMachine_updateCPUcount(NetBSDMachine* this) {
    }
 
    if (value != super->existingCPUs) {
-      opl->cpuData = xReallocArray(this->cpuData, value + 1, sizeof(CPUData));
+      this->cpuData = xReallocArray(this->cpuData, value + 1, sizeof(CPUData));
       super->existingCPUs = value;
       change = true;
    }
@@ -127,7 +127,7 @@ Machine* Machine_new(UsersTable* usersTable, uid_t userId) {
       CRT_fatalError("kvm_openfiles() failed");
    }
 
-   return this;
+   return super;
 }
 
 void Machine_delete(Machine* super) {
@@ -268,11 +268,11 @@ static void NetBSDMachine_scanCPUFrequency(NetBSDMachine* this) {
 void Machine_scan(Machine* super) {
    NetBSDMachine* this = (NetBSDMachine*) super;
 
-   NetBSDProcessTable_scanMemoryInfo(this);
-   NetBSDProcessTable_scanCPUTime(this);
+   NetBSDMachine_scanMemoryInfo(this);
+   NetBSDMachine_scanCPUTime(this);
 
    if (super->settings->showCPUFrequency) {
-      NetBSDProcessTable_scanCPUFrequency(npl);
+      NetBSDMachine_scanCPUFrequency(this);
    }
 }
 

--- a/netbsd/NetBSDProcess.c
+++ b/netbsd/NetBSDProcess.c
@@ -237,7 +237,7 @@ static void NetBSDProcess_rowWriteField(const Row* super, RichString* str, Proce
    switch (field) {
    // add NetBSD-specific fields here
    default:
-      Process_writeField(np->super, str, field);
+      Process_writeField(&np->super, str, field);
       return;
    }
 

--- a/netbsd/NetBSDProcessTable.c
+++ b/netbsd/NetBSDProcessTable.c
@@ -151,7 +151,7 @@ static double getpcpu(const NetBSDMachine* nhost, const struct kinfo_proc2* kp) 
 }
 
 static void NetBSDProcessTable_scanProcs(NetBSDProcessTable* this) {
-   const Machine* host = this->super.host;
+   const Machine* host = this->super.super.host;
    const NetBSDMachine* nhost = (const NetBSDMachine*) host;
    const Settings* settings = host->settings;
    bool hideKernelThreads = settings->hideKernelThreads;


### PR DESCRIPTION
- Fix build in NetBSD from the renaming done in b74673fe.
- Simplify the `ProcessTable_goThroughEntries()` and also apply the fixes for the compiler warning.
  ```
  netbsd/NetBSDProcessTable.c: In function 'NetBSDProcessTable_scanProcs':
  netbsd/NetBSDProcessTable.c:185:53: warning: comparison is always true due to limited range of data type [-Wtype-limits]
           const char* name = ((int64_t)kproc->p_tdev != (int64_t)KERN_PROC_TTY_NODEV) ? devname(kproc->p_tdev, S_IFCHR): NULL;
  ```
  The fix came in as part of the discussion [here](https://github.com/htop-dev/htop/pull/1360#discussion_r1439257379).


