### PR TITLE
pcp: Add GPU metrics support

### DIFF
--- a/pcp/columns/gpu_memory
+++ b/pcp/columns/gpu_memory
@@ -1,0 +1,75 @@
+#
+# pcp-htop(1) configuration file - see pcp-htop(5)
+#
+
+[drm_memory_cpu]
+heading = DCPU
+width = 6
+metric = proc.fdinfo.drm_memory_cpu
+description = CPU memory which can be used by the GPU to store buffer objects
+
+[drm_memory_gtt]
+heading = DGTT
+width = 6
+metric = proc.fdinfo.drm_memory_gtt
+description = GTT memory which can be used by the GPU to store buffer objects
+
+[drm_memory_vram]
+heading = DVRAM
+width = 6
+metric = proc.fdinfo.drm_memory_vram
+description = VRAM memory which can be used by the GPU to store buffer objects
+
+[drm_shared_cpu]
+heading = DCPU_SHARE
+width = 6
+metric = proc.fdinfo.drm_shared_cpu
+description = CPU memory which can be used by the GPU to store buffer objects, and is shared with another file
+
+[drm_shared_gtt]
+heading = DGTT_SHARE
+width = 6
+metric = proc.fdinfo.drm_shared_gtt
+description = GTT memory which can be used by the GPU to store buffer objects, and is shared with another file
+
+[drm_shared_vram]
+heading = DVRAM_SHARE
+width = 6
+metric = proc.fdinfo.drm_shared_vram
+description = VRAM memory which can be used by the GPU to store buffer objects, and is shared with another file
+
+[amd_evicted_visible_vram]
+heading = AMD_EVVRAM
+width = 6
+metric = proc.fdinfo.amd_evicted_visible_vram
+description = Sum of evicted buffers due to CPU access
+
+[amd_evicted_vram]
+heading = AMD_EVRAM
+width = 6
+metric = proc.fdinfo.amd_evicted_vram
+description = Sum of evicted buffers, includes visible VRAM
+
+[amd_memory_visible_vram]
+heading = AMD_VVRAM
+width = 6
+metric = proc.fdinfo.amd_memory_visible_vram
+description = Current visible VRAM usage
+
+[amd_requested_gtt]
+heading = AMD_RGTT
+width = 6
+metric = proc.fdinfo.amd_requested_gtt
+description = How much GTT memory userspace asked for
+
+[amd_requested_visible_vram]
+heading = AMD_RVVRAM
+width = 6
+metric = proc.fdinfo.amd_requested_visible_vram
+description = How much visible VRAM userspace asked for
+
+[amd_requested_vram]
+heading = AMD_RVRAM
+width = 6
+metric = proc.fdinfo.amd_requested_vram
+description = How much VRAM userspace asked for, includes visible VRAM

--- a/pcp/meters/gpu
+++ b/pcp/meters/gpu
@@ -1,0 +1,42 @@
+#
+# pcp-htop(1) configuration file - see pcp-htop(5)
+#
+
+[amd_gpu_load]
+caption = AMD GPU load
+description = AMD GPU load
+load.metric = amdgpu.gpu.load
+load.suffix = %
+
+[amd_gpu_average_power]
+caption = AMD GPU average power
+description = AMD GPU average power in Watts
+average_power.metric = amdgpu.gpu.average_power
+average_power.suffix = W
+
+[amd_gpu_memory]
+type = bar
+caption = AMD GPU memory
+description = Allocated frame buffer memory
+used.metric = amdgpu.memory.used
+used.color = red
+total.metric = amdgpu.memory.total
+total.color: blue
+
+[amd_gpu_clock]
+caption = AMD GPU clock
+description = The GPU clock speed in MHz
+clock.metric = amdgpu.gpu.clock
+clock.label = MHz
+
+[amd_gpu_memory_clock]
+caption = AMD GPU memory clock
+description = The GDDRx memory clock speed in MHz
+clock.metric = amdgpu.memory.clock
+clock.label = MHz
+
+[amd_gpu_temp]
+caption = AMD GPU temperature
+description = The GPU temperature in dregree Celsius
+temp.metric = amdgpu.gpu.temperature / 1000
+temp.label = °C


### PR DESCRIPTION
Since PCP now provides initial AMD GPU support, add dedicated columns and meters.