### PR TITLE
Define keys for other $TERM values

### DIFF
--- a/CRT.c
+++ b/CRT.c
@@ -1007,6 +1007,24 @@ static bool terminalSupportsDefinedKeys(const char* termType) {
    }
 
    switch (termType[0]) {
+   case 'a':
+      if (String_eq(termType, "alacritty")) {
+         return true;
+      }
+      break;
+   case 's':
+      if (termType[1] == 't' && (termType[2] == '-' || !termType[2])) {
+         return true;
+      }
+      if (String_eq(termType, "screen")) {
+         return true;
+      }
+      break;
+   case 't':
+      if (String_eq(termType, "tmux")) {
+         return true;
+      }
+      break;
    case 'v':
       if (String_eq(termType, "vt220")) {
          return true;

--- a/CRT.c
+++ b/CRT.c
@@ -1001,6 +1001,27 @@ void CRT_setMouse(bool enabled) {
 }
 #endif
 
+static bool terminalSupportsDefinedKeys(const char* termType) {
+   if (!termType) {
+      return false;
+   }
+
+   switch (termType[0]) {
+   case 'v':
+      if (String_eq(termType, "vt220")) {
+         return true;
+      }
+      break;
+   case 'x':
+      if (String_eq(termType, "xterm")) {
+         return true;
+      }
+      break;
+   }
+
+   return false;
+}
+
 void CRT_init(const Settings* settings, bool allowUnicode, bool retainScreenOnExit) {
    initscr();
 
@@ -1046,7 +1067,7 @@ void CRT_init(const Settings* settings, bool allowUnicode, bool retainScreenOnEx
       CRT_scrollHAmount = 5;
    }
 
-   if (termType && (String_startsWith(termType, "xterm") || String_eq(termType, "vt220"))) {
+   if (terminalSupportsDefinedKeys(termType)) {
 #ifdef HTOP_NETBSD
 #define define_key(s_, k_) define_key((char*)s_, k_)
 IGNORE_WCASTQUAL_BEGIN


### PR DESCRIPTION
Allow keymaps to work in terminals that have other `$TERM` values set.

Closes #1397