### PR TITLE
Work around GCC14 memleak diagnostic

### DIFF
--- a/darwin/DarwinProcess.c
+++ b/darwin/DarwinProcess.c
@@ -62,7 +62,7 @@ Process* DarwinProcess_new(const Machine* host) {
    this->taskAccess = true;
    this->translated = false;
 
-   return &this->super;
+   return (Process*)this;
 }
 
 void Process_delete(Object* cast) {

--- a/dragonflybsd/DragonFlyBSDProcess.c
+++ b/dragonflybsd/DragonFlyBSDProcess.c
@@ -56,7 +56,7 @@ Process* DragonFlyBSDProcess_new(const Machine* host) {
    DragonFlyBSDProcess* this = xCalloc(1, sizeof(DragonFlyBSDProcess));
    Object_setClass(this, Class(DragonFlyBSDProcess));
    Process_init(&this->super, host);
-   return &this->super;
+   return (Process*)this;
 }
 
 void Process_delete(Object* cast) {

--- a/freebsd/FreeBSDProcess.c
+++ b/freebsd/FreeBSDProcess.c
@@ -62,7 +62,7 @@ Process* FreeBSDProcess_new(const Machine* machine) {
    FreeBSDProcess* this = xCalloc(1, sizeof(FreeBSDProcess));
    Object_setClass(this, Class(FreeBSDProcess));
    Process_init(&this->super, machine);
-   return &this->super;
+   return (Process*)this;
 }
 
 void Process_delete(Object* cast) {

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -118,7 +118,7 @@ Process* LinuxProcess_new(const Machine* host) {
    LinuxProcess* this = xCalloc(1, sizeof(LinuxProcess));
    Object_setClass(this, Class(LinuxProcess));
    Process_init(&this->super, host);
-   return &this->super;
+   return (Process*)this;
 }
 
 void Process_delete(Object* cast) {

--- a/netbsd/NetBSDProcess.c
+++ b/netbsd/NetBSDProcess.c
@@ -219,7 +219,7 @@ Process* NetBSDProcess_new(const Machine* host) {
    NetBSDProcess* this = xCalloc(1, sizeof(NetBSDProcess));
    Object_setClass(this, Class(NetBSDProcess));
    Process_init(&this->super, host);
-   return &this->super;
+   return (Process*)this;
 }
 
 void Process_delete(Object* cast) {

--- a/openbsd/OpenBSDProcess.c
+++ b/openbsd/OpenBSDProcess.c
@@ -211,7 +211,7 @@ Process* OpenBSDProcess_new(const Machine* host) {
    OpenBSDProcess* this = xCalloc(1, sizeof(OpenBSDProcess));
    Object_setClass(this, Class(OpenBSDProcess));
    Process_init(&this->super, host);
-   return &this->super;
+   return (Process*)this;
 }
 
 void Process_delete(Object* cast) {

--- a/pcp/PCPProcess.c
+++ b/pcp/PCPProcess.c
@@ -97,7 +97,7 @@ Process* PCPProcess_new(const Machine* host) {
    PCPProcess* this = xCalloc(1, sizeof(PCPProcess));
    Object_setClass(this, Class(PCPProcess));
    Process_init(&this->super, host);
-   return &this->super;
+   return (Process*)this;
 }
 
 void Process_delete(Object* cast) {

--- a/solaris/SolarisProcess.c
+++ b/solaris/SolarisProcess.c
@@ -64,7 +64,7 @@ Process* SolarisProcess_new(const Machine* host) {
    SolarisProcess* this = xCalloc(1, sizeof(SolarisProcess));
    Object_setClass(this, Class(SolarisProcess));
    Process_init(&this->super, host);
-   return &this->super;
+   return (Process*)this;
 }
 
 void Process_delete(Object* cast) {


### PR DESCRIPTION
While both pointers are identical, GCC-14 with `-fanalyzer` complains about these return statements to leak memory. The leak is only reported with LTO though.

The reported "memory leak" on Linux looks as follows:

```
linux/LinuxProcess.c: In function ‘LinuxProcess_new’:
linux/LinuxProcess.c:121:11: warning: leak of ‘<unknown>’ [CWE-401] [-Wanalyzer-malloc-leak]
  121 |    return &this->super;
      |           ^
  ‘ProcessTable_goThroughEntries’: events 1-2
    |
    |linux/LinuxProcessTable.c:1740:6:
    | 1740 | void ProcessTable_goThroughEntries(ProcessTable* super) {
    |      |      ^
    |      |      |
    |      |      (1) entry to ‘ProcessTable_goThroughEntries’
    |......
    | 1775 |    LinuxProcessTable_recurseProcTree(this, rootFd, lhost, PROCDIR, NULL);
    |      |    ~  
    |      |    |
    |      |    (2) calling ‘LinuxProcessTable_recurseProcTree’ from ‘ProcessTable_goThroughEntries’
    |
    +--> ‘LinuxProcessTable_recurseProcTree’: events 3-17
           |
           | 1378 | static bool LinuxProcessTable_recurseProcTree(LinuxProcessTable* this, openat_arg_t parentFd, const LinuxMachine* lhost, const char* dirname, const LinuxProcess* mainTask) {
           |      |             ^
           |      |             |
           |      |             (3) entry to ‘LinuxProcessTable_recurseProcTree’
           |......
           | 1390 |    if (dirFd < 0)
           |      |       ~      
           |      |       |
           |      |       (4) following ‘false’ branch...
           | 1391 |       return false;
           | 1392 |    DIR* dir = fdopendir(dirFd);
           |      |               ~
           |      |               |
           |      |               (5) ...to here
           |......
           | 1398 |    if (!dir) {
           |      |       ~      
           |      |       |
           |      |       (6) following ‘false’ branch (when ‘dir_202’ is non-NULL)...
           |......
           | 1403 |    const bool hideKernelThreads = settings->hideKernelThreads;
           |      |               ~
           |      |               |
           |      |               (7) ...to here
           |......
           | 1406 |    while ((entry = readdir(dir)) != NULL) {
           |      |                                  ~
           |      |                                  |
           |      |                                  (8) following ‘true’ branch (when ‘entry_207’ is non-NULL)...
           | 1407 |       const char* name = entry->d_name;
           |      |                   ~
           |      |                   |
           |      |                   (9) ...to here
           |......
           | 1410 |       if (entry->d_type != DT_DIR && entry->d_type != DT_UNKNOWN) {
           |      |          ~   
           |      |          |
           |      |          (10) following ‘false’ branch...
           |......
           | 1416 |       if (name[0] == '.') {
           |      |               ~
           |      |               |
           |      |               (11) ...to here
           |......
           | 1421 |       if (name[0] < '0' || name[0] > '9') {
           |      |          ~   
           |      |          |
           |      |          (12) following ‘false’ branch...
           |......
           | 1429 |          unsigned long parsedPid = strtoul(name, &endptr, 10);
           |      |                                    ~
           |      |                                    |
           |      |                                    (13) ...to here
           | 1430 |          if (parsedPid == 0 || parsedPid == ULONG_MAX || *endptr != '\0')
           |      |             ~
           |      |             |
           |      |             (14) following ‘false’ branch...
           | 1431 |             continue;
           | 1432 |          pid = parsedPid;
           |      |              ~
           |      |              |
           |      |              (15) ...to here
           |......
           | 1436 |       if (mainTask && pid == Process_getPid(&mainTask->super))
           |      |          ~   
           |      |          |
           |      |          (16) following ‘false’ branch (when ‘mainTask_215(D)’ is NULL)...
           |......
           | 1440 |       int procFd = openat(dirFd, entry->d_name, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
           |      |                    ~
           |      |                    |
           |      |                    (17) inlined call to ‘openat’ from ‘LinuxProcessTable_recurseProcTree’
           |
           +--> ‘openat’: event 18
                  |
                  |/usr/include/x86_64-linux-gnu/bits/fcntl2.h:129:14:
                  |  129 |       return __openat_alias (__fd, __path, __oflag, __va_arg_pack ());
                  |      |              ^
                  |      |              |
                  |      |              (18) ...to here
                  |
           <------+
           |
         ‘LinuxProcessTable_recurseProcTree’: events 19-21
           |
           |linux/LinuxProcessTable.c:1441:10:
           | 1441 |       if (procFd < 0)
           |      |          ^
           |      |          |
           |      |          (19) following ‘false’ branch...
           |......
           | 1449 |       Process* proc = ProcessTable_getProcess(pt, pid, &preExisting, LinuxProcess_new);
           |      |                       ~
           |      |                       |
           |      |                       (20) ...to here
           |      |                       (21) calling ‘ProcessTable_getProcess’ from ‘LinuxProcessTable_recurseProcTree’
           |
           +--> ‘ProcessTable_getProcess’: events 22-23
                  |
                  |ProcessTable.c:31:10:
                  |   31 | Process* ProcessTable_getProcess(ProcessTable* this, pid_t pid, bool* preExisting, Process_New constructor) {
                  |      |          ^
                  |      |          |
                  |      |          (22) entry to ‘ProcessTable_getProcess’
                  |......
                  |   35 |    if (proc) {
                  |      |       ~   
                  |      |       |
                  |      |       (23) following ‘false’ branch (when ‘proc_10’ is NULL)...
                  |
                ‘ProcessTable_getProcess’: event 24
                  |
                  |lto1:
                  | (24): ...to here
                  |
                ‘ProcessTable_getProcess’: event 25
                  |
                  |lto1:
                  | (25): calling ‘ProcessTable_getProcess.part.0’ from ‘ProcessTable_getProcess’
                  |
                  +--> ‘ProcessTable_getProcess.part.0’: events 26-27
                         |
                         |   31 | Process* ProcessTable_getProcess(ProcessTable* this, pid_t pid, bool* preExisting, Process_New constructor) {
                         |      |          ^
                         |      |          |
                         |      |          (26) entry to ‘ProcessTable_getProcess.part.0’
                         |......
                         |   39 |       proc = constructor(table->host);
                         |      |              ~
                         |      |              |
                         |      |              (27) calling ‘LinuxProcess_new’ from ‘ProcessTable_getProcess.part.0’
                         |
                         +--> ‘LinuxProcess_new’: events 28-29
                                |
                                |linux/LinuxProcess.c:117:10:
                                |  117 | Process* LinuxProcess_new(const Machine* host) {
                                |      |          ^
                                |      |          |
                                |      |          (28) entry to ‘LinuxProcess_new’
                                |  118 |    LinuxProcess* this = xCalloc(1, sizeof(LinuxProcess));
                                |      |                         ~
                                |      |                         |
                                |      |                         (29) calling ‘xCalloc’ from ‘LinuxProcess_new’
                                |
                                +--> ‘xCalloc’: events 30-36
                                       |
                                       |XUtils.c:51:7:
                                       |   51 | void* xCalloc(size_t nmemb, size_t size) {
                                       |      |       ^
                                       |      |       |
                                       |      |       (30) entry to ‘xCalloc’
                                       |......
                                       |   54 |    if (SIZE_MAX / nmemb < size) {
                                       |      |       ~
                                       |      |       |
                                       |      |       (31) following ‘false’ branch...
                                       |......
                                       |   57 |    void* data = calloc(nmemb, size);
                                       |      |                 ~
                                       |      |                 |
                                       |      |                 (32) ...to here
                                       |      |                 (33) allocated here
                                       |   58 |    if (!data) {
                                       |      |       ~
                                       |      |       |
                                       |      |       (34) assuming ‘data_7’ is non-NULL
                                       |      |       (35) following ‘false’ branch (when ‘data_7’ is non-NULL)...
                                       |......
                                       |   61 |    return data;
                                       |      |           ~
                                       |      |           |
                                       |      |           (36) ...to here
                                       |
                                <------+
                                |
                              ‘LinuxProcess_new’: events 37-38
                                |
                                |linux/LinuxProcess.c:118:25:
                                |  118 |    LinuxProcess* this = xCalloc(1, sizeof(LinuxProcess));
                                |      |                         ^
                                |      |                         |
                                |      |                         (37) returning to ‘LinuxProcess_new’ from ‘xCalloc’
                                |......
                                |  121 |    return &this->super;
                                |      |           ~              
                                |      |           |
                                |      |           (38) ‘<unknown>’ leaks here; was allocated at (33)
                                |
```