### PR TITLE
Permit zero items in drawing a Graph meter

### DIFF
--- a/Meter.c
+++ b/Meter.c
@@ -224,7 +224,11 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
 
       memmove(&data->values[0], &data->values[1], (nValues - 1) * sizeof(*data->values));
 
-      data->values[nValues - 1] = sumPositiveValues(this->values, this->curItems);
+      data->values[nValues - 1] = 0.0;
+      if (this->curItems > 0) {
+         assert(this->values);
+         data->values[nValues - 1] = sumPositiveValues(this->values, this->curItems);
+      }
    }
 
    if (w <= 0)

--- a/Meter.c
+++ b/Meter.c
@@ -190,6 +190,7 @@ static const char* const GraphMeterMode_dotsAscii[] = {
 };
 
 static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
+   // Draw the caption
    const char* caption = Meter_getCaption(this);
    attrset(CRT_colors[METER_TEXT]);
    const int captionLen = 3;
@@ -198,6 +199,8 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
    w -= captionLen;
 
    GraphData* data = &this->drawData;
+
+   // Expand the graph data buffer if necessary
    assert(data->nValues / 2 <= INT_MAX);
    if (w > (int)(data->nValues / 2) && MAX_METER_GRAPHDATA_VALUES > data->nValues) {
       size_t oldNValues = data->nValues;
@@ -212,6 +215,7 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
    if (nValues < 1)
       return;
 
+   // Record new value if necessary
    const Machine* host = this->host;
    if (!timercmp(&host->realtime, &(data->time), <)) {
       int globalDelay = host->settings->delay;
@@ -226,6 +230,7 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
    if (w <= 0)
       return;
 
+   // Graph drawing style (character set, etc.)
    const char* const* GraphMeterMode_dots;
    int GraphMeterMode_pixPerRow;
 #ifdef HAVE_LIBNCURSESW
@@ -239,12 +244,14 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
       GraphMeterMode_pixPerRow = PIXPERROW_ASCII;
    }
 
+   // Starting positions of graph data and terminal column
    if ((size_t)w > nValues / 2) {
       x += w - nValues / 2;
       w = nValues / 2;
    }
    size_t i = nValues - (size_t)w * 2;
 
+   // Draw the actual graph
    for (int col = 0; i < nValues - 1; i += 2, col++) {
       int pix = GraphMeterMode_pixPerRow * GRAPH_HEIGHT;
       double total = MAXIMUM(this->total, 1);

--- a/Meter.c
+++ b/Meter.c
@@ -226,11 +226,6 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
    if (w <= 0)
       return;
 
-   if ((size_t)w > nValues / 2) {
-      x += w - nValues / 2;
-      w = nValues / 2;
-   }
-
    const char* const* GraphMeterMode_dots;
    int GraphMeterMode_pixPerRow;
 #ifdef HAVE_LIBNCURSESW
@@ -244,7 +239,12 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
       GraphMeterMode_pixPerRow = PIXPERROW_ASCII;
    }
 
+   if ((size_t)w > nValues / 2) {
+      x += w - nValues / 2;
+      w = nValues / 2;
+   }
    size_t i = nValues - (size_t)w * 2;
+
    for (int col = 0; i < nValues - 1; i += 2, col++) {
       int pix = GraphMeterMode_pixPerRow * GRAPH_HEIGHT;
       double total = MAXIMUM(this->total, 1);


### PR DESCRIPTION
There are three commits in this PR. The first two changes some code comment and ordering without any change to the code behavior. The third commit is the main one I am proposing to change.

`sumPositiveValues()` now has a "nonnull" attribute, which slightly breaks the use case in `GraphMeterMode_draw()` in which `Meter.values` was allowed to be NULL when `Meter.curItems` is zero. With the "nonnull" attribute, that case turned to an undefined behavior. Fix that and allow the old behavior to work again.