### PR TITLE
Fix static linking with libsystemd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -336,7 +336,7 @@ if test "$my_htop_platform" = pcp; then
 fi
 
 if test "$my_htop_platform" = linux && test "x$enable_static" = xyes; then
-   AC_CHECK_LIB([systemd], [sd_bus_open_system])
+   AC_CHECK_LIB([systemd], [sd_bus_open_system], [], [], [-lcap])
 fi
 
 # ----------------------------------------------------------------------

--- a/linux/SystemdMeter.c
+++ b/linux/SystemdMeter.c
@@ -33,6 +33,7 @@ in the source distribution for its full text.
 #ifdef BUILD_STATIC
 
 #define sym_sd_bus_open_system sd_bus_open_system
+#define sym_sd_bus_open_user sd_bus_open_user
 #define sym_sd_bus_get_property_string sd_bus_get_property_string
 #define sym_sd_bus_get_property_trivial sd_bus_get_property_trivial
 #define sym_sd_bus_unref sd_bus_unref


### PR DESCRIPTION
libsystemd requires libcap for static linking.

Add missing macro for function alias.