### PR TITLE
darwin: Fix memory metrics support for Apple Silicon (ARM64)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -330,6 +330,10 @@ if test "$my_htop_platform" = darwin; then
    AC_CHECK_FUNCS([mach_timebase_info])
    AC_CHECK_DECLS([IOMainPort], [], [], [[#include <IOKit/IOKitLib.h>]])
    AC_CHECK_DECLS([IOMasterPort], [], [], [[#include <IOKit/IOKitLib.h>]])
+
+   AC_CHECK_FUNCS([host_statistics64], [
+      AC_CHECK_TYPES([struct vm_statistics64], [], [], [[#include <mach/vm_statistics.h>]])
+   ], [])
 fi
 
 if test "$my_htop_platform" = pcp; then

--- a/darwin/DarwinMachine.c
+++ b/darwin/DarwinMachine.c
@@ -59,12 +59,20 @@ static unsigned DarwinMachine_allocateCPULoadInfo(processor_cpu_load_info_t* p) 
    return cpu_count;
 }
 
-static void DarwinMachine_getVMStats(vm_statistics_t p) {
+static void DarwinMachine_getVMStats(DarwinMachine* this) {
+#ifdef HAVE_STRUCT_VM_STATISTICS64
+   mach_msg_type_number_t info_size = HOST_VM_INFO64_COUNT;
+
+   if (host_statistics64(mach_host_self(), HOST_VM_INFO64, (host_info_t)&this->vm_stats, &info_size) != 0) {
+      CRT_fatalError("Unable to retrieve VM statistics64");
+   }
+#else
    mach_msg_type_number_t info_size = HOST_VM_INFO_COUNT;
 
-   if (host_statistics(mach_host_self(), HOST_VM_INFO, (host_info_t)p, &info_size) != 0) {
+   if (host_statistics(mach_host_self(), HOST_VM_INFO, (host_info_t)&this->vm_stats, &info_size) != 0) {
       CRT_fatalError("Unable to retrieve VM statistics");
    }
+#endif
 }
 
 void Machine_scan(Machine* super) {
@@ -74,7 +82,7 @@ void Machine_scan(Machine* super) {
    DarwinMachine_freeCPULoadInfo(&host->prev_load);
    host->prev_load = host->curr_load;
    DarwinMachine_allocateCPULoadInfo(&host->curr_load);
-   DarwinMachine_getVMStats(&host->vm_stats);
+   DarwinMachine_getVMStats(host);
    openzfs_sysctl_updateArcStats(&host->zfs);
 }
 
@@ -91,7 +99,7 @@ Machine* Machine_new(UsersTable* usersTable, uid_t userId) {
    DarwinMachine_allocateCPULoadInfo(&this->curr_load);
 
    /* Initialize the VM statistics */
-   DarwinMachine_getVMStats(&this->vm_stats);
+   DarwinMachine_getVMStats(this);
 
    /* Initialize the ZFS kstats, if zfs.kext loaded */
    openzfs_sysctl_init(&this->zfs);

--- a/darwin/DarwinMachine.h
+++ b/darwin/DarwinMachine.h
@@ -18,7 +18,11 @@ typedef struct DarwinMachine_ {
    Machine super;
 
    host_basic_info_data_t host_info;
+#ifdef HAVE_STRUCT_VM_STATISTICS64
+   vm_statistics64_data_t vm_stats;
+#else
    vm_statistics_data_t vm_stats;
+#endif
    processor_cpu_load_info_t prev_load;
    processor_cpu_load_info_t curr_load;
 

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -292,13 +292,28 @@ double Platform_setCPUValues(Meter* mtr, unsigned int cpu) {
 
 void Platform_setMemoryValues(Meter* mtr) {
    const DarwinMachine* dhost = (const DarwinMachine*) mtr->host;
+#ifdef HAVE_STRUCT_VM_STATISTICS64
+   const struct vm_statistics64* vm = &dhost->vm_stats;
+#else
    const struct vm_statistics* vm = &dhost->vm_stats;
+#endif
    double page_K = (double)vm_page_size / (double)1024;
 
    mtr->total = dhost->host_info.max_mem / 1024;
+#ifdef HAVE_STRUCT_VM_STATISTICS64
+   natural_t used = vm->active_count + vm->inactive_count +
+              vm->speculative_count + vm->wire_count +
+              vm->compressor_page_count - vm->purgeable_count - vm->external_page_count;
+   mtr->values[MEMORY_METER_USED] = (double)(used - vm->compressor_page_count) * page_K;
+#else
    mtr->values[MEMORY_METER_USED] = (double)(vm->active_count + vm->wire_count) * page_K;
+#endif
    // mtr->values[MEMORY_METER_SHARED] = "shared memory, like tmpfs and shm"
+#ifdef HAVE_STRUCT_VM_STATISTICS64
+   mtr->values[MEMORY_METER_COMPRESSED] = (double)vm->compressor_page_count * page_K;
+#else
    // mtr->values[MEMORY_METER_COMPRESSED] = "compressed memory, like zswap on linux"
+#endif
    mtr->values[MEMORY_METER_BUFFERS] = (double)vm->purgeable_count * page_K;
    mtr->values[MEMORY_METER_CACHE] = (double)vm->inactive_count * page_K;
    // mtr->values[MEMORY_METER_AVAILABLE] = "available memory"


### PR DESCRIPTION
Fix memory metrics of Apple Silicon (ARM64)
Detailed description: https://github.com/htop-dev/htop/issues/631

The calculation of memory refers to [exelban/stats Modules/RAM/readers.swift](
https://github.com/exelban/stats/blob/c78319bdecdf56a73b8edfd791f727a3c1c1451c/Modules/RAM/readers.swift#L56)
```
let used = active + inactive + speculative + wired + compressed - purgeable - external
```

