### PR TITLE
Fix the compiler name for OpenBSD.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,7 @@ jobs:
             CPPFLAGS="-I/usr/pkg/include" ./configure --enable-unicode --enable-werror
             gmake -k
 
-  build-openbsd-latest-gcc:
+  build-openbsd-latest-clang:
       runs-on: ubuntu-22.04
       timeout-minutes: 20
       steps:


### PR DESCRIPTION
Fix the compiler name for OpenBSD as indicated by @Explorer09 [here](https://github.com/htop-dev/htop/pull/1400#issuecomment-2002512840).