### PR TITLE
Separate htoprc for htop and pcp-htop to prevent overwrite

### DIFF
--- a/Settings.c
+++ b/Settings.c
@@ -874,9 +874,9 @@ Settings* Settings_new(unsigned int initialCpuCount, Hashtable* dynamicMeters, H
          configDir = xStrdup(xdgConfigHome);
          htopDir = String_cat(xdgConfigHome, "/htop");
       } else {
-         this->initialFilename = String_cat(home, "/.config/htop/htoprc");
-         configDir = String_cat(home, "/.config");
-         htopDir = String_cat(home, "/.config/htop");
+         this->initialFilename = String_cat(home, CONFIGDIR "/htop/htoprc");
+         configDir = String_cat(home, CONFIGDIR);
+         htopDir = String_cat(home, CONFIGDIR "/htop");
       }
       (void) mkdir(configDir, 0700);
       (void) mkdir(htopDir, 0700);

--- a/configure.ac
+++ b/configure.ac
@@ -599,6 +599,19 @@ if test -n "$with_os_release" && test ! -f "$with_os_release"; then
 fi
 AC_DEFINE_UNQUOTED([OSRELEASEFILE], ["$with_os_release"], [File with OS release details.])
 
+AC_ARG_WITH([config],
+            [AS_HELP_STRING([--with-config=DIR],
+			    [configuration path @<:@default=/.config@:>@])],
+            [],
+            [with_config="/.config"])
+dnl Performance Co-Pilot configuration location to prevent overwrite
+if test "$my_htop_platform" = pcp -a "$with_config" = /.config; then
+    with_config="/.pcp"
+elif test -z "$with_config"; then
+   AC_MSG_ERROR([bad empty value for --with-config option])
+fi
+AC_DEFINE_UNQUOTED([CONFIGDIR], ["$with_config"], [Configuration path.])
+
 # ----------------------------------------------------------------------
 
 

--- a/htop.1.in
+++ b/htop.1.in
@@ -619,12 +619,23 @@ The
 .B pcp-htop
 utility makes use of
 .I htoprc
-in exactly the same way.
-In addition, it supports additional configuration files allowing
-new meters and columns to be added to the display via the usual
-Setup function, which will display additional Available Meters
-and Available Column entries for each runtime configured meter
-or column.
+in a similar way.
+However,
+.B pcp-htop
+reads its configuration from a path more conventionally used by
+Performance Co-Pilot tools,
+.IR ~/.pcp/htop/htoprc ,
+in order to provide separate configuration when both
+.B htop
+and
+.B pcp-htop
+are installed and in use.
+.B pcp-htop
+supports additional configuration files below the same directory
+allowing new meters, columns and screen tabs to be added via the
+Setup screen (F2).
+This displays additional Available Meters, Available Column and
+Screen Tabs for each meter, column or screen configuration file.
 .LP
 These
 .B pcp-htop

--- a/pcp/PCPDynamicColumn.c
+++ b/pcp/PCPDynamicColumn.c
@@ -230,7 +230,7 @@ void PCPDynamicColumns_init(PCPDynamicColumns* columns) {
    if (xdgConfigHome)
       path = String_cat(xdgConfigHome, "/htop/columns/");
    else if (home)
-      path = String_cat(home, "/.config/htop/columns/");
+      path = String_cat(home, CONFIGDIR "/htop/columns/");
    else
       path = NULL;
    if (path) {

--- a/pcp/PCPDynamicMeter.c
+++ b/pcp/PCPDynamicMeter.c
@@ -273,7 +273,7 @@ void PCPDynamicMeters_init(PCPDynamicMeters* meters) {
    if (xdgConfigHome)
       path = String_cat(xdgConfigHome, "/htop/meters/");
    else if (home)
-      path = String_cat(home, "/.config/htop/meters/");
+      path = String_cat(home, CONFIGDIR "/htop/meters/");
    else
       path = NULL;
    if (path) {

--- a/pcp/PCPDynamicScreen.c
+++ b/pcp/PCPDynamicScreen.c
@@ -307,7 +307,7 @@ void PCPDynamicScreens_init(PCPDynamicScreens* screens, PCPDynamicColumns* colum
    if (xdgConfigHome)
       path = String_cat(xdgConfigHome, "/htop/screens/");
    else if (home)
-      path = String_cat(home, "/.config/htop/screens/");
+      path = String_cat(home, CONFIGDIR "/htop/screens/");
    else
       path = NULL;
    if (path) {


### PR DESCRIPTION
The original intention with pcp-htop was to share the same htoprc configuration file with regular htop.  However this also stores tab configuration which causes confusion since the default pcp-htop tab set is unintentionally reduced to match the defaults on Linux (when htop is invoked prior to pcp-htop).

Relates to issue #952.