### PR TITLE
Fix regression from storing monotonic time deltas

### DIFF
--- a/Machine.c
+++ b/Machine.c
@@ -101,11 +101,12 @@ void Machine_scanTables(Machine* this) {
 
    if (firstScanDone) {
       this->prevMonotonicMs = this->monotonicMs;
+      Platform_gettime_monotonic(&this->monotonicMs);
    } else {
       this->prevMonotonicMs = 0;
+      this->monotonicMs = 1;
       firstScanDone = true;
    }
-   Platform_gettime_monotonic(&this->monotonicMs);
    assert(this->monotonicMs > this->prevMonotonicMs);
 
    this->maxUserId = 0;


### PR DESCRIPTION
When starting htop the timestamp of the first scan must be far in the past to avoid showing all processes as being started just recently.

Fixes: b61685779cdf696ba4135a97ce66075c337c7562