### PR TITLE
Add the timezone in clock meter

### DIFF
--- a/ClockMeter.c
+++ b/ClockMeter.c
@@ -26,7 +26,7 @@ static void ClockMeter_updateValues(Meter* this) {
 
    struct tm result;
    const struct tm* lt = localtime_r(&host->realtime.tv_sec, &result);
-   strftime(this->txtBuffer, sizeof(this->txtBuffer), "%H:%M:%S", lt);
+   strftime(this->txtBuffer, sizeof(this->txtBuffer), "%H:%M:%S %Z", lt);
 }
 
 const MeterClass ClockMeter_class = {

--- a/DateTimeMeter.c
+++ b/DateTimeMeter.c
@@ -26,7 +26,7 @@ static void DateTimeMeter_updateValues(Meter* this) {
 
    struct tm result;
    const struct tm* lt = localtime_r(&host->realtime.tv_sec, &result);
-   strftime(this->txtBuffer, sizeof(this->txtBuffer), "%F %H:%M:%S", lt);
+   strftime(this->txtBuffer, sizeof(this->txtBuffer), "%F %H:%M:%S %Z", lt);
 }
 
 const MeterClass DateTimeMeter_class = {


### PR DESCRIPTION
I connect to servers with non-local timezones every now and then... Let's add the timezone in clock meter to minimize confusion there.