### PR TITLE
darwin/Platform.c: do not include non-existing headers which break build

### DIFF
--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -18,7 +18,7 @@ in the source distribution for its full text.
 #include <net/if_types.h>
 #include <net/route.h>
 #include <sys/socket.h>
-#include <sys/_types/_mach_port_t.h>
+#include <mach/port.h>
 
 #include <CoreFoundation/CFBase.h>
 #include <CoreFoundation/CFDictionary.h>


### PR DESCRIPTION
Commit ed7eac5dfe8239f7942102f9d1a4f9ef5210f4d7 unconditionally includes a header which is not present on earlier macOS. This unnecessarily breaks the build. Use includes correctly.