### PR TITLE
Fix and improve NICE on FreeBSD

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -649,10 +649,15 @@ void Process_writeField(const Process* this, RichString* str, RowField field) {
    case M_RESIDENT: Row_printKBytes(str, this->m_resident, coloring); return;
    case M_VIRT: Row_printKBytes(str, this->m_virt, coloring); return;
    case NICE:
-      xSnprintf(buffer, n, "%3ld ", this->nice);
-      attr = this->nice < 0 ? CRT_colors[PROCESS_HIGH_PRIORITY]
-         : this->nice > 0 ? CRT_colors[PROCESS_LOW_PRIORITY]
-         : CRT_colors[PROCESS_SHADOW];
+      if (this->nice == PROCESS_NICE_UNKNOWN) {
+         xSnprintf(buffer, n, "N/A ");
+         attr = CRT_colors[PROCESS_SHADOW];
+      } else {
+         xSnprintf(buffer, n, "%3ld ", this->nice);
+         attr = this->nice < 0 ? CRT_colors[PROCESS_HIGH_PRIORITY]
+            : this->nice > 0 ? CRT_colors[PROCESS_LOW_PRIORITY]
+            : CRT_colors[PROCESS_SHADOW];
+      }
       break;
    case NLWP:
       if (this->nlwp == 1)

--- a/Process.h
+++ b/Process.h
@@ -8,6 +8,7 @@ Released under the GNU GPLv2+, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/types.h>
@@ -23,6 +24,9 @@ in the source distribution for its full text.
 #define PROCESS_FLAG_SCHEDPOL        0x00000004
 
 #define DEFAULT_HIGHLIGHT_SECS 5
+
+/* Sentinel value for an unknown niceness in Process.nice */
+#define PROCESS_NICE_UNKNOWN (-LONG_MAX)
 
 typedef enum Tristate_ {
    TRI_INITIAL = 0,

--- a/freebsd/FreeBSDProcess.h
+++ b/freebsd/FreeBSDProcess.h
@@ -13,12 +13,23 @@ in the source distribution for its full text.
 #include "Process.h"
 #include "Machine.h"
 
+typedef enum {
+   SCHEDCLASS_UNKNOWN = 0,
+
+   SCHEDCLASS_INTR_THREAD, /* interrupt thread */
+   SCHEDCLASS_REALTIME,
+   SCHEDCLASS_TIMESHARE, /* Regular scheduling */
+   SCHEDCLASS_IDLE,
+
+   MAX_SCHEDCLASS,
+} FreeBSDSchedClass;
 
 typedef struct FreeBSDProcess_ {
    Process super;
    int   jid;
    char* jname;
    char* emul;
+   FreeBSDSchedClass sched_class;
 } FreeBSDProcess;
 
 extern const ProcessClass FreeBSDProcess_class;

--- a/freebsd/ProcessField.h
+++ b/freebsd/ProcessField.h
@@ -12,6 +12,7 @@ in the source distribution for its full text.
    JID = 100,                    \
    JAIL = 101,                   \
    EMULATION = 102,              \
+   SCHEDCLASS = 103,             \
                                  \
    DUMMY_BUMP_FIELD = CWD,       \
    // End of list


### PR DESCRIPTION
Previously the niceness value on FreeBSD was utterly broken (to my and others annoyance):

 - it displayed out-of-range values for idletime and realtime scheduled processes
 - there was no indicator for such scheduled processes

This fixes:

 - The calculation of the niceness value (see https://github.com/freebsd/freebsd-src/blob/main/usr.bin/top/machine.c#L1182)
 - Add a column (SCHEDCLASS) that tells whether a process is idletime, realtime, timeshared or otherwise scheduled

I have tested this with other people on a few architectures and different versions of FreeBSD and it seems to be working just fine.

Please tell me if I can improve on this or if something is utterly wrong and I should fix.
