### PR TITLE
Disable basename matching for kernel threads

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -1038,8 +1038,14 @@ void Process_updateCmdline(Process* this, const char* cmdline, int basenameStart
 
    free(this->cmdline);
    this->cmdline = cmdline ? xStrdup(cmdline) : NULL;
-   this->cmdlineBasenameStart = (basenameStart || !cmdline) ? basenameStart : skipPotentialPath(cmdline, basenameEnd);
-   this->cmdlineBasenameEnd = basenameEnd;
+   if (Process_isKernelThread(this)) {
+      /* kernel threads have no basename */
+      this->cmdlineBasenameStart = 0;
+      this->cmdlineBasenameEnd = 0;
+   } else {
+      this->cmdlineBasenameStart = (basenameStart || !cmdline) ? basenameStart : skipPotentialPath(cmdline, basenameEnd);
+      this->cmdlineBasenameEnd = basenameEnd;
+   }
 
    this->mergedCommand.lastUpdate = 0;
 }


### PR DESCRIPTION
Kernel threads are commonly not based on an executable and their cmdline therefore just a human readable string.
On Linux this string might contain slashes, e.g. kworker/7:5H-ttm, which cause Process_writeCommand() to print only the trailing parts if the option *Show Program Path* is disabled.

Reported-and-Suggested-By: mmrmaximuzz
Fixes: #1391

/cc @mmrmaximuzz