### PR TITLE
Fix "CPU usage bar" help alignment.

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -734,7 +734,7 @@ static Htop_Reaction actionHelp(State* st) {
       addbartext(CRT_colors[BAR_SHADOW], " ", "used%");
    } else {
       addbartext(CRT_colors[CPU_GUEST], "/", "guest");
-      addbartext(CRT_colors[BAR_SHADOW], "                  ", "used%");
+      addbartext(CRT_colors[BAR_SHADOW], "                            ", "used%");
    }
    addattrstr(CRT_colors[BAR_BORDER], "]");
 


### PR DESCRIPTION
fixes https://github.com/htop-dev/htop/issues/1465
before:
![Screenshot_20240423_143846](https://github.com/htop-dev/htop/assets/17964763/f6380ce7-a6c9-4e21-bf7c-b038023611d9)

after:
![Screenshot_20240423_144934](https://github.com/htop-dev/htop/assets/17964763/4bd2f958-6592-4dab-a7c5-7fe733440705)
