### PR TITLE
Avoid writing configuration to non-regular file

### DIFF
--- a/Settings.h
+++ b/Settings.h
@@ -55,6 +55,7 @@ typedef struct ScreenSettings_ {
 typedef struct Settings_ {
    char* filename;
    char* initialFilename;
+   bool writeConfig; /* whether to write the current settings on exit */
    int config_version;
    HeaderLayout hLayout;
    MeterColumnSetting* hColumns;


### PR DESCRIPTION
(This pull request supersedes #1428)

Check whether the configuration file (after symlink resolution) is writable and is a regular file on htop startup, and only then, write the configuration on exit.

Thanks to @cgzones for providing the initial version of the patch.

Fixes: #1426