### PR TITLE
Fallback on printing invalid wide string

### DIFF
--- a/RichString.h
+++ b/RichString.h
@@ -7,6 +7,7 @@ Released under the GNU GPLv2+, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "Macros.h"
 #include "ProvideCurses.h"
 
 
@@ -61,6 +62,7 @@ void RichString_appendChr(RichString* this, int attrs, char c, int count);
 
 int RichString_appendWide(RichString* this, int attrs, const char* data);
 
+ATTR_ACCESS3_R(3, 4)
 int RichString_appendnWide(RichString* this, int attrs, const char* data, int len);
 
 /* columns takes the maximum number of columns to write and contains on return the number of columns written. */
@@ -70,6 +72,7 @@ int RichString_writeWide(RichString* this, int attrs, const char* data);
 
 int RichString_appendAscii(RichString* this, int attrs, const char* data);
 
+ATTR_ACCESS3_R(3, 4)
 int RichString_appendnAscii(RichString* this, int attrs, const char* data, int len);
 
 int RichString_writeAscii(RichString* this, int attrs, const char* data);

--- a/Table.c
+++ b/Table.c
@@ -308,10 +308,9 @@ void Table_printHeader(const Settings* settings, RichString* header) {
       if (key == fields[i] && RichString_getCharVal(*header, RichString_size(header) - 1) == ' ') {
          bool ascending = ScreenSettings_getActiveDirection(ss) == 1;
          RichString_rewind(header, 1);  // rewind to override space
-         RichString_appendnWide(header,
+         RichString_appendWide(header,
                                 CRT_colors[PANEL_SELECTION_FOCUS],
-                                CRT_treeStr[ascending ? TREE_STR_ASC : TREE_STR_DESC],
-                                1);
+                                CRT_treeStr[ascending ? TREE_STR_ASC : TREE_STR_DESC]);
       }
       if (COMM == fields[i] && settings->showMergedCommand) {
          RichString_appendAscii(header, color, "(merged)");


### PR DESCRIPTION
In case the string to be printed contains invalid wide characters, fall
back to print as ASCII string.

Closes: https://github.com/htop-dev/htop/issues/1373