### PR TITLE
Simplify expression in Process_updateCPUFieldWidths()

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -1071,7 +1071,7 @@ void Process_updateExe(Process* this, const char* exe) {
 }
 
 void Process_updateCPUFieldWidths(float percentage) {
-   if (percentage < 99.9F || isNaN(percentage)) {
+   if (!isgreaterequal(percentage, 99.9F)) {
       Row_updateFieldWidth(PERCENT_CPU, 4);
       Row_updateFieldWidth(PERCENT_NORM_CPU, 4);
       return;


### PR DESCRIPTION
(A follow-up of #1421)

Because the compilers weren't yet able to optimize this one. (The behaviors aren't exactly the same. When `percentage < 99.9F` is checked before `isNaN(percentage)` it could potentially produce an `FP_INVALID` exception. By merging the conditional checks this exception is avoided.)