### PR TITLE
Avoid glibc FILE voodoo

### DIFF
--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -682,13 +682,15 @@ static void LinuxProcessTable_readMaps(LinuxProcess* process, openat_arg_t procF
 }
 
 static bool LinuxProcessTable_readStatmFile(LinuxProcess* process, openat_arg_t procFd, const LinuxMachine* host) {
-   FILE* statmfile = fopenat(procFd, "statm", "r");
-   if (!statmfile)
+   char statmdata[128] = {0};
+
+   if (xReadfileat(procFd, "statm", statmdata, sizeof(statmdata)) < 1) {
       return false;
+   }
 
    long int dummy, dummy2;
 
-   int r = fscanf(statmfile, "%ld %ld %ld %ld %ld %ld %ld",
+   int r = sscanf(statmdata, "%ld %ld %ld %ld %ld %ld %ld",
                   &process->super.m_virt,
                   &process->super.m_resident,
                   &process->m_share,
@@ -696,7 +698,6 @@ static bool LinuxProcessTable_readStatmFile(LinuxProcess* process, openat_arg_t 
                   &dummy, /* unused since Linux 2.6; always 0 */
                   &process->m_drs,
                   &dummy2); /* unused since Linux 2.6; always 0 */
-   fclose(statmfile);
 
    if (r == 7) {
       process->super.m_virt *= host->pageSizeKB;

--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -969,21 +969,15 @@ static void LinuxProcessTable_readAutogroup(LinuxProcess* process, openat_arg_t 
 }
 
 static void LinuxProcessTable_readSecattrData(LinuxProcess* process, openat_arg_t procFd) {
-   FILE* file = fopenat(procFd, "attr/current", "r");
-   if (!file) {
+   char buffer[PROC_LINE_LENGTH + 1] = {0};
+
+   ssize_t attrdata = xReadfileat(procFd, "attr/current", buffer, sizeof(buffer));
+   if (attrdata < 1) {
       free(process->secattr);
       process->secattr = NULL;
       return;
    }
 
-   char buffer[PROC_LINE_LENGTH + 1];
-   const char* res = fgets(buffer, sizeof(buffer), file);
-   fclose(file);
-   if (!res) {
-      free(process->secattr);
-      process->secattr = NULL;
-      return;
-   }
    char* newline = strchr(buffer, '\n');
    if (newline) {
       *newline = '\0';

--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -931,19 +931,24 @@ static void LinuxProcessTable_readCGroupFile(LinuxProcess* process, openat_arg_t
 }
 
 static void LinuxProcessTable_readOomData(LinuxProcess* process, openat_arg_t procFd) {
-   FILE* file = fopenat(procFd, "oom_score", "r");
-   if (!file)
-      return;
+   char buffer[PROC_LINE_LENGTH + 1] = {0};
 
-   char buffer[PROC_LINE_LENGTH + 1];
-   if (fgets(buffer, PROC_LINE_LENGTH, file)) {
-      unsigned int oom;
-      int ok = sscanf(buffer, "%u", &oom);
-      if (ok == 1) {
-         process->oom = oom;
-      }
+   ssize_t oomRead = xReadfileat(procFd, "oom_score", buffer, sizeof(buffer));
+   if (oomRead < 1) {
+      return;
    }
-   fclose(file);
+
+   char* oomPtr = buffer;
+   uint64_t oom = fast_strtoull_dec(&oomPtr, oomRead);
+   if (*oomPtr && *oomPtr != '\n' && *oomPtr != ' ') {
+      return;
+   }
+
+   if (oom > UINT_MAX) {
+      return;
+   }
+
+   process->oom = oom;
 }
 
 static void LinuxProcessTable_readAutogroup(LinuxProcess* process, openat_arg_t procFd) {

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -275,25 +275,26 @@ int Platform_getUptime(void) {
 }
 
 void Platform_getLoadAverage(double* one, double* five, double* fifteen) {
-   FILE* fd = fopen(PROCDIR "/loadavg", "r");
-   if (!fd)
-      goto err;
+   char loaddata[128] = {0};
 
-   double scanOne, scanFive, scanFifteen;
-   int r = fscanf(fd, "%lf %lf %lf", &scanOne, &scanFive, &scanFifteen);
-   fclose(fd);
+   *one = NAN;
+   *five = NAN;
+   *fifteen = NAN;
+
+   ssize_t loadread = xReadfile(PROCDIR "/loadavg", loaddata, sizeof(loaddata));
+   if (loadread < 1)
+      return;
+
+   double scanOne = NAN;
+   double scanFive = NAN;
+   double scanFifteen = NAN;
+   int r = sscanf(loaddata, "%lf %lf %lf", &scanOne, &scanFive, &scanFifteen);
    if (r != 3)
-      goto err;
+      return;
 
    *one = scanOne;
    *five = scanFive;
    *fifteen = scanFifteen;
-   return;
-
-err:
-   *one = NAN;
-   *five = NAN;
-   *fifteen = NAN;
 }
 
 pid_t Platform_getMaxPid(void) {

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -587,21 +587,21 @@ void Platform_getPressureStall(const char* file, bool some, double* ten, double*
 }
 
 void Platform_getFileDescriptors(double* used, double* max) {
+   char buffer[128] = {0};
+
    *used = NAN;
    *max = 65536;
 
-   FILE* fd = fopen(PROCDIR "/sys/fs/file-nr", "r");
-   if (!fd)
+   ssize_t fdread = xReadfile(PROCDIR "/sys/fs/file-nr", buffer, sizeof(buffer));
+   if (fdread < 1)
       return;
 
    unsigned long long v1, v2, v3;
-   int total = fscanf(fd, "%llu %llu %llu", &v1, &v2, &v3);
+   int total = sscanf(buffer, "%llu %llu %llu", &v1, &v2, &v3);
    if (total == 3) {
       *used = v1;
       *max = v3;
    }
-
-   fclose(fd);
 }
 
 bool Platform_getDiskIO(DiskIOData* data) {

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -256,15 +256,21 @@ const MeterClass* const Platform_meterTypes[] = {
 };
 
 int Platform_getUptime(void) {
-   double uptime = 0;
-   FILE* fd = fopen(PROCDIR "/uptime", "r");
-   if (fd) {
-      int n = fscanf(fd, "%64lf", &uptime);
-      fclose(fd);
-      if (n != 1) {
-         return 0;
-      }
+   char uptimedata[64] = {0};
+
+   ssize_t uptimeread = xReadfile(PROCDIR "/uptime", uptimedata, sizeof(uptimedata));
+   if (uptimeread < 1) {
+      return 0;
    }
+
+   double uptime = 0;
+   double idle = 0;
+
+   int n = sscanf(uptimedata, "%lf %lf", &uptime, &idle);
+   if (n != 2) {
+      return 0;
+   }
+
    return floor(uptime);
 }
 


### PR DESCRIPTION
Addresses #1408

Background: Using `xReadfileat` avoids the internal buffer handling from glibc, which should improve robustness in low-memory situations as detailled in #1408. Avoiding any dynamic memory allocation also improves on the performance side of things as no dynamic allocations need to be managed (Except for the changed code formatting this IS even shorter ;-)).