### PR TITLE
documentation update "pcp htop" –> "pcp-htop"

### DIFF
--- a/htop.1.in
+++ b/htop.1.in
@@ -5,7 +5,7 @@ htop, pcp-htop \- interactive process viewer
 .B htop
 .RB [ \-dCFhpustvH ]
 .br
-.B pcp\ htop
+.B pcp-htop
 .RB [ \-dCFhpustvH ]
 .RB [ \-\-host/-h\ host ]
 .SH "DESCRIPTION"


### PR DESCRIPTION
Rarely (if ever) do we see references in the documentation to `pcp htop` (it's mainly just `pcp-htop`, with a hyphen instead of a space). I fixed the documentation to reflect this. 

Feel free to ignore this if the space is intentional.