### PR TITLE
Add forward declarations in some headers

### DIFF
--- a/CRT.h
+++ b/CRT.h
@@ -14,6 +14,8 @@ in the source distribution for its full text.
 #include "Settings.h"
 
 
+struct Settings_; // IWYU pragma: keep
+
 typedef enum TreeStr_ {
    TREE_STR_VERT,
    TREE_STR_RTEE,
@@ -202,7 +204,7 @@ void CRT_setMouse(bool enabled);
 #define CRT_setMouse(enabled)
 #endif
 
-void CRT_init(const Settings* settings, bool allowUnicode, bool retainScreenOnExit);
+void CRT_init(const struct Settings_* settings, bool allowUnicode, bool retainScreenOnExit);
 
 void CRT_done(void);
 

--- a/Machine.h
+++ b/Machine.h
@@ -32,6 +32,9 @@ in the source distribution for its full text.
 #define MAX_READ 2048
 #endif
 
+struct Panel_; // IWYU pragma: keep
+struct Settings_; // IWYU pragma: keep
+
 typedef unsigned long long int memory_t;
 #define MEMORY_MAX ULLONG_MAX
 
@@ -86,9 +89,9 @@ void Machine_done(Machine* this);
 
 bool Machine_isCPUonline(const Machine* this, unsigned int id);
 
-void Machine_populateTablesFromSettings(Machine* this, Settings* settings, Table* processTable);
+void Machine_populateTablesFromSettings(Machine* this, struct Settings_* settings, Table* processTable);
 
-void Machine_setTablesPanel(Machine* this, Panel* panel);
+void Machine_setTablesPanel(Machine* this, struct Panel_* panel);
 
 void Machine_scan(Machine* this);
 

--- a/Meter.h
+++ b/Meter.h
@@ -42,6 +42,7 @@ in the source distribution for its full text.
       }                                                    \
    } while (0)
 
+struct Machine_; // IWYU pragma: keep
 
 struct Meter_;
 typedef struct Meter_ Meter;
@@ -102,7 +103,7 @@ typedef struct GraphData_ {
 struct Meter_ {
    Object super;
    Meter_Draw draw;
-   const Machine* host;
+   const struct Machine_* host;
 
    char* caption;
    int mode;
@@ -142,7 +143,7 @@ typedef enum {
 
 extern const MeterClass Meter_class;
 
-Meter* Meter_new(const Machine* host, unsigned int param, const MeterClass* type);
+Meter* Meter_new(const struct Machine_* host, unsigned int param, const MeterClass* type);
 
 /* Converts 'value' in kibibytes into a human readable string.
    Example output strings: "0K", "1023K", "98.7M" and "1.23G" */

--- a/Table.h
+++ b/Table.h
@@ -17,9 +17,10 @@ in the source distribution for its full text.
 #include "Vector.h"
 
 
-struct Machine_;  // IWYU pragma: keep
-struct Panel_;    // IWYU pragma: keep
-struct Row_;      // IWYU pragma: keep
+struct Machine_; // IWYU pragma: keep
+struct Panel_; // IWYU pragma: keep
+struct Row_; // IWYU pragma: keep
+struct Settings_; // IWYU pragma: keep
 
 typedef struct Table_ {
    /* Super object for emulated OOP */
@@ -64,7 +65,7 @@ extern const TableClass Table_class;
 
 void Table_setPanel(Table* this, struct Panel_* panel);
 
-void Table_printHeader(const Settings* settings, RichString* header);
+void Table_printHeader(const struct Settings_* settings, RichString* header);
 
 void Table_add(Table* this, struct Row_* row);
 
@@ -86,7 +87,7 @@ void Table_prepareEntries(Table* this);
 
 void Table_cleanupEntries(Table* this);
 
-void Table_cleanupRow(Table* this, Row* row, int idx);
+void Table_cleanupRow(Table* this, struct Row_* row, int idx);
 
 static inline void Table_compact(Table* this) {
    Vector_compact(this->rows);


### PR DESCRIPTION
I'm not sure this code quality issue is worth fixing in htop, but I hope getting some discussions.

In #1454 I mentioned a "header dependency hell" that motivated me to split the `MeterModeId` type into a separate header. It is this one.

When I added an `#include "Meter.h"` line into `Settings.h`, a _circular inclusion_ of headers would happen and that results in build errors in many `.c` files.

`Meter.h` includes `Machine.h` which includes `Settings.h` which would then include `Meter.h`, but due to the header guard, the latter `Meter.h` include line resolves to no-op. Sometimes a module might include just `Machine.h` or just `Settings.h` but the circular inclusion can happen either case.

When a C header depends on a `typedef` of another type, it has to include the header defining that type as the type redefinition (`typedef` defining the same type twice) is an error in C. Forward declarations only work with `struct`, `union`, `enum` and `class` (C++) names, but not `typedef`s, but htops uses `typedef`s extensively even for `struct`s in the coding style.

When a structure like `Meter` only include a _reference_ of another class such as `Machine`, there's no need to fully define the `Machine` type nor include the `Machine.h` in order to use it (in the header; the implementation part, i.e. `Meter.c` would have to include `Machine.h` of course). A forward declaration could work equally well for a header.

The commit I presented is not a complete fix. It's a part of header changes that, when using forward declarations, can fix build errors I encountered. Is it a good idea to apply such forward declarations whenever possible in htop headers?