### PR TITLE
Additional function attributes for XUtils (+analyzer fixes)

### DIFF
--- a/Macros.h
+++ b/Macros.h
@@ -69,6 +69,16 @@ in the source distribution for its full text.
 
 #endif /* HAVE_ATTR_NONNULL */
 
+#ifdef HAVE_ATTR_RETNONNULL
+
+#define ATTR_RETNONNULL                 __attribute__((returns_nonnull))
+
+#else
+
+#define ATTR_RETNONNULL
+
+#endif /* HAVE_ATTR_RETNONNULL */
+
 #ifdef HAVE_ATTR_ALLOC_SIZE
 
 #define ATTR_ALLOC_SIZE1(a)             __attribute__((alloc_size (a)))

--- a/XUtils.c
+++ b/XUtils.c
@@ -63,7 +63,7 @@ void* xCalloc(size_t nmemb, size_t size) {
 
 void* xRealloc(void* ptr, size_t size) {
    assert(size > 0);
-   void* data = size ? realloc(ptr, size) : NULL; // deepcode ignore MemoryLeakOnRealloc: this goes to fail()
+   void* data = realloc(ptr, size);
    if (!data) {
       /* free'ing ptr here causes an indirect memory leak if pointers
        * are held as part of an potential array referenced in ptr.

--- a/XUtils.h
+++ b/XUtils.h
@@ -24,19 +24,26 @@ in the source distribution for its full text.
 #include "Macros.h"
 
 
-void fail(void) ATTR_NORETURN;
+ATTR_NORETURN
+void fail(void);
 
-void* xMalloc(size_t size) ATTR_ALLOC_SIZE1(1) ATTR_MALLOC;
+ATTR_RETNONNULL ATTR_MALLOC ATTR_ALLOC_SIZE1(1)
+void* xMalloc(size_t size);
 
-void* xMallocArray(size_t nmemb, size_t size) ATTR_ALLOC_SIZE2(1, 2) ATTR_MALLOC;
+ATTR_RETNONNULL ATTR_MALLOC ATTR_ALLOC_SIZE2(1, 2)
+void* xMallocArray(size_t nmemb, size_t size);
 
-void* xCalloc(size_t nmemb, size_t size) ATTR_ALLOC_SIZE2(1, 2) ATTR_MALLOC;
+ATTR_RETNONNULL ATTR_MALLOC ATTR_ALLOC_SIZE2(1, 2)
+void* xCalloc(size_t nmemb, size_t size);
 
-void* xRealloc(void* ptr, size_t size) ATTR_ALLOC_SIZE1(2);
+ATTR_RETNONNULL ATTR_ALLOC_SIZE1(2)
+void* xRealloc(void* ptr, size_t size);
 
-void* xReallocArray(void* ptr, size_t nmemb, size_t size) ATTR_ALLOC_SIZE2(2, 3);
+ATTR_RETNONNULL ATTR_ALLOC_SIZE2(2, 3)
+void* xReallocArray(void* ptr, size_t nmemb, size_t size);
 
-void* xReallocArrayZero(void* ptr, size_t prevmemb, size_t newmemb, size_t size) ATTR_ALLOC_SIZE2(3, 4);
+ATTR_RETNONNULL ATTR_ALLOC_SIZE2(3, 4)
+void* xReallocArrayZero(void* ptr, size_t prevmemb, size_t newmemb, size_t size);
 
 /*
  * String_startsWith gives better performance if strlen(match) can be computed
@@ -64,21 +71,21 @@ static inline bool String_eq_nullable(const char* s1, const char* s2) {
    return false;
 }
 
-ATTR_NONNULL
-char* String_cat(const char* s1, const char* s2) ATTR_MALLOC;
+ATTR_NONNULL ATTR_RETNONNULL ATTR_MALLOC
+char* String_cat(const char* s1, const char* s2);
 
-ATTR_NONNULL
-char* String_trim(const char* in) ATTR_MALLOC;
+ATTR_NONNULL ATTR_RETNONNULL ATTR_MALLOC
+char* String_trim(const char* in);
 
-ATTR_NONNULL_N(1)
+ATTR_NONNULL_N(1) ATTR_RETNONNULL
 char** String_split(const char* s, char sep, size_t* n);
 
 void String_freeArray(char** s);
 
-ATTR_NONNULL
-char* String_readLine(FILE* fp) ATTR_MALLOC;
+ATTR_NONNULL ATTR_MALLOC
+char* String_readLine(FILE* fp);
 
-ATTR_NONNULL
+ATTR_NONNULL ATTR_RETNONNULL
 static inline char* String_strchrnul(const char* s, int c) {
 #ifdef HAVE_STRCHRNUL
    return strchrnul(s, c);
@@ -91,32 +98,33 @@ static inline char* String_strchrnul(const char* s, int c) {
 }
 
 /* Always null-terminates dest. Caller must pass a strictly positive size. */
-ATTR_ACCESS3_W(1, 3)
-ATTR_ACCESS3_R(2, 3)
+ATTR_NONNULL ATTR_ACCESS3_W(1, 3) ATTR_ACCESS3_R(2, 3)
 size_t String_safeStrncpy(char* restrict dest, const char* restrict src, size_t size);
 
-ATTR_FORMAT(printf, 2, 3)
-ATTR_NONNULL_N(1, 2)
+ATTR_FORMAT(printf, 2, 3) ATTR_NONNULL_N(1, 2)
 int xAsprintf(char** strp, const char* fmt, ...);
 
-ATTR_FORMAT(printf, 3, 4)
-ATTR_ACCESS3_W(1, 2)
+ATTR_FORMAT(printf, 3, 4) ATTR_NONNULL_N(1, 3) ATTR_ACCESS3_W(1, 2)
 int xSnprintf(char* buf, size_t len, const char* fmt, ...);
 
-char* xStrdup(const char* str) ATTR_NONNULL ATTR_MALLOC;
+ATTR_NONNULL ATTR_RETNONNULL ATTR_MALLOC
+char* xStrdup(const char* str);
+
+ATTR_NONNULL
 void free_and_xStrdup(char** ptr, const char* str);
 
-ATTR_ACCESS3_R(1, 2)
-char* xStrndup(const char* str, size_t len) ATTR_NONNULL ATTR_MALLOC;
+ATTR_NONNULL ATTR_RETNONNULL ATTR_MALLOC ATTR_ACCESS3_R(1, 2)
+char* xStrndup(const char* str, size_t len);
 
-ATTR_ACCESS3_W(2, 3)
+ATTR_NONNULL ATTR_ACCESS3_W(2, 3)
 ssize_t xReadfile(const char* pathname, void* buffer, size_t count);
-ATTR_ACCESS3_W(3, 4)
+ATTR_NONNULL ATTR_ACCESS3_W(3, 4)
 ssize_t xReadfileat(openat_arg_t dirfd, const char* pathname, void* buffer, size_t count);
 
-ATTR_ACCESS3_R(2, 3)
+ATTR_NONNULL ATTR_ACCESS3_R(2, 3)
 ssize_t full_write(int fd, const void* buf, size_t count);
 
+ATTR_NONNULL
 static inline ssize_t full_write_str(int fd, const char* str) {
    return full_write(fd, str, strlen(str));
 }
@@ -129,6 +137,7 @@ int compareRealNumbers(double a, double b);
 /* Computes the sum of all positive floating point values in an array.
    NaN values in the array are skipped. The returned sum will always be
    nonnegative. */
+ATTR_NONNULL ATTR_ACCESS3_R(1, 2)
 double sumPositiveValues(const double* array, size_t count);
 
 /* Returns the number of trailing zero bits */

--- a/configure.ac
+++ b/configure.ac
@@ -235,6 +235,21 @@ AC_COMPILE_IFELSE([
    AC_MSG_RESULT(no))
 CFLAGS="$old_CFLAGS"
 
+AC_MSG_CHECKING(for returns_nonnull)
+old_CFLAGS="$CFLAGS"
+CFLAGS="$CFLAGS -Wno-error -Werror=attributes"
+AC_COMPILE_IFELSE([
+   AC_LANG_SOURCE(
+      [[
+         /* Attribute supported in GCC 4.9 or later */
+         __attribute__((returns_nonnull)) void* foo(void);
+      ]]
+   )],
+   AC_DEFINE([HAVE_ATTR_RETNONNULL], 1, [The returns_nonnull attribute is supported.])
+   AC_MSG_RESULT(yes),
+   AC_MSG_RESULT(no))
+CFLAGS="$old_CFLAGS"
+
 AC_MSG_CHECKING(for NaN support)
 dnl Note: AC_RUN_IFELSE does not try compiling the program at all when
 dnl $cross_compiling is 'yes'.


### PR DESCRIPTION
This does 3 things:
- Fix a nasty diagnostic from GCC 14's static code analyzer
- Introduce `ATTR_RETNONNULL` to indicate that a function always returns a non-NULL result
- Mark several functions in `XUtils.h` with applicable attributes

The third commit depends on the second one to land. ;-)

Also a note on the first commit: We previously already asserted that `size` is non-zero for `xRealloc`, thus we'd never intentionally free. Thus if assertions were compiled in you already couldn't have passed `xRealloc(p, 0)`. Thus although technically correct, previously the function would have to have an additional `if (!size) { free(p); return NULL; }` path or simply bail on `size==0` too. Interestingly [util-linux](https://sources.debian.org/src/util-linux/2.40.2-1/include/xalloc.h/?hl=42#L42-L49) did basically the same thing, but given our explicit constraint on `size` we can simplify. Not simplifying triggers GCC 14.1, while simply checking for `!data` after `realloc` makes GCC 14 happy.