### PR TITLE
Fix reachable assert for CPU percentage of NAN

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -1071,7 +1071,7 @@ void Process_updateExe(Process* this, const char* exe) {
 }
 
 void Process_updateCPUFieldWidths(float percentage) {
-   if (percentage < 99.9F) {
+   if (percentage < 99.9F || isNaN(percentage)) {
       Row_updateFieldWidth(PERCENT_CPU, 4);
       Row_updateFieldWidth(PERCENT_NORM_CPU, 4);
       return;

--- a/Row.c
+++ b/Row.c
@@ -442,6 +442,10 @@ void Row_printLeftAlignedField(RichString* str, int attr, const char* content, u
 }
 
 int Row_printPercentage(float val, char* buffer, size_t n, uint8_t width, int* attr) {
+   assert(width >= 4 && width < n && "Invalid width in Row_printPercentage()");
+   // truncate in favour of abort in xSnprintf()
+   width = (uint8_t)CLAMP(width, 4, n - 1);
+
    if (isNonnegative(val)) {
       if (val < 0.05F)
          *attr = CRT_colors[PROCESS_SHADOW];


### PR DESCRIPTION
* Avoid too large CPU field widths

  In case the current CPU usage percentage is NAN the width calculation is invalid.  Use the default with of 4, which is appropriate for "N/A ".

* Check width in Row_printPercentage()
  The passed width should always be at least 4, otherwise printing will always truncate and lead to an abort().

  The passed should not be greater or equal to the available buffer size, otherwise printing will always truncate and lead to an abort().

  Add fallback for non debug builds.

Fixes: #1420