### PR TITLE
'FILE*' and 'struct stat' variable rename. No code changes.

### DIFF
--- a/Compat.c
+++ b/Compat.c
@@ -50,11 +50,11 @@ int Compat_faccessat(int dirfd,
    }
 
    // Fallback to stat(2)/lstat(2) depending on flags
-   struct stat statinfo;
+   struct stat sb;
    if (flags) {
-      ret = lstat(pathname, &statinfo);
+      ret = lstat(pathname, &sb);
    } else {
-      ret = stat(pathname, &statinfo);
+      ret = stat(pathname, &sb);
    }
 
    return ret;

--- a/OpenFilesScreen.c
+++ b/OpenFilesScreen.c
@@ -238,10 +238,10 @@ static OpenFiles_ProcessData* OpenFilesScreen_getProcessData(pid_t pid) {
       item = &fdata->data;
       const char* filename = getDataForType(item, 'n');
 
-      struct stat st;
-      if (stat(filename, &st) == 0) {
+      struct stat sb;
+      if (stat(filename, &sb) == 0) {
          char fileSizeBuf[21]; /* 20 (long long) + 1 (NULL) */
-         xSnprintf(fileSizeBuf, sizeof(fileSizeBuf), "%"PRIu64, (uint64_t)st.st_size); /* st.st_size is long long on macOS, long on linux */
+         xSnprintf(fileSizeBuf, sizeof(fileSizeBuf), "%"PRIu64, (uint64_t)sb.st_size); /* sb.st_size is long long on macOS, long on linux */
          free_and_xStrdup(&item->data[fileSizeIndex], fileSizeBuf);
       }
    }

--- a/OpenFilesScreen.c
+++ b/OpenFilesScreen.c
@@ -138,13 +138,13 @@ static OpenFiles_ProcessData* OpenFilesScreen_getProcessData(pid_t pid) {
    OpenFiles_FileData* fdata = NULL;
    bool lsofIncludesFileSize = false;
 
-   FILE* fd = fdopen(fdpair[0], "r");
-   if (!fd) {
+   FILE* fp = fdopen(fdpair[0], "r");
+   if (!fp) {
       pdata->error = 1;
       return pdata;
    }
    for (;;) {
-      char* line = String_readLine(fd);
+      char* line = String_readLine(fp);
       if (!line) {
          break;
       }
@@ -212,7 +212,7 @@ static OpenFiles_ProcessData* OpenFilesScreen_getProcessData(pid_t pid) {
 
       free(line);
    }
-   fclose(fd);
+   fclose(fp);
 
    int wstatus;
    while (waitpid(child, &wstatus, 0) == -1)

--- a/TraceScreen.c
+++ b/TraceScreen.c
@@ -113,14 +113,14 @@ bool TraceScreen_forkTracer(TraceScreen* this) {
       exit(127);
    }
 
-   FILE* fd = fdopen(fdpair[0], "r");
-   if (!fd)
+   FILE* fp = fdopen(fdpair[0], "r");
+   if (!fp)
       goto err;
 
    close(fdpair[1]);
 
    this->child = child;
-   this->strace = fd;
+   this->strace = fp;
    return true;
 
 err:

--- a/XUtils.c
+++ b/XUtils.c
@@ -186,13 +186,13 @@ void String_freeArray(char** s) {
    free(s);
 }
 
-char* String_readLine(FILE* fd) {
+char* String_readLine(FILE* fp) {
    const size_t step = 1024;
    size_t bufSize = step;
    char* buffer = xMalloc(step + 1);
    char* at = buffer;
    for (;;) {
-      const char* ok = fgets(at, step + 1, fd);
+      const char* ok = fgets(at, step + 1, fp);
       if (!ok) {
          free(buffer);
          return NULL;
@@ -202,7 +202,7 @@ char* String_readLine(FILE* fd) {
          *newLine = '\0';
          return buffer;
       } else {
-         if (feof(fd)) {
+         if (feof(fp)) {
             return buffer;
          }
       }

--- a/XUtils.h
+++ b/XUtils.h
@@ -76,7 +76,7 @@ char** String_split(const char* s, char sep, size_t* n);
 void String_freeArray(char** s);
 
 ATTR_NONNULL
-char* String_readLine(FILE* fd) ATTR_MALLOC;
+char* String_readLine(FILE* fp) ATTR_MALLOC;
 
 ATTR_NONNULL
 static inline char* String_strchrnul(const char* s, int c) {

--- a/generic/uname.c
+++ b/generic/uname.c
@@ -26,8 +26,8 @@ in the source distribution for its full text.
 #endif
 
 static void parseOSRelease(char* buffer, size_t bufferLen) {
-   FILE* stream = fopen(OSRELEASEFILE, "r");
-   if (!stream) {
+   FILE* fp = fopen(OSRELEASEFILE, "r");
+   if (!fp) {
       xSnprintf(buffer, bufferLen, "No OS Release");
       return;
    }
@@ -35,14 +35,14 @@ static void parseOSRelease(char* buffer, size_t bufferLen) {
    char name[64] = {'\0'};
    char version[64] = {'\0'};
    char lineBuffer[256];
-   while (fgets(lineBuffer, sizeof(lineBuffer), stream)) {
+   while (fgets(lineBuffer, sizeof(lineBuffer), fp)) {
       if (String_startsWith(lineBuffer, "PRETTY_NAME=\"")) {
          const char* start = lineBuffer + strlen("PRETTY_NAME=\"");
          const char* stop = strrchr(lineBuffer, '"');
          if (!stop || stop <= start)
             continue;
          String_safeStrncpy(buffer, start, MINIMUM(bufferLen, (size_t)(stop - start + 1)));
-         fclose(stream);
+         fclose(fp);
          return;
       }
       if (String_startsWith(lineBuffer, "NAME=\"")) {
@@ -62,7 +62,7 @@ static void parseOSRelease(char* buffer, size_t bufferLen) {
          continue;
       }
    }
-   fclose(stream);
+   fclose(fp);
 
    snprintf(buffer, bufferLen, "%s%s%s", name[0] ? name : "", name[0] && version[0] ? " " : "", version);
 }

--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -490,18 +490,18 @@ static bool LinuxProcessTable_updateUser(const Machine* host, Process* process, 
       return true;
    }
 
-   struct stat sstat;
+   struct stat sb;
 #ifdef HAVE_OPENAT
-   int statok = fstat(procFd, &sstat);
+   int statok = fstat(procFd, &sb);
 #else
-   int statok = stat(procFd, &sstat);
+   int statok = stat(procFd, &sb);
 #endif
    if (statok == -1)
       return false;
 
-   if (process->st_uid != sstat.st_uid) {
-      process->st_uid = sstat.st_uid;
-      process->user = UsersTable_getRef(host->usersTable, sstat.st_uid);
+   if (process->st_uid != sb.st_uid) {
+      process->st_uid = sb.st_uid;
+      process->user = UsersTable_getRef(host->usersTable, sb.st_uid);
    }
 
    return true;
@@ -1349,19 +1349,19 @@ static char* LinuxProcessTable_updateTtyDevice(TtyDriver* ttyDrivers, unsigned l
          continue;
       }
       unsigned int idx = min - ttyDrivers[i].minorFrom;
-      struct stat sstat;
+      struct stat sb;
       char* fullPath;
       for (;;) {
          xAsprintf(&fullPath, "%s/%d", ttyDrivers[i].path, idx);
-         int err = stat(fullPath, &sstat);
-         if (err == 0 && major(sstat.st_rdev) == maj && minor(sstat.st_rdev) == min) {
+         int err = stat(fullPath, &sb);
+         if (err == 0 && major(sb.st_rdev) == maj && minor(sb.st_rdev) == min) {
             return fullPath;
          }
          free(fullPath);
 
          xAsprintf(&fullPath, "%s%d", ttyDrivers[i].path, idx);
-         err = stat(fullPath, &sstat);
-         if (err == 0 && major(sstat.st_rdev) == maj && minor(sstat.st_rdev) == min) {
+         err = stat(fullPath, &sb);
+         if (err == 0 && major(sb.st_rdev) == maj && minor(sb.st_rdev) == min) {
             return fullPath;
          }
          free(fullPath);
@@ -1372,8 +1372,8 @@ static char* LinuxProcessTable_updateTtyDevice(TtyDriver* ttyDrivers, unsigned l
 
          idx = min;
       }
-      int err = stat(ttyDrivers[i].path, &sstat);
-      if (err == 0 && tty_nr == sstat.st_rdev) {
+      int err = stat(ttyDrivers[i].path, &sb);
+      if (err == 0 && tty_nr == sb.st_rdev) {
          return xStrdup(ttyDrivers[i].path);
       }
    }

--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -71,11 +71,11 @@ static FILE* fopenat(openat_arg_t openatArg, const char* pathname, const char* m
    if (fd < 0)
       return NULL;
 
-   FILE* stream = fdopen(fd, mode);
-   if (!stream)
+   FILE* fp = fdopen(fd, mode);
+   if (!fp)
       close(fd);
 
-   return stream;
+   return fp;
 }
 
 static inline uint64_t fast_strtoull_dec(char** str, int maxlen) {
@@ -755,8 +755,8 @@ static bool LinuxProcessTable_readStatmFile(LinuxProcess* process, openat_arg_t 
 static bool LinuxProcessTable_readSmapsFile(LinuxProcess* process, openat_arg_t procFd, bool haveSmapsRollup) {
    //http://elixir.free-electrons.com/linux/v4.10/source/fs/proc/task_mmu.c#L719
    //kernel will return data in chunks of size PAGE_SIZE or less.
-   FILE* f = fopenat(procFd, haveSmapsRollup ? "smaps_rollup" : "smaps", "r");
-   if (!f)
+   FILE* fp = fopenat(procFd, haveSmapsRollup ? "smaps_rollup" : "smaps", "r");
+   if (!fp)
       return false;
 
    process->m_pss   = 0;
@@ -764,10 +764,10 @@ static bool LinuxProcessTable_readSmapsFile(LinuxProcess* process, openat_arg_t 
    process->m_psswp = 0;
 
    char buffer[256];
-   while (fgets(buffer, sizeof(buffer), f)) {
+   while (fgets(buffer, sizeof(buffer), fp)) {
       if (!strchr(buffer, '\n')) {
          // Partial line, skip to end of this line
-         while (fgets(buffer, sizeof(buffer), f)) {
+         while (fgets(buffer, sizeof(buffer), fp)) {
             if (strchr(buffer, '\n')) {
                break;
             }
@@ -784,7 +784,7 @@ static bool LinuxProcessTable_readSmapsFile(LinuxProcess* process, openat_arg_t 
       }
    }
 
-   fclose(f);
+   fclose(fp);
    return true;
 }
 


### PR DESCRIPTION
Rename local `FILE*` and `struct stat` variables to make the naming consistent throughout htop codebase.