### PR TITLE
darwin/PlatformHelpers: fix CPU detection for PowerPC

### DIFF
--- a/darwin/PlatformHelpers.c
+++ b/darwin/PlatformHelpers.c
@@ -60,6 +60,10 @@ bool Platform_KernelVersionIsBetween(KernelVersion lowerBound, KernelVersion upp
 
 void Platform_getCPUBrandString(char* cpuBrandString, size_t cpuBrandStringSize) {
    if (sysctlbyname("machdep.cpu.brand_string", cpuBrandString, &cpuBrandStringSize, NULL, 0) == -1) {
+   #ifdef __POWERPC__
+      if (sysctlbyname("hw.cpusubtype", cpuBrandString, &cpuBrandStringSize, NULL, 0) != -1)
+         return;
+   #endif
       fprintf(stderr,
          "WARN: Unable to determine the CPU brand string.\n"
          "errno: %i, %s\n", errno, strerror(errno));


### PR DESCRIPTION
Closes: https://github.com/htop-dev/htop/issues/1382

Notice, that hw.cpusubtype outputs a numerical code of a CPU. For PowerPC, 100 = G5, 11 = ppc7450, 10 = ppc7400.

P. S. As far as I can see, the resulting string is only used on Apple Silicon, and in other cases it is either something (cpu is known) or unknown. It is desirable to avoid a bogus warning on PowerPC – we know those cpus very well :) 
