### PR TITLE
Meter mode code refactor

### DIFF
--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -253,7 +253,7 @@ static void CPUMeterCommonInit(Meter* this) {
    }
 }
 
-static void CPUMeterCommonUpdateMode(Meter* this, int mode, int ncol) {
+static void CPUMeterCommonUpdateMode(Meter* this, MeterModeId mode, int ncol) {
    CPUMeterData* data = this->meterData;
    Meter** meters = data->meters;
    this->mode = mode;
@@ -278,19 +278,19 @@ static void AllCPUsMeter_done(Meter* this) {
    free(data);
 }
 
-static void SingleColCPUsMeter_updateMode(Meter* this, int mode) {
+static void SingleColCPUsMeter_updateMode(Meter* this, MeterModeId mode) {
    CPUMeterCommonUpdateMode(this, mode, 1);
 }
 
-static void DualColCPUsMeter_updateMode(Meter* this, int mode) {
+static void DualColCPUsMeter_updateMode(Meter* this, MeterModeId mode) {
    CPUMeterCommonUpdateMode(this, mode, 2);
 }
 
-static void QuadColCPUsMeter_updateMode(Meter* this, int mode) {
+static void QuadColCPUsMeter_updateMode(Meter* this, MeterModeId mode) {
    CPUMeterCommonUpdateMode(this, mode, 4);
 }
 
-static void OctoColCPUsMeter_updateMode(Meter* this, int mode) {
+static void OctoColCPUsMeter_updateMode(Meter* this, MeterModeId mode) {
    CPUMeterCommonUpdateMode(this, mode, 8);
 }
 

--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -9,6 +9,7 @@ in the source distribution for its full text.
 
 #include "CPUMeter.h"
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -256,12 +257,13 @@ static void CPUMeterCommonUpdateMode(Meter* this, int mode, int ncol) {
    CPUMeterData* data = this->meterData;
    Meter** meters = data->meters;
    this->mode = mode;
-   int h = Meter_modes[mode]->h;
    int start, count;
    AllCPUsMeter_getRange(this, &start, &count);
    for (int i = 0; i < count; i++) {
       Meter_setMode(meters[i], mode);
    }
+   int h = meters[0]->h;
+   assert(h > 0);
    this->h = h * ((count + ncol - 1) / ncol);
 }
 

--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -233,7 +233,7 @@ static void AllCPUsMeter_updateValues(Meter* this) {
       Meter_updateValues(meters[i]);
 }
 
-static void CPUMeterCommonInit(Meter* this, int ncol) {
+static void CPUMeterCommonInit(Meter* this) {
    unsigned int cpus = this->host->existingCPUs;
    CPUMeterData* data = this->meterData;
    if (!data) {
@@ -250,14 +250,6 @@ static void CPUMeterCommonInit(Meter* this, int ncol) {
 
       Meter_init(meters[i]);
    }
-
-   if (this->mode == 0) {
-      this->mode = BAR_METERMODE;
-      this->draw = Meter_drawFn(this);
-   }
-
-   int h = Meter_modes[this->mode]->h;
-   this->h = h * ((count + ncol - 1) / ncol);
 }
 
 static void CPUMeterCommonUpdateMode(Meter* this, int mode, int ncol) {
@@ -284,32 +276,16 @@ static void AllCPUsMeter_done(Meter* this) {
    free(data);
 }
 
-static void SingleColCPUsMeter_init(Meter* this) {
-   CPUMeterCommonInit(this, 1);
-}
-
 static void SingleColCPUsMeter_updateMode(Meter* this, int mode) {
    CPUMeterCommonUpdateMode(this, mode, 1);
-}
-
-static void DualColCPUsMeter_init(Meter* this) {
-   CPUMeterCommonInit(this, 2);
 }
 
 static void DualColCPUsMeter_updateMode(Meter* this, int mode) {
    CPUMeterCommonUpdateMode(this, mode, 2);
 }
 
-static void QuadColCPUsMeter_init(Meter* this) {
-   CPUMeterCommonInit(this, 4);
-}
-
 static void QuadColCPUsMeter_updateMode(Meter* this, int mode) {
    CPUMeterCommonUpdateMode(this, mode, 4);
-}
-
-static void OctoColCPUsMeter_init(Meter* this) {
-   CPUMeterCommonInit(this, 8);
 }
 
 static void OctoColCPUsMeter_updateMode(Meter* this, int mode) {
@@ -390,7 +366,7 @@ const MeterClass AllCPUsMeter_class = {
    .description = "CPUs (1/1): all CPUs",
    .caption = "CPU",
    .draw = SingleColCPUsMeter_draw,
-   .init = SingleColCPUsMeter_init,
+   .init = CPUMeterCommonInit,
    .updateMode = SingleColCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
@@ -411,7 +387,7 @@ const MeterClass AllCPUs2Meter_class = {
    .description = "CPUs (1&2/2): all CPUs in 2 shorter columns",
    .caption = "CPU",
    .draw = DualColCPUsMeter_draw,
-   .init = DualColCPUsMeter_init,
+   .init = CPUMeterCommonInit,
    .updateMode = DualColCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
@@ -432,7 +408,7 @@ const MeterClass LeftCPUsMeter_class = {
    .description = "CPUs (1/2): first half of list",
    .caption = "CPU",
    .draw = SingleColCPUsMeter_draw,
-   .init = SingleColCPUsMeter_init,
+   .init = CPUMeterCommonInit,
    .updateMode = SingleColCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
@@ -453,7 +429,7 @@ const MeterClass RightCPUsMeter_class = {
    .description = "CPUs (2/2): second half of list",
    .caption = "CPU",
    .draw = SingleColCPUsMeter_draw,
-   .init = SingleColCPUsMeter_init,
+   .init = CPUMeterCommonInit,
    .updateMode = SingleColCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
@@ -474,7 +450,7 @@ const MeterClass LeftCPUs2Meter_class = {
    .description = "CPUs (1&2/4): first half in 2 shorter columns",
    .caption = "CPU",
    .draw = DualColCPUsMeter_draw,
-   .init = DualColCPUsMeter_init,
+   .init = CPUMeterCommonInit,
    .updateMode = DualColCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
@@ -495,7 +471,7 @@ const MeterClass RightCPUs2Meter_class = {
    .description = "CPUs (3&4/4): second half in 2 shorter columns",
    .caption = "CPU",
    .draw = DualColCPUsMeter_draw,
-   .init = DualColCPUsMeter_init,
+   .init = CPUMeterCommonInit,
    .updateMode = DualColCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
@@ -516,7 +492,7 @@ const MeterClass AllCPUs4Meter_class = {
    .description = "CPUs (1&2&3&4/4): all CPUs in 4 shorter columns",
    .caption = "CPU",
    .draw = QuadColCPUsMeter_draw,
-   .init = QuadColCPUsMeter_init,
+   .init = CPUMeterCommonInit,
    .updateMode = QuadColCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
@@ -537,7 +513,7 @@ const MeterClass LeftCPUs4Meter_class = {
    .description = "CPUs (1-4/8): first half in 4 shorter columns",
    .caption = "CPU",
    .draw = QuadColCPUsMeter_draw,
-   .init = QuadColCPUsMeter_init,
+   .init = CPUMeterCommonInit,
    .updateMode = QuadColCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
@@ -558,7 +534,7 @@ const MeterClass RightCPUs4Meter_class = {
    .description = "CPUs (5-8/8): second half in 4 shorter columns",
    .caption = "CPU",
    .draw = QuadColCPUsMeter_draw,
-   .init = QuadColCPUsMeter_init,
+   .init = CPUMeterCommonInit,
    .updateMode = QuadColCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
@@ -579,7 +555,7 @@ const MeterClass AllCPUs8Meter_class = {
    .description = "CPUs (1-8/8): all CPUs in 8 shorter columns",
    .caption = "CPU",
    .draw = OctoColCPUsMeter_draw,
-   .init = OctoColCPUsMeter_init,
+   .init = CPUMeterCommonInit,
    .updateMode = OctoColCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
@@ -600,7 +576,7 @@ const MeterClass LeftCPUs8Meter_class = {
    .description = "CPUs (1-8/16): first half in 8 shorter columns",
    .caption = "CPU",
    .draw = OctoColCPUsMeter_draw,
-   .init = OctoColCPUsMeter_init,
+   .init = CPUMeterCommonInit,
    .updateMode = OctoColCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
@@ -621,7 +597,7 @@ const MeterClass RightCPUs8Meter_class = {
    .description = "CPUs (9-16/16): second half in 8 shorter columns",
    .caption = "CPU",
    .draw = OctoColCPUsMeter_draw,
-   .init = OctoColCPUsMeter_init,
+   .init = CPUMeterCommonInit,
    .updateMode = OctoColCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };

--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -251,8 +251,10 @@ static void CPUMeterCommonInit(Meter* this, int ncol) {
       Meter_init(meters[i]);
    }
 
-   if (this->mode == 0)
+   if (this->mode == 0) {
       this->mode = BAR_METERMODE;
+      this->draw = Meter_drawFn(this);
+   }
 
    int h = Meter_modes[this->mode]->h;
    this->h = h * ((count + ncol - 1) / ncol);
@@ -380,7 +382,7 @@ const MeterClass AllCPUsMeter_class = {
       .display = CPUMeter_display
    },
    .updateValues = AllCPUsMeter_updateValues,
-   .defaultMode = CUSTOM_METERMODE,
+   .defaultMode = BAR_METERMODE,
    .total = 100.0,
    .attributes = CPUMeter_attributes,
    .name = "AllCPUs",
@@ -400,7 +402,7 @@ const MeterClass AllCPUs2Meter_class = {
       .display = CPUMeter_display
    },
    .updateValues = AllCPUsMeter_updateValues,
-   .defaultMode = CUSTOM_METERMODE,
+   .defaultMode = BAR_METERMODE,
    .isMultiColumn = true,
    .total = 100.0,
    .attributes = CPUMeter_attributes,
@@ -421,7 +423,7 @@ const MeterClass LeftCPUsMeter_class = {
       .display = CPUMeter_display
    },
    .updateValues = AllCPUsMeter_updateValues,
-   .defaultMode = CUSTOM_METERMODE,
+   .defaultMode = BAR_METERMODE,
    .isMultiColumn = true,
    .total = 100.0,
    .attributes = CPUMeter_attributes,
@@ -442,7 +444,7 @@ const MeterClass RightCPUsMeter_class = {
       .display = CPUMeter_display
    },
    .updateValues = AllCPUsMeter_updateValues,
-   .defaultMode = CUSTOM_METERMODE,
+   .defaultMode = BAR_METERMODE,
    .isMultiColumn = true,
    .total = 100.0,
    .attributes = CPUMeter_attributes,
@@ -463,7 +465,7 @@ const MeterClass LeftCPUs2Meter_class = {
       .display = CPUMeter_display
    },
    .updateValues = AllCPUsMeter_updateValues,
-   .defaultMode = CUSTOM_METERMODE,
+   .defaultMode = BAR_METERMODE,
    .isMultiColumn = true,
    .total = 100.0,
    .attributes = CPUMeter_attributes,
@@ -484,7 +486,7 @@ const MeterClass RightCPUs2Meter_class = {
       .display = CPUMeter_display
    },
    .updateValues = AllCPUsMeter_updateValues,
-   .defaultMode = CUSTOM_METERMODE,
+   .defaultMode = BAR_METERMODE,
    .isMultiColumn = true,
    .total = 100.0,
    .attributes = CPUMeter_attributes,
@@ -505,7 +507,7 @@ const MeterClass AllCPUs4Meter_class = {
       .display = CPUMeter_display
    },
    .updateValues = AllCPUsMeter_updateValues,
-   .defaultMode = CUSTOM_METERMODE,
+   .defaultMode = BAR_METERMODE,
    .isMultiColumn = true,
    .total = 100.0,
    .attributes = CPUMeter_attributes,
@@ -526,7 +528,7 @@ const MeterClass LeftCPUs4Meter_class = {
       .display = CPUMeter_display
    },
    .updateValues = AllCPUsMeter_updateValues,
-   .defaultMode = CUSTOM_METERMODE,
+   .defaultMode = BAR_METERMODE,
    .isMultiColumn = true,
    .total = 100.0,
    .attributes = CPUMeter_attributes,
@@ -547,7 +549,7 @@ const MeterClass RightCPUs4Meter_class = {
       .display = CPUMeter_display
    },
    .updateValues = AllCPUsMeter_updateValues,
-   .defaultMode = CUSTOM_METERMODE,
+   .defaultMode = BAR_METERMODE,
    .isMultiColumn = true,
    .total = 100.0,
    .attributes = CPUMeter_attributes,
@@ -568,7 +570,7 @@ const MeterClass AllCPUs8Meter_class = {
       .display = CPUMeter_display
    },
    .updateValues = AllCPUsMeter_updateValues,
-   .defaultMode = CUSTOM_METERMODE,
+   .defaultMode = BAR_METERMODE,
    .isMultiColumn = true,
    .total = 100.0,
    .attributes = CPUMeter_attributes,
@@ -589,7 +591,7 @@ const MeterClass LeftCPUs8Meter_class = {
       .display = CPUMeter_display
    },
    .updateValues = AllCPUsMeter_updateValues,
-   .defaultMode = CUSTOM_METERMODE,
+   .defaultMode = BAR_METERMODE,
    .isMultiColumn = true,
    .total = 100.0,
    .attributes = CPUMeter_attributes,
@@ -610,7 +612,7 @@ const MeterClass RightCPUs8Meter_class = {
       .display = CPUMeter_display
    },
    .updateValues = AllCPUsMeter_updateValues,
-   .defaultMode = CUSTOM_METERMODE,
+   .defaultMode = BAR_METERMODE,
    .isMultiColumn = true,
    .total = 100.0,
    .attributes = CPUMeter_attributes,

--- a/Header.c
+++ b/Header.c
@@ -150,7 +150,7 @@ void Header_writeBackToSettings(const Header* this) {
       int len = Vector_size(vec);
 
       colSettings->names = len ? xCalloc(len + 1, sizeof(char*)) : NULL;
-      colSettings->modes = len ? xCalloc(len, sizeof(int)) : NULL;
+      colSettings->modes = len ? xCalloc(len, sizeof(MeterModeId)) : NULL;
       colSettings->len = len;
 
       for (int i = 0; i < len; i++) {

--- a/Header.c
+++ b/Header.c
@@ -149,8 +149,8 @@ void Header_writeBackToSettings(const Header* this) {
       const Vector* vec = this->columns[col];
       int len = Vector_size(vec);
 
-      colSettings->names = len ? xCalloc(len + 1, sizeof(char*)) : NULL;
-      colSettings->modes = len ? xCalloc(len, sizeof(MeterModeId)) : NULL;
+      colSettings->names = len ? xCalloc(len + 1, sizeof(*colSettings->names)) : NULL;
+      colSettings->modes = len ? xCalloc(len, sizeof(*colSettings->modes)) : NULL;
       colSettings->len = len;
 
       for (int i = 0; i < len; i++) {

--- a/Makefile.am
+++ b/Makefile.am
@@ -134,6 +134,7 @@ myhtopheaders = \
 	MemoryMeter.h \
 	MemorySwapMeter.h \
 	Meter.h \
+	MeterMode.h \
 	MetersPanel.h \
 	NetworkIOMeter.h \
 	Object.h \

--- a/MemorySwapMeter.c
+++ b/MemorySwapMeter.c
@@ -50,9 +50,7 @@ static void MemorySwapMeter_init(Meter* this) {
    MemorySwapMeterData* data = this->meterData;
 
    if (!data) {
-      data = this->meterData = xMalloc(sizeof(MemorySwapMeterData));
-      data->memoryMeter = NULL;
-      data->swapMeter = NULL;
+      data = this->meterData = xCalloc(1, sizeof(MemorySwapMeterData));
    }
 
    if (!data->memoryMeter)

--- a/MemorySwapMeter.c
+++ b/MemorySwapMeter.c
@@ -76,7 +76,7 @@ static void MemorySwapMeter_updateMode(Meter* this, int mode) {
    Meter_setMode(data->memoryMeter, mode);
    Meter_setMode(data->swapMeter, mode);
 
-   this->h = MAXIMUM(Meter_modes[data->memoryMeter->mode]->h, Meter_modes[data->swapMeter->mode]->h);
+   this->h = MAXIMUM(data->memoryMeter->h, data->swapMeter->h);
 }
 
 static void MemorySwapMeter_done(Meter* this) {

--- a/MemorySwapMeter.c
+++ b/MemorySwapMeter.c
@@ -68,7 +68,7 @@ static void MemorySwapMeter_init(Meter* this) {
    }
 }
 
-static void MemorySwapMeter_updateMode(Meter* this, int mode) {
+static void MemorySwapMeter_updateMode(Meter* this, MeterModeId mode) {
    MemorySwapMeterData* data = this->meterData;
 
    this->mode = mode;

--- a/MemorySwapMeter.c
+++ b/MemorySwapMeter.c
@@ -60,17 +60,12 @@ static void MemorySwapMeter_init(Meter* this) {
    if (!data->swapMeter)
       data->swapMeter = Meter_new(this->host, 0, (const MeterClass*) Class(SwapMeter));
 
-   if (Meter_initFn(data->memoryMeter))
+   if (Meter_initFn(data->memoryMeter)) {
       Meter_init(data->memoryMeter);
-   if (Meter_initFn(data->swapMeter))
-      Meter_init(data->swapMeter);
-
-   if (this->mode == 0) {
-      this->mode = BAR_METERMODE;
-      this->draw = Meter_drawFn(this);
    }
-
-   this->h = MAXIMUM(Meter_modes[data->memoryMeter->mode]->h, Meter_modes[data->swapMeter->mode]->h);
+   if (Meter_initFn(data->swapMeter)) {
+      Meter_init(data->swapMeter);
+   }
 }
 
 static void MemorySwapMeter_updateMode(Meter* this, int mode) {

--- a/MemorySwapMeter.c
+++ b/MemorySwapMeter.c
@@ -65,8 +65,10 @@ static void MemorySwapMeter_init(Meter* this) {
    if (Meter_initFn(data->swapMeter))
       Meter_init(data->swapMeter);
 
-   if (this->mode == 0)
+   if (this->mode == 0) {
       this->mode = BAR_METERMODE;
+      this->draw = Meter_drawFn(this);
+   }
 
    this->h = MAXIMUM(Meter_modes[data->memoryMeter->mode]->h, Meter_modes[data->swapMeter->mode]->h);
 }
@@ -97,7 +99,7 @@ const MeterClass MemorySwapMeter_class = {
       .delete = Meter_delete,
    },
    .updateValues = MemorySwapMeter_updateValues,
-   .defaultMode = CUSTOM_METERMODE,
+   .defaultMode = BAR_METERMODE,
    .isMultiColumn = true,
    .name = "MemorySwap",
    .uiName = "Memory & Swap",

--- a/Meter.c
+++ b/Meter.c
@@ -122,11 +122,10 @@ void Meter_setMode(Meter* this, int modeIndex) {
    }
 
    assert(modeIndex < LAST_METERMODE);
-   if (Meter_defaultMode(this) == CUSTOM_METERMODE) {
+   if (Meter_updateModeFn(this)) {
+      assert(Meter_drawFn(this));
       this->draw = Meter_drawFn(this);
-      if (Meter_updateModeFn(this)) {
-         Meter_updateMode(this, modeIndex);
-      }
+      Meter_updateMode(this, modeIndex);
    } else {
       assert(modeIndex >= 1);
       free(this->drawData.values);

--- a/Meter.c
+++ b/Meter.c
@@ -438,7 +438,7 @@ void Meter_setCaption(Meter* this, const char* caption) {
    free_and_xStrdup(&this->caption, caption);
 }
 
-void Meter_setMode(Meter* this, int modeIndex) {
+void Meter_setMode(Meter* this, MeterModeId modeIndex) {
    if (modeIndex > 0 && modeIndex == this->mode) {
       return;
    }

--- a/Meter.c
+++ b/Meter.c
@@ -26,6 +26,12 @@ in the source distribution for its full text.
 
 #define GRAPH_HEIGHT 4 /* Unit: rows (lines) */
 
+typedef struct MeterMode_ {
+   Meter_Draw draw;
+   const char* uiName;
+   int h;
+} MeterMode;
+
 /* Meter drawing modes */
 
 static inline void Meter_displayBuffer(const Meter* this, RichString* out) {
@@ -324,37 +330,32 @@ static void LEDMeterMode_draw(Meter* this, int x, int y, int w) {
    RichString_delete(&out);
 }
 
-static MeterMode BarMeterMode = {
-   .uiName = "Bar",
-   .h = 1,
-   .draw = BarMeterMode_draw,
-};
-
-static MeterMode TextMeterMode = {
-   .uiName = "Text",
-   .h = 1,
-   .draw = TextMeterMode_draw,
-};
-
-static MeterMode GraphMeterMode = {
-   .uiName = "Graph",
-   .h = GRAPH_HEIGHT,
-   .draw = GraphMeterMode_draw,
-};
-
-static MeterMode LEDMeterMode = {
-   .uiName = "LED",
-   .h = 3,
-   .draw = LEDMeterMode_draw,
-};
-
-const MeterMode* const Meter_modes[] = {
-   NULL,
-   &BarMeterMode,
-   &TextMeterMode,
-   &GraphMeterMode,
-   &LEDMeterMode,
-   NULL
+static const MeterMode Meter_modes[] = {
+   [0] = {
+      .uiName = NULL,
+      .h = 0,
+      .draw = NULL,
+   },
+   [BAR_METERMODE] = {
+      .uiName = "Bar",
+      .h = 1,
+      .draw = BarMeterMode_draw,
+   },
+   [TEXT_METERMODE] = {
+      .uiName = "Text",
+      .h = 1,
+      .draw = TextMeterMode_draw,
+   },
+   [GRAPH_METERMODE] = {
+      .uiName = "Graph",
+      .h = GRAPH_HEIGHT,
+      .draw = GraphMeterMode_draw,
+   },
+   [LED_METERMODE] = {
+      .uiName = "LED",
+      .h = 3,
+      .draw = LEDMeterMode_draw,
+   },
 };
 
 /* Meter class and methods */
@@ -457,7 +458,7 @@ void Meter_setMode(Meter* this, int modeIndex) {
       this->drawData.values = NULL;
       this->drawData.nValues = 0;
 
-      const MeterMode* mode = Meter_modes[modeIndex];
+      const MeterMode* mode = &Meter_modes[modeIndex];
       this->draw = mode->draw;
       this->h = mode->h;
    }
@@ -467,7 +468,7 @@ void Meter_setMode(Meter* this, int modeIndex) {
 ListItem* Meter_toListItem(const Meter* this, bool moving) {
    char mode[20];
    if (this->mode) {
-      xSnprintf(mode, sizeof(mode), " [%s]", Meter_modes[this->mode]->uiName);
+      xSnprintf(mode, sizeof(mode), " [%s]", Meter_modes[this->mode].uiName);
    } else {
       mode[0] = '\0';
    }

--- a/Meter.c
+++ b/Meter.c
@@ -443,7 +443,7 @@ void Meter_setMode(Meter* this, MeterModeId modeIndex) {
       return;
    }
 
-   if (!modeIndex) {
+   if (modeIndex == 0) {
       modeIndex = 1;
    }
 
@@ -467,7 +467,7 @@ void Meter_setMode(Meter* this, MeterModeId modeIndex) {
 
 ListItem* Meter_toListItem(const Meter* this, bool moving) {
    char mode[20];
-   if (this->mode) {
+   if (this->mode > 0) {
       xSnprintf(mode, sizeof(mode), " [%s]", Meter_modes[this->mode].uiName);
    } else {
       mode[0] = '\0';

--- a/Meter.h
+++ b/Meter.h
@@ -124,8 +124,8 @@ typedef struct MeterMode_ {
 } MeterMode;
 
 typedef enum {
-   CUSTOM_METERMODE = 0,
-   BAR_METERMODE,
+   /* Meter mode 0 is reserved */
+   BAR_METERMODE = 1,
    TEXT_METERMODE,
    GRAPH_METERMODE,
    LED_METERMODE,

--- a/Meter.h
+++ b/Meter.h
@@ -117,12 +117,6 @@ struct Meter_ {
    void* meterData;
 };
 
-typedef struct MeterMode_ {
-   Meter_Draw draw;
-   const char* uiName;
-   int h;
-} MeterMode;
-
 typedef enum {
    /* Meter mode 0 is reserved */
    BAR_METERMODE = 1,
@@ -154,8 +148,6 @@ void Meter_setCaption(Meter* this, const char* caption);
 void Meter_setMode(Meter* this, int modeIndex);
 
 ListItem* Meter_toListItem(const Meter* this, bool moving);
-
-extern const MeterMode* const Meter_modes[];
 
 extern const MeterClass BlankMeter_class;
 

--- a/Meter.h
+++ b/Meter.h
@@ -14,6 +14,7 @@ in the source distribution for its full text.
 
 #include "ListItem.h"
 #include "Machine.h"
+#include "MeterMode.h"
 #include "Object.h"
 
 
@@ -116,15 +117,6 @@ struct Meter_ {
    double total;
    void* meterData;
 };
-
-typedef enum {
-   /* Meter mode 0 is reserved */
-   BAR_METERMODE = 1,
-   TEXT_METERMODE,
-   GRAPH_METERMODE,
-   LED_METERMODE,
-   LAST_METERMODE
-} MeterModeId;
 
 typedef enum {
    RATESTATUS_DATA,

--- a/Meter.h
+++ b/Meter.h
@@ -87,7 +87,6 @@ typedef struct MeterClass_ {
 #define Meter_getUiName(this_,n_,l_)   As_Meter(this_)->getUiName((const Meter*)(this_),n_,l_)
 #define Meter_getCaptionFn(this_)      As_Meter(this_)->getCaption
 #define Meter_getCaption(this_)        (Meter_getCaptionFn(this_) ? As_Meter(this_)->getCaption((const Meter*)(this_)) : (this_)->caption)
-#define Meter_defaultMode(this_)       As_Meter(this_)->defaultMode
 #define Meter_attributes(this_)        As_Meter(this_)->attributes
 #define Meter_name(this_)              As_Meter(this_)->name
 #define Meter_uiName(this_)            As_Meter(this_)->uiName

--- a/Meter.h
+++ b/Meter.h
@@ -49,7 +49,7 @@ typedef struct Meter_ Meter;
 
 typedef void(*Meter_Init)(Meter*);
 typedef void(*Meter_Done)(Meter*);
-typedef void(*Meter_UpdateMode)(Meter*, int);
+typedef void(*Meter_UpdateMode)(Meter*, MeterModeId);
 typedef void(*Meter_UpdateValues)(Meter*);
 typedef void(*Meter_Draw)(Meter*, int, int, int);
 typedef const char* (*Meter_GetCaption)(const Meter*);
@@ -64,7 +64,7 @@ typedef struct MeterClass_ {
    const Meter_Draw draw;
    const Meter_GetCaption getCaption;
    const Meter_GetUiName getUiName;
-   const int defaultMode;
+   const MeterModeId defaultMode;
    const double total;
    const int* const attributes;
    const char* const name;                 /* internal name of the meter, must not contain any space */
@@ -105,7 +105,7 @@ struct Meter_ {
    const Machine* host;
 
    char* caption;
-   int mode;
+   MeterModeId mode;
    unsigned int param;
    GraphData drawData;
    int h;
@@ -137,7 +137,7 @@ void Meter_delete(Object* cast);
 
 void Meter_setCaption(Meter* this, const char* caption);
 
-void Meter_setMode(Meter* this, int modeIndex);
+void Meter_setMode(Meter* this, MeterModeId modeIndex);
 
 ListItem* Meter_toListItem(const Meter* this, bool moving);
 

--- a/MeterMode.h
+++ b/MeterMode.h
@@ -8,13 +8,15 @@ in the source distribution for its full text.
 */
 
 
-typedef enum {
+enum MeterModeId_ {
    /* Meter mode 0 is reserved */
    BAR_METERMODE = 1,
    TEXT_METERMODE,
    GRAPH_METERMODE,
    LED_METERMODE,
    LAST_METERMODE
-} MeterModeId;
+};
+
+typedef unsigned int MeterModeId;
 
 #endif

--- a/MeterMode.h
+++ b/MeterMode.h
@@ -1,0 +1,20 @@
+#ifndef HEADER_MeterMode
+#define HEADER_MeterMode
+/*
+htop - MeterMode.h
+(C) 2024 htop dev team
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+
+typedef enum {
+   /* Meter mode 0 is reserved */
+   BAR_METERMODE = 1,
+   TEXT_METERMODE,
+   GRAPH_METERMODE,
+   LED_METERMODE,
+   LAST_METERMODE
+} MeterModeId;
+
+#endif

--- a/MetersPanel.c
+++ b/MetersPanel.c
@@ -108,7 +108,7 @@ static HandlerResult MetersPanel_eventHandler(Panel* super, int ch) {
          if (!Vector_size(this->meters))
             break;
          Meter* meter = (Meter*) Vector_get(this->meters, selected);
-         int mode = meter->mode + 1;
+         MeterModeId mode = meter->mode + 1;
          if (mode == LAST_METERMODE)
             mode = 1;
          Meter_setMode(meter, mode);

--- a/Settings.c
+++ b/Settings.c
@@ -163,8 +163,8 @@ static void Settings_defaultMeters(Settings* this, unsigned int initialCpuCount)
    this->hLayout = HF_TWO_50_50;
    this->hColumns = xCalloc(HeaderLayout_getColumns(this->hLayout), sizeof(MeterColumnSetting));
    for (size_t i = 0; i < 2; i++) {
-      this->hColumns[i].names = xCalloc(sizes[i] + 1, sizeof(char*));
-      this->hColumns[i].modes = xCalloc(sizes[i], sizeof(MeterModeId));
+      this->hColumns[i].names = xCalloc(sizes[i] + 1, sizeof(*this->hColumns[0].names));
+      this->hColumns[i].modes = xCalloc(sizes[i], sizeof(*this->hColumns[0].modes));
       this->hColumns[i].len = sizes[i];
    }
 

--- a/Settings.c
+++ b/Settings.c
@@ -108,9 +108,9 @@ static void Settings_readMeterModes(Settings* this, const char* line, unsigned i
    }
    column = MINIMUM(column, HeaderLayout_getColumns(this->hLayout) - 1);
    this->hColumns[column].len = len;
-   int* modes = len ? xCalloc(len, sizeof(int)) : NULL;
+   MeterModeId* modes = len ? xCalloc(len, sizeof(MeterModeId)) : NULL;
    for (int i = 0; i < len; i++) {
-      modes[i] = atoi(ids[i]);
+      modes[i] = (MeterModeId) atoi(ids[i]);
    }
    String_freeArray(ids);
    this->hColumns[column].modes = modes;
@@ -123,7 +123,7 @@ static bool Settings_validateMeters(Settings* this) {
 
    for (size_t column = 0; column < colCount; column++) {
       char** names = this->hColumns[column].names;
-      const int* modes = this->hColumns[column].modes;
+      const MeterModeId* modes = this->hColumns[column].modes;
       const size_t len = this->hColumns[column].len;
 
       if (!len)
@@ -164,7 +164,7 @@ static void Settings_defaultMeters(Settings* this, unsigned int initialCpuCount)
    this->hColumns = xCalloc(HeaderLayout_getColumns(this->hLayout), sizeof(MeterColumnSetting));
    for (size_t i = 0; i < 2; i++) {
       this->hColumns[i].names = xCalloc(sizes[i] + 1, sizeof(char*));
-      this->hColumns[i].modes = xCalloc(sizes[i], sizeof(int));
+      this->hColumns[i].modes = xCalloc(sizes[i], sizeof(MeterModeId));
       this->hColumns[i].len = sizes[i];
    }
 
@@ -646,7 +646,7 @@ static void writeMeterModes(const Settings* this, OutputFunc of,
    if (this->hColumns[column].len) {
       const char* sep = "";
       for (size_t i = 0; i < this->hColumns[column].len; i++) {
-         of(fp, "%s%d", sep, this->hColumns[column].modes[i]);
+         of(fp, "%s%u", sep, this->hColumns[column].modes[i]);
          sep = " ";
       }
    } else {

--- a/Settings.h
+++ b/Settings.h
@@ -13,6 +13,7 @@ in the source distribution for its full text.
 
 #include "Hashtable.h"
 #include "HeaderLayout.h"
+#include "MeterMode.h"
 #include "Row.h"
 #include "RowField.h"
 
@@ -34,7 +35,7 @@ typedef struct {
 typedef struct {
    size_t len;
    char** names;
-   int* modes;
+   MeterModeId* modes;
 } MeterColumnSetting;
 
 typedef struct ScreenSettings_ {


### PR DESCRIPTION
The main goal of this set of patches is to remove the use of `CUSTOM_METERMODE` in `defaultMode` values, and to adjust `Meter_setMode()` code in preparation of the `supportedModes` feature (PR #1387).