### PR TITLE
Prevent a memory leak when legacy config file exists

### DIFF
--- a/Settings.c
+++ b/Settings.c
@@ -815,11 +815,12 @@ Settings* Settings_new(unsigned int initialCpuCount, Hashtable* dynamicMeters, H
          configDir = String_cat(home, "/.config");
          htopDir = String_cat(home, "/.config/htop");
       }
-      legacyDotfile = String_cat(home, "/.htoprc");
       (void) mkdir(configDir, 0700);
       (void) mkdir(htopDir, 0700);
       free(htopDir);
       free(configDir);
+
+      legacyDotfile = String_cat(home, "/.htoprc");
       struct stat st;
       int err = lstat(legacyDotfile, &st);
       if (err || S_ISLNK(st.st_mode)) {
@@ -838,6 +839,7 @@ Settings* Settings_new(unsigned int initialCpuCount, Hashtable* dynamicMeters, H
 #endif
    this->changed = false;
    this->delay = DEFAULT_DELAY;
+
    bool ok = Settings_read(this, this->filename, initialCpuCount);
    if (!ok && legacyDotfile) {
       ok = Settings_read(this, legacyDotfile, initialCpuCount);
@@ -847,8 +849,9 @@ Settings* Settings_new(unsigned int initialCpuCount, Hashtable* dynamicMeters, H
             unlink(legacyDotfile);
          }
       }
-      free(legacyDotfile);
    }
+   free(legacyDotfile);
+
    if (!ok) {
       this->screenTabs = true;
       this->changed = true;


### PR DESCRIPTION
(This supercedes pull request #1450)

Fix a regression caused by 15b4bc45b2b0ccf2d93164b2b1b05fb94cc89220

Resolves: #1449