### PR TITLE
Resolve configuration path

### DIFF
--- a/CommandLine.c
+++ b/CommandLine.c
@@ -411,6 +411,10 @@ int CommandLine_run(int argc, char** argv) {
    CRT_done();
 
    if (settings->changed) {
+#ifndef NDEBUG
+      if (!String_eq(settings->initialFilename, settings->filename))
+         fprintf(stderr, "Configuration %s was resolved to %s\n", settings->initialFilename, settings->filename);
+#endif /* NDEBUG */
       int r = Settings_write(settings, false);
       if (r < 0)
          fprintf(stderr, "Can not save configuration to %s: %s\n", settings->filename, strerror(-r));

--- a/Settings.c
+++ b/Settings.c
@@ -826,6 +826,12 @@ Settings* Settings_new(unsigned int initialCpuCount, Hashtable* dynamicMeters, H
          legacyDotfile = NULL;
       }
    }
+
+   char* resolvedFilename = xMalloc(PATH_MAX);
+   if (realpath(this->filename, resolvedFilename))
+      free_and_xStrdup(&this->filename, resolvedFilename);
+   free(resolvedFilename);
+
    this->colorScheme = 0;
 #ifdef HAVE_GETMOUSE
    this->enableMouse = true;

--- a/Settings.c
+++ b/Settings.c
@@ -74,6 +74,7 @@ static void writeQuotedList(FILE* fd, char** list) {
 
 void Settings_delete(Settings* this) {
    free(this->filename);
+   free(this->initialFilename);
    for (unsigned int i = 0; i < HeaderLayout_getColumns(this->hLayout); i++) {
       String_freeArray(this->hColumns[i].names);
       free(this->hColumns[i].modes);
@@ -795,7 +796,7 @@ Settings* Settings_new(unsigned int initialCpuCount, Hashtable* dynamicMeters, H
    char* legacyDotfile = NULL;
    const char* rcfile = getenv("HTOPRC");
    if (rcfile) {
-      this->filename = xStrdup(rcfile);
+      this->initialFilename = xStrdup(rcfile);
    } else {
       const char* home = getenv("HOME");
       if (!home) {
@@ -806,11 +807,11 @@ Settings* Settings_new(unsigned int initialCpuCount, Hashtable* dynamicMeters, H
       char* configDir = NULL;
       char* htopDir = NULL;
       if (xdgConfigHome) {
-         this->filename = String_cat(xdgConfigHome, "/htop/htoprc");
+         this->initialFilename = String_cat(xdgConfigHome, "/htop/htoprc");
          configDir = xStrdup(xdgConfigHome);
          htopDir = String_cat(xdgConfigHome, "/htop");
       } else {
-         this->filename = String_cat(home, "/.config/htop/htoprc");
+         this->initialFilename = String_cat(home, "/.config/htop/htoprc");
          configDir = String_cat(home, "/.config");
          htopDir = String_cat(home, "/.config/htop");
       }
@@ -827,10 +828,9 @@ Settings* Settings_new(unsigned int initialCpuCount, Hashtable* dynamicMeters, H
       }
    }
 
-   char* resolvedFilename = xMalloc(PATH_MAX);
-   if (realpath(this->filename, resolvedFilename))
-      free_and_xStrdup(&this->filename, resolvedFilename);
-   free(resolvedFilename);
+   this->filename = xMalloc(PATH_MAX);
+   if (!realpath(this->initialFilename, this->filename))
+      free_and_xStrdup(&this->filename, this->initialFilename);
 
    this->colorScheme = 0;
 #ifdef HAVE_GETMOUSE

--- a/Settings.h
+++ b/Settings.h
@@ -54,6 +54,7 @@ typedef struct ScreenSettings_ {
 
 typedef struct Settings_ {
    char* filename;
+   char* initialFilename;
    int config_version;
    HeaderLayout hLayout;
    MeterColumnSetting* hColumns;


### PR DESCRIPTION
Some configuration systems might link a htop configuration file and we don't really want to replace the symlink but rather its source. This will also allow us to fail in case the source is read only.