### PR TITLE
fixes for illumos/Solaris platforms

### DIFF
--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -220,7 +220,7 @@ double Platform_setCPUValues(Meter* this, unsigned int cpu) {
 
    v[CPU_METER_NICE]   = cpuData->nicePercent;
    v[CPU_METER_NORMAL] = cpuData->userPercent;
-   if (super->settings->detailedCPUTime) {
+   if (host->settings->detailedCPUTime) {
       v[CPU_METER_KERNEL]  = cpuData->systemPercent;
       v[CPU_METER_IRQ]     = cpuData->irqPercent;
       this->curItems = 4;
@@ -258,13 +258,13 @@ void Platform_setSwapValues(Meter* this) {
 }
 
 void Platform_setZfsArcValues(Meter* this) {
-   const SolarisMachine* shost = (SolarisMachine*) this->host;
+   const SolarisMachine* shost = (const SolarisMachine*) this->host;
 
    ZfsArcMeter_readStats(this, &shost->zfs);
 }
 
 void Platform_setZfsCompressedArcValues(Meter* this) {
-   const SolarisMachine* shost = (SolarisMachine*) this->host;
+   const SolarisMachine* shost = (const SolarisMachine*) this->host;
 
    ZfsCompressedArcMeter_readStats(this, &shost->zfs);
 }

--- a/solaris/SolarisMachine.c
+++ b/solaris/SolarisMachine.c
@@ -57,7 +57,7 @@ static void SolarisMachine_updateCPUcount(SolarisMachine* this) {
 
    if (s != super->activeCPUs) {
       change = true;
-      hsuper->activeCPUs = s;
+      super->activeCPUs = s;
    }
 
    if (change) {
@@ -309,6 +309,10 @@ Machine* Machine_new(UsersTable* usersTable, uid_t userId) {
    if (this->pageSize == -1)
       CRT_fatalError("Cannot get pagesize by sysconf(_SC_PAGESIZE)");
    this->pageSizeKB = this->pageSize / 1024;
+
+   this->kd = kstat_open();
+   if (!this->kd)
+      CRT_fatalError("Cannot open kstat handle");
 
    SolarisMachine_updateCPUcount(this);
 

--- a/solaris/SolarisMachine.h
+++ b/solaris/SolarisMachine.h
@@ -19,6 +19,7 @@ in the source distribution for its full text.
 #include <sys/uio.h>
 
 #include "Hashtable.h"
+#include "Machine.h"
 #include "UsersTable.h"
 
 #include "zfs/ZfsArcStats.h"

--- a/solaris/SolarisProcess.c
+++ b/solaris/SolarisProcess.c
@@ -15,7 +15,6 @@ in the source distribution for its full text.
 #include <unistd.h>
 #include <sys/syscall.h>
 
-#include "Process.h"
 #include "ProcessTable.h"
 #include "CRT.h"
 

--- a/solaris/SolarisProcess.h
+++ b/solaris/SolarisProcess.h
@@ -20,6 +20,7 @@ in the source distribution for its full text.
 #define ERR (-1)
 
 #include "Machine.h"
+#include "Process.h"
 
 
 typedef struct SolarisProcess_ {

--- a/solaris/SolarisProcessTable.c
+++ b/solaris/SolarisProcessTable.c
@@ -24,6 +24,7 @@ in the source distribution for its full text.
 
 #include "CRT.h"
 #include "solaris/Platform.h"
+#include "solaris/SolarisMachine.h"
 #include "solaris/SolarisProcess.h"
 
 
@@ -112,8 +113,8 @@ static int SolarisProcessTable_walkproc(psinfo_t* _psinfo, lwpsinfo_t* _lwpsinfo
 
    // Setup process list
    ProcessTable* pt = (ProcessTable*) listptr;
-   SolarisProcessTable* spt = (SolarisProcessTable*) listptr;
-   Machine* host = pt->host;
+   const Machine* host = pt->super.host;
+   const SolarisMachine* shost = (const SolarisMachine*) host;
 
    id_t lwpid_real = _lwpsinfo->pr_lwpid;
    if (lwpid_real > 1023) {
@@ -133,7 +134,7 @@ static int SolarisProcessTable_walkproc(psinfo_t* _psinfo, lwpsinfo_t* _lwpsinfo
    const Settings* settings = host->settings;
 
    // Common code pass 1
-   proc->show               = false;
+   proc->super.show         = false;
    sproc->taskid            = _psinfo->pr_taskid;
    sproc->projid            = _psinfo->pr_projid;
    sproc->poolid            = _psinfo->pr_poolid;
@@ -171,7 +172,7 @@ static int SolarisProcessTable_walkproc(psinfo_t* _psinfo, lwpsinfo_t* _lwpsinfo
       sproc->realpid        = _psinfo->pr_pid;
       sproc->lwpid          = lwpid_real;
       sproc->zoneid         = _psinfo->pr_zoneid;
-      sproc->zname          = SolarisProcessTable_readZoneName(spt->kd, sproc);
+      sproc->zname          = SolarisProcessTable_readZoneName(shost->kd, sproc);
       SolarisProcessTable_updateExe(_psinfo->pr_pid, proc);
 
       Process_updateComm(proc, _psinfo->pr_fname);
@@ -218,7 +219,7 @@ static int SolarisProcessTable_walkproc(psinfo_t* _psinfo, lwpsinfo_t* _lwpsinfo
             pt->totalTasks += proc->nlwp + 1;
          }
       }
-      proc->show = !(settings->hideKernelThreads && proc->isKernelThread);
+      proc->super.show = !(settings->hideKernelThreads && proc->isKernelThread);
    } else { // We are not in the master LWP, so jump to the LWP handling code
       proc->percent_cpu        = ((uint16_t)_lwpsinfo->pr_pctcpu / (double)32768) * (double)100.0;
       Process_updateCPUFieldWidths(proc->percent_cpu);


### PR DESCRIPTION
This fixes build errors/warnings on illumos that were introduced in the most recent `htop` release (`3.3.0`), as well as a segmentation fault due to a non-allocated kstat structure.