### PR TITLE
Avoid saving configuration to non regular files

### DIFF
--- a/Settings.h
+++ b/Settings.h
@@ -55,6 +55,7 @@ typedef struct ScreenSettings_ {
 typedef struct Settings_ {
    char* filename;
    char* initialFilename;
+   bool writeConfig; /* whether to write the current settings on exit */
    int config_version;
    HeaderLayout hLayout;
    MeterColumnSetting* hColumns;


### PR DESCRIPTION
Check on startup whether the resolved configuration filename points to a
regular file, and only then write the settings on exit.

Fixes: #1426