### PR TITLE
New "nanoseconds" format for GPU time fields.

### DIFF
--- a/Row.c
+++ b/Row.c
@@ -403,6 +403,57 @@ void Row_printTime(RichString* str, unsigned long long totalHundredths, bool col
    }
 }
 
+void Row_printNanoseconds(RichString* str, unsigned long long totalNanoseconds, bool coloring) {
+   if (totalNanoseconds == 0) {
+      int shadowColor = coloring ? CRT_colors[PROCESS_SHADOW] : CRT_colors[PROCESS];
+
+      RichString_appendAscii(str, shadowColor, "     0ns ");
+      return;
+   }
+
+   char buffer[10];
+   int len;
+   int baseColor = CRT_colors[PROCESS];
+
+   if (totalNanoseconds < 1000000) {
+      len = xSnprintf(buffer, sizeof(buffer), "%6luns ", (unsigned long)totalNanoseconds);
+      RichString_appendnAscii(str, baseColor, buffer, len);
+      return;
+   }
+
+   unsigned long long totalMicroseconds = totalNanoseconds / 1000;
+   if (totalMicroseconds < 1000000) {
+      len = xSnprintf(buffer, sizeof(buffer), ".%06lus ", (unsigned long)totalMicroseconds);
+      RichString_appendnAscii(str, baseColor, buffer, len);
+   }
+
+   unsigned long long totalSeconds = totalMicroseconds / 1000000;
+   unsigned long microseconds = totalMicroseconds % 1000000;
+   if (totalSeconds < 60) {
+      int width = 5;
+      unsigned long fraction = microseconds;
+      if (totalSeconds >= 10) {
+         width--;
+         fraction /= 10;
+      }
+      len = xSnprintf(buffer, sizeof(buffer), "%u.%0*lus ", (unsigned int)totalSeconds, width, fraction);
+      RichString_appendnAscii(str, baseColor, buffer, len);
+      return;
+   }
+
+   if (totalSeconds < 600) {
+      unsigned int minutes = totalSeconds / 60;
+      unsigned int seconds = totalSeconds % 60;
+      unsigned int milliseconds = microseconds / 1000;
+      len = xSnprintf(buffer, sizeof(buffer), "%u:%02u.%03u ", minutes, seconds, milliseconds);
+      RichString_appendnAscii(str, baseColor, buffer, len);
+      return;
+   }
+
+   unsigned long long totalHundredths = totalMicroseconds / 1000 / 10;
+   Row_printTime(str, totalHundredths, coloring);
+}
+
 void Row_printRate(RichString* str, double rate, bool coloring) {
    char buffer[16];
 

--- a/Row.h
+++ b/Row.h
@@ -154,6 +154,9 @@ void Row_printCount(RichString* str, unsigned long long number, bool coloring);
 /* Takes time in hundredths of a seconds. Prints 9 columns. */
 void Row_printTime(RichString* str, unsigned long long totalHundredths, bool coloring);
 
+/* Takes time in nanoseconds. Prints 9 columns. */
+void Row_printNanoseconds(RichString* str, unsigned long long totalNanoseconds, bool coloring);
+
 /* Takes rate in bare unit (base 1024) per second. Prints 12 columns. */
 void Row_printRate(RichString* str, double rate, bool coloring);
 

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -109,7 +109,7 @@ const ProcessFieldData Process_fields[LAST_PROCESSFIELD] = {
 #ifdef SCHEDULER_SUPPORT
    [SCHEDULERPOLICY] = { .name = "SCHEDULERPOLICY", .title = "SCHED ", .description = "Current scheduling policy of the process", .flags = PROCESS_FLAG_SCHEDPOL, },
 #endif
-   [GPU_TIME] = { .name = "GPU_TIME", .title = " GPU_TIME", .description = "Total GPU time in nano seconds", .flags = PROCESS_FLAG_LINUX_GPU, .defaultSortDesc = true, .autoWidth = true, .autoTitleRightAlign = true, },
+   [GPU_TIME] = { .name = "GPU_TIME", .title = " GPU_TIME", .description = "Total GPU time", .flags = PROCESS_FLAG_LINUX_GPU, .defaultSortDesc = true, .autoWidth = true, .autoTitleRightAlign = true, },
    [GPU_PERCENT] = { .name = "GPU_PERCENT", .title = "GPU% ", .description = "Percentage of the GPU time the process used in the last sampling", .flags = PROCESS_FLAG_LINUX_GPU, .defaultSortDesc = true, },
 };
 
@@ -242,7 +242,7 @@ static void LinuxProcess_rowWriteField(const Row* super, RichString* str, Proces
    case CMINFLT: Row_printCount(str, lp->cminflt, coloring); return;
    case CMAJFLT: Row_printCount(str, lp->cmajflt, coloring); return;
    case GPU_PERCENT: Row_printPercentage(lp->gpu_percent, buffer, n, 5, &attr); break;
-   case GPU_TIME: Row_printTime(str, lp->gpu_time / 1000 / 1000 / 10 /* nano to centi seconds */, coloring); return;
+   case GPU_TIME: Row_printNanoseconds(str, lp->gpu_time, coloring); return;
    case M_DRS: Row_printBytes(str, lp->m_drs * lhost->pageSize, coloring); return;
    case M_LRS:
       if (lp->m_lrs) {


### PR DESCRIPTION
This is a new time format that I just came up with, because I just don't want to see extra time precision gets truncated.

The new formats are:
```text
     0ns - 999999ns
.001000s - .999999s (1 ms or above)
1.00000s - 9.99999s (1 second or above)
10.0000s - 59.9999s (10 seconds or above)
1:00.000 - 9.59.999 (1 minute or above)
10:00.00 - 59.59.99 (uses Row_printTime() to avoid duplicate code)
```