### PR TITLE
Linux: show newlines in commands as ? instead of space

### DIFF
--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -1172,6 +1172,12 @@ static bool LinuxProcessTable_readCmdlineFile(Process* process, openat_arg_t pro
 
       /* newline used as delimiter - when forming the mergedCommand, newline is
        * converted to space by Process_makeCommandStr */
+      if (argChar == '\n') {
+         /* Set to some other non-printable character */
+         command[i] = '\r';
+         continue;
+      }
+
       if (argChar == '\0') {
          command[i] = '\n';
 


### PR DESCRIPTION
Since `\n` is used internally by htop to split command lines, replace `\n` with `\r` in command lines to not display them as space.

Merging the command string will not work, but newlines in commands should be rather the exception.