### PR TITLE
Linux: use fseek(3)

### DIFF
--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -196,13 +196,10 @@ static bool LinuxProcess_changeAutogroupPriorityBy(Process* p, Arg delta) {
    long int identity;
    int nice;
    int ok = fscanf(file, "/autogroup-%ld nice %d", &identity, &nice);
-   bool success;
-   if (ok == 2) {
-      rewind(file);
+   bool success = false;
+   if (ok == 2 && fseek(file, 0L, SEEK_SET) == 0) {
       xSnprintf(buffer, sizeof(buffer), "%d", nice + delta.i);
       success = fputs(buffer, file) > 0;
-   } else {
-      success = false;
    }
 
    fclose(file);


### PR DESCRIPTION
Use fseek(3) instead of rewind(3) to check for success.