### PR TITLE
Minor bug fixes for Coverity issues

### DIFF
--- a/Settings.c
+++ b/Settings.c
@@ -622,8 +622,11 @@ int Settings_write(const Settings* this, bool onCrash) {
       fd = stderr;
       separator = ';';
    } else {
+      /* create tempfile with mode 0600 */
+      mode_t	cur_umask = umask(S_IXUSR | S_IRWXG | S_IRWXO);
       xAsprintf(&tmpFilename, "%s.tmp.XXXXXX", this->filename);
       int fdtmp = mkstemp(tmpFilename);
+      umask(cur_umask);
       if (fdtmp == -1)
          return -errno;
       fd = fdopen(fdtmp, "w");

--- a/Settings.c
+++ b/Settings.c
@@ -623,7 +623,7 @@ int Settings_write(const Settings* this, bool onCrash) {
       separator = ';';
    } else {
       /* create tempfile with mode 0600 */
-      mode_t	cur_umask = umask(S_IXUSR | S_IRWXG | S_IRWXO);
+      mode_t cur_umask = umask(S_IXUSR | S_IRWXG | S_IRWXO);
       xAsprintf(&tmpFilename, "%s.tmp.XXXXXX", this->filename);
       int fdtmp = mkstemp(tmpFilename);
       umask(cur_umask);

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -480,7 +480,7 @@ pid_t Platform_getMaxPid(void) {
 
    pmAtomValue value;
    if (Metric_values(PCP_PID_MAX, &value, 1, PM_TYPE_32) == NULL)
-      return UINT_MAX;
+      return INT_MAX;
    pcp->pidmax = value.l;
    return pcp->pidmax;
 }


### PR DESCRIPTION
Over in the PCP project, Coverity has spotted a couple of minor issues in the htop code.

This commit addresses them:

Settings.c
    need to take control of the umask before calling mkstemp()

pcp/Platform.c
    Although Platform_getMaxPid() returns a pid_t (which
    strictly speaking is signed), the value is used to call
    Row_setPidColumnWidth() and a negative value here is not good
    ... using INT_MAX instead of UNIT_MAX on the (unlikely) error
    path makes no practical difference but may keep Coverity quiet