### PR TITLE
Read htoprc in modern location first before old one

### DIFF
--- a/Settings.c
+++ b/Settings.c
@@ -838,8 +838,8 @@ Settings* Settings_new(unsigned int initialCpuCount, Hashtable* dynamicMeters, H
 #endif
    this->changed = false;
    this->delay = DEFAULT_DELAY;
-   bool ok = false;
-   if (legacyDotfile) {
+   bool ok = Settings_read(this, this->filename, initialCpuCount);
+   if (!ok && legacyDotfile) {
       ok = Settings_read(this, legacyDotfile, initialCpuCount);
       if (ok) {
          // Transition to new location and delete old configuration file
@@ -848,9 +848,6 @@ Settings* Settings_new(unsigned int initialCpuCount, Hashtable* dynamicMeters, H
          }
       }
       free(legacyDotfile);
-   }
-   if (!ok) {
-      ok = Settings_read(this, this->filename, initialCpuCount);
    }
    if (!ok) {
       this->screenTabs = true;


### PR DESCRIPTION
Read htop configuration file in the modern location first ("~/.config/htop/htoprc") before trying the legacy location ("~/.htoprc"). This would prevent a case where configuration files exist in both locations and the new configuration gets replaced by the old one.