### PR TITLE
Use designated initializer more

### DIFF
--- a/Hashtable.c
+++ b/Hashtable.c
@@ -109,13 +109,15 @@ static size_t nextPrime(size_t n) {
 }
 
 Hashtable* Hashtable_new(size_t size, bool owner) {
-   Hashtable* this;
+   size = size ? nextPrime(size) : 13;
 
-   this = xMalloc(sizeof(Hashtable));
-   this->items = 0;
-   this->size = size ? nextPrime(size) : 13;
-   this->buckets = (HashtableItem*) xCalloc(this->size, sizeof(HashtableItem));
-   this->owner = owner;
+   Hashtable* this = xMalloc(sizeof(Hashtable));
+   *this = (Hashtable) {
+      .items = 0,
+      .size = size,
+      .buckets = xCalloc(size, sizeof(HashtableItem)),
+      .owner = owner,
+   };
 
    assert(Hashtable_isConsistent(this));
    return this;

--- a/Settings.c
+++ b/Settings.c
@@ -790,7 +790,7 @@ Settings* Settings_new(unsigned int initialCpuCount, Hashtable* dynamicMeters, H
    this->topologyAffinity = false;
    #endif
 
-   this->screens = xCalloc(Platform_numberOfDefaultScreens * sizeof(ScreenSettings*), 1);
+   this->screens = xCalloc(Platform_numberOfDefaultScreens, sizeof(ScreenSettings*));
    this->nScreens = 0;
 
    char* legacyDotfile = NULL;

--- a/Vector.c
+++ b/Vector.c
@@ -25,14 +25,16 @@ Vector* Vector_new(const ObjectClass* type, bool owner, int size) {
 
    assert(size > 0);
    this = xMalloc(sizeof(Vector));
-   this->growthRate = size;
-   this->array = (Object**) xCalloc(size, sizeof(Object*));
-   this->arraySize = size;
-   this->items = 0;
-   this->type = type;
-   this->owner = owner;
-   this->dirty_index = -1;
-   this->dirty_count = 0;
+   *this = (Vector) {
+      .growthRate = size,
+      .array = xCalloc(size, sizeof(Object*)),
+      .arraySize = size,
+      .items = 0,
+      .type = type,
+      .owner = owner,
+      .dirty_index = -1,
+      .dirty_count = 0,
+   };
    return this;
 }
 


### PR DESCRIPTION
Designated initializers are supported in C99 and simplify struct initializations.  All members not explicitly mentioned are default initialized to 0, and also modern compilers can warn on of those missing ones.