### PR TITLE
New "configure" ncurses detection code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,7 @@ jobs:
             run: |
               set -e
               ./autogen.sh
-              CPPFLAGS=$(pkg-config --cflags ncurses) LDFLAGS=$(pkg-config --libs ncurses) ./configure --enable-unicode --enable-werror
+              ./configure --enable-unicode --enable-werror
               gmake -k
 
   build-openbsd-latest-clang:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
             release: '14.1'
             usesh: true
             prepare: |
-              pkg install -y gmake autoconf automake git
+              pkg install -y gmake autoconf automake pkgconf git
               git config --global --add safe.directory /home/runner/work/htop/htop
             run: |
               set -e

--- a/Makefile.am
+++ b/Makefile.am
@@ -508,8 +508,9 @@ cppcheck:
 	cppcheck -q -v . --enable=all -DHAVE_OPENVZ
 
 dist-hook: $(top_distdir)/configure
-	@if grep 'pkg_m4_absent' '$(top_distdir)/configure'; then \
-	   echo 'ERROR: configure is generated without pkg.m4. Please supply pkg.m4 and run ./autogen.sh to rebuild the configure script.'>&2; \
+	@if test "x$$FORCE_MAKE_DIST" = x && \
+	   grep 'pkg_m4_absent' '$(top_distdir)/configure' >/dev/null; then \
+	   echo 'ERROR: This distribution would have incomplete pkg-config support. Rebuilding the configure script is advised. Set FORCE_MAKE_DIST=1 to ignore this warning.'>&2; \
 	   (exit 1); \
 	else :; \
 	fi

--- a/README.md
+++ b/README.md
@@ -46,10 +46,13 @@ List of build-time dependencies:
 > This is also something that is reflected in the package name on Debian/Ubuntu (via the additional 'w' - 'w'ide character support).
 
 List of additional build-time dependencies (based on feature flags):
+*  `pkg-config`
 *  `sensors`
 *  `hwloc`
 *  `libcap` (v2.21 or later)
 *  `libnl-3` and `libnl-genl-3`
+
+`pkg-config` is optional but recommended. The configure script of `htop` might utilize `pkg-config` to obtain the compiler and linker flags required for a library. Some OS distributions provide `pkg-config` functionalities through an alternative implementation such as `pkgconf`. Look for both names in your package manager.
 
 Install these and other required packages for C development from your package manager.
 

--- a/configure.ac
+++ b/configure.ac
@@ -450,19 +450,38 @@ htop_check_curses_capability () {
    # At this point we have not checked the name of curses header, so
    # use forward declaration for the linking tests below.
 
+   # htop uses keypad() and "stdscr", but for ncurses implementation,
+   # the symbols are in "-ltinfo" and not "-lncurses".
+   # Check "-ltinfo" symbols first, as libncurses might require
+   # explicit "-ltinfo" to link (for internal dependency).
+   AC_MSG_CHECKING([for keypad in $htop_msg_linker_flags])
+   AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+/* extern WINDOW* stdscr; */
+/* int keypad(WINDOW* win, bool enable); */
+extern void* stdscr;
+int keypad(void* win, int enable);
+      ]], [[
+keypad(stdscr, 0);
+      ]])],
+      [AC_MSG_RESULT(yes)],
+      [AC_MSG_RESULT(no)
+      htop_curses_status=1])
+
    # htop calls refresh(), which might be implemented as a macro.
    # It is more reliable to test linking with doupdate(), which
    # refresh() would call internally.
-   AC_MSG_CHECKING([for doupdate in $htop_msg_linker_flags])
-   AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+   if test "$htop_curses_status" -eq 0; then
+      AC_MSG_CHECKING([for doupdate in $htop_msg_linker_flags])
+      AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 int doupdate(void);
-      ]], [[
+         ]], [[
 doupdate();
-      ]])],
-      [AC_MSG_RESULT(yes)
-      htop_curses_capability=nonwide],
-      [AC_MSG_RESULT(no)
-      htop_curses_status=1])
+         ]])],
+         [AC_MSG_RESULT(yes)
+         htop_curses_capability=nonwide],
+         [AC_MSG_RESULT(no)
+         htop_curses_status=1])
+   fi
 
    if test "x$htop_curses_status$enable_unicode" = x0yes; then
       AC_MSG_CHECKING([for mvadd_wchnstr in $htop_msg_linker_flags])
@@ -553,6 +572,15 @@ none-*|nonwide-yes)
       if htop_check_curses_capability "" "-l$curses_name"; then
          break
       fi
+      # For ncurses implementation, an extra "-ltinfo" or "-ltinfow"
+      # flag might be needed to link.
+      if test "x$enable_unicode" = xyes &&
+         htop_check_curses_capability "" "-l$curses_name -ltinfow"; then
+         break
+      fi
+      if htop_check_curses_capability "" "-l$curses_name -ltinfo"; then
+         break
+      fi
    done
    ;;
 esac
@@ -579,10 +607,6 @@ if test "x$enable_unicode" = xyes; then
       [AC_CHECK_HEADERS([ncurses/term.h], [],
          [AC_CHECK_HEADERS([term.h], [],
             [AC_MSG_ERROR([can not find required term header file])])])])
-
-   # check if additional linker flags are needed for keypad(3)
-   # (at this point we already link against a working ncurses library with wide character support)
-   AC_SEARCH_LIBS([keypad], [tinfow tinfo])
 else
    AC_CHECK_HEADERS([curses.h], [],
       [AC_CHECK_HEADERS([ncurses/curses.h], [],
@@ -593,10 +617,6 @@ else
    AC_CHECK_HEADERS([ncurses/term.h], [],
       [AC_CHECK_HEADERS([term.h], [],
          [AC_MSG_ERROR([can not find required term header file])])])
-
-   # check if additional linker flags are needed for keypad(3)
-   # (at this point we already link against a working ncurses library)
-   AC_SEARCH_LIBS([keypad], [tinfo])
 fi
 CFLAGS=$htop_save_CFLAGS
 

--- a/configure.ac
+++ b/configure.ac
@@ -384,6 +384,11 @@ dnl If the macro is not called, some pkg-config checks might be skipped
 dnl and $PKG_CONFIG might be unset.
 m4_ifdef([PKG_PROG_PKG_CONFIG], [
    PKG_PROG_PKG_CONFIG()
+], [
+   pkg_m4_absent=1 # Makefile might grep this keyword. Don't remove.
+   m4_warn(
+      [syntax],
+      [pkg.m4 is absent or older than version 0.16; this 'configure' would have incomplete pkg-config support])
 ])
 
 # HTOP_CHECK_SCRIPT(LIBNAME, FUNCTION, DEFINE, CONFIG_SCRIPT, ELSE_PART)

--- a/configure.ac
+++ b/configure.ac
@@ -614,7 +614,7 @@ AC_DEFINE_UNQUOTED([OSRELEASEFILE], ["$with_os_release"], [File with OS release 
 
 AC_ARG_WITH([config],
             [AS_HELP_STRING([--with-config=DIR],
-			    [configuration path @<:@default=/.config@:>@])],
+                            [configuration path @<:@default=/.config@:>@])],
             [],
             [with_config="/.config"])
 dnl Performance Co-Pilot configuration location to prevent overwrite

--- a/configure.ac
+++ b/configure.ac
@@ -566,6 +566,53 @@ esac
 
 case ${htop_curses_capability}-$enable_unicode in
 none-*|nonwide-yes)
+   if test "x$PKG_CONFIG" = x; then (
+      # Friendly warning to advise user to install pkg-config.
+      # The local variables get discarded when done.
+      list=""
+      echo "" >conftest.c
+      if test "$cross_compiling" != yes; then
+         # "-print-multi-directory" supported in GCC 3.0 or later
+         name=""
+         if $CC $CPPFLAGS $CFLAGS -print-multi-directory -E conftest.c >/dev/null 2>&1; then
+            name=`$CC $CPPFLAGS $CFLAGS -print-multi-directory -E conftest.c 2>/dev/null |
+               sed '/^ *#/ d; s/^\.$//; q'`
+         fi
+         list="/usr/lib${name}/pkgconfig $list"
+         case $host_os in
+         darwin*)
+            list="/opt/homebrew/Library/Homebrew/os/mac/pkgconfig $list"
+            ;;
+         freebsd*)
+            list="/usr/libdata/pkgconfig $list"
+            ;;
+         netbsd*)
+            list="/usr/pkg/lib/pkgconfig $list"
+            ;;
+         esac
+      fi
+      if test "x$host_alias" != x; then
+         list="/usr/lib/${host_alias}/pkgconfig $list"
+      fi
+      # "-print-multiarch" supported in GCC 4.6 or later
+      if $CC $CPPFLAGS $CFLAGS -print-multiarch -E conftest.c >/dev/null 2>&1; then
+         name=`$CC $CPPFLAGS $CFLAGS -print-multiarch -E conftest.c 2>/dev/null |
+            sed '/^ *#/ d; q'`
+         if test "x$name" != x; then
+            list="/usr/lib/${name}/pkgconfig $list"
+         fi
+      fi
+      rm -f conftest.*
+
+      for d in $list; do
+         result=`find "$d" -name '*curses*.pc' 2>/dev/null | sed '1 q'`
+         if test "x$result" != x; then
+            AC_MSG_WARN([your system supports pkg-config; installing pkg-config is recommended before configuring htop])
+            break
+         fi
+      done
+   ) fi
+
    # OpenBSD and Solaris are known to not provide '*curses*.pc' files.
    AC_MSG_RESULT([no curses information found through '*-config' utilities; will guess the linker flags])
    for curses_name in $curses_pkg_names; do

--- a/configure.ac
+++ b/configure.ac
@@ -391,61 +391,184 @@ m4_ifdef([PKG_PROG_PKG_CONFIG], [
       [pkg.m4 is absent or older than version 0.16; this 'configure' would have incomplete pkg-config support])
 ])
 
-# HTOP_CHECK_SCRIPT(LIBNAME, FUNCTION, DEFINE, CONFIG_SCRIPT, ELSE_PART)
-m4_define([HTOP_CHECK_SCRIPT],
-[
-   if test ! -z "m4_toupper($HTOP_[$1]_CONFIG_SCRIPT)"; then
-      # to be used to set the path to ncurses*-config when cross-compiling
-      htop_config_script_libs=$(m4_toupper($HTOP_[$1]_CONFIG_SCRIPT) --libs 2> /dev/null)
-      htop_config_script_cflags=$(m4_toupper($HTOP_[$1]_CONFIG_SCRIPT) --cflags 2> /dev/null)
-   else
-      htop_config_script_libs=$([$4] --libs 2> /dev/null)
-      htop_config_script_cflags=$([$4] --cflags 2> /dev/null)
-   fi
-   htop_script_success=no
-   htop_save_CFLAGS="$AM_CFLAGS"
-   if test ! "x$htop_config_script_libs" = x; then
-      AM_CFLAGS="$AM_CFLAGS $htop_config_script_cflags"
-      AC_CHECK_LIB([$1], [$2], [
-         AC_DEFINE([$3], 1, [The library is present.])
-         LIBS="$htop_config_script_libs $LIBS "
-         htop_script_success=yes
-      ], [
-         AM_CFLAGS="$htop_save_CFLAGS"
-      ], [
-         $htop_config_script_libs
-      ])
-   fi
-   if test "x$htop_script_success" = xno; then
-      [$5]
-   fi
-])
-
-# HTOP_CHECK_LIB(LIBNAME, FUNCTION, DEFINE, ELSE_PART)
-m4_define([HTOP_CHECK_LIB],
-[
-   AC_CHECK_LIB([$1], [$2], [
-      AC_DEFINE([$3], [1], [The library is present.])
-      LIBS="-l[$1] $LIBS "
-   ], [$4])
-])
-
 AC_ARG_ENABLE([unicode],
               [AS_HELP_STRING([--enable-unicode],
                               [enable Unicode support @<:@default=yes@:>@])],
               [],
               [enable_unicode=yes])
-if test "x$enable_unicode" = xyes; then
-   HTOP_CHECK_SCRIPT([ncursesw6], [waddwstr], [HAVE_LIBNCURSESW], "ncursesw6-config",
-    HTOP_CHECK_SCRIPT([ncursesw], [waddwstr], [HAVE_LIBNCURSESW], "ncursesw6-config",
-     HTOP_CHECK_SCRIPT([ncursesw], [wadd_wch], [HAVE_LIBNCURSESW], "ncursesw5-config",
-      HTOP_CHECK_SCRIPT([ncurses], [wadd_wch], [HAVE_LIBNCURSESW], "ncurses5-config",
-       HTOP_CHECK_LIB([ncursesw6], [addnwstr], [HAVE_LIBNCURSESW],
-        HTOP_CHECK_LIB([ncursesw], [addnwstr], [HAVE_LIBNCURSESW],
-         HTOP_CHECK_LIB([ncurses], [addnwstr], [HAVE_LIBNCURSESW],
-          AC_MSG_ERROR([can not find required library libncursesw; you may want to use --disable-unicode])
-   )))))))
 
+AC_ARG_VAR([CURSES_CFLAGS], [C compiler flags for curses; this overrides auto detected values])
+AC_ARG_VAR([CURSES_LIBS], [linker flags for curses; this overrides auto detected values])
+
+curses_pkg_names="ncurses6 ncurses5 ncurses curses"
+
+if test "x$enable_unicode" = xyes; then
+   curses_pkg_names="ncursesw6 ncursesw5 ncursesw $curses_pkg_names"
+fi
+
+AC_ARG_WITH([curses],
+            [AS_HELP_STRING([--with-curses=NAME],
+                            [select curses package NAME to link with; e.g. ncursesw6])],
+            [],
+            [with_curses=check])
+case $with_curses in
+check)
+   : # No-op. Use default list.
+   ;;
+yes|no)
+   AC_MSG_ERROR([bad value '$with_curses' for --with-curses option])
+   ;;
+*)
+   if test "x${CURSES_CFLAGS+y}${CURSES_LIBS+y}" = xyy; then
+      AC_MSG_WARN([ignoring --with-curses value due to override])
+   fi
+   curses_pkg_names=`echo "x$with_curses" | sed 's/^x\(lib\)\{0,1\}//'`
+   ;;
+esac
+
+# $1: C preprocessor and compiler flags for curses library
+# $2: linker flags for curses library
+htop_check_curses_capability () {
+   htop_curses_cflags=${CURSES_CFLAGS-"$1"}
+   htop_curses_libs=${CURSES_LIBS-"$2"}
+
+   echo "curses cflags${CURSES_CFLAGS+ (override)}: $htop_curses_cflags" >&AS_MESSAGE_LOG_FD
+   echo "curses libs${CURSES_LIBS+ (override)}: $htop_curses_libs" >&AS_MESSAGE_LOG_FD
+
+   htop_msg_linker_flags=$htop_curses_libs
+   if test "`echo x $htop_msg_linker_flags`" = x; then
+      htop_msg_linker_flags="(no linker flags)"
+   fi
+
+   htop_curses_status=0 # 0 for success; nonzero for failure
+
+   htop_save_CFLAGS=$CFLAGS
+   htop_save_LIBS=$LIBS
+   CFLAGS="$AM_CFLAGS $htop_curses_cflags $CFLAGS"
+   LIBS="$htop_curses_libs $LIBS"
+
+   # At this point we have not checked the name of curses header, so
+   # use forward declaration for the linking tests below.
+
+   # htop calls refresh(), which might be implemented as a macro.
+   # It is more reliable to test linking with doupdate(), which
+   # refresh() would call internally.
+   AC_MSG_CHECKING([for doupdate in $htop_msg_linker_flags])
+   AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+int doupdate(void);
+      ]], [[
+doupdate();
+      ]])],
+      [AC_MSG_RESULT(yes)
+      htop_curses_capability=nonwide],
+      [AC_MSG_RESULT(no)
+      htop_curses_status=1])
+
+   if test "x$htop_curses_status$enable_unicode" = x0yes; then
+      AC_MSG_CHECKING([for mvadd_wchnstr in $htop_msg_linker_flags])
+      AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+/* int mvadd_wchnstr(int y, int x, const cchar_t* wchstr, int n); */
+int mvadd_wchnstr(int y, int x, const void* wchstr, int n);
+         ]], [[
+mvadd_wchnstr(0, 0, (void*)0, 0);
+         ]])],
+         [AC_MSG_RESULT(yes)
+         htop_curses_capability=wide],
+         [AC_MSG_RESULT(no)
+         htop_curses_status=1])
+   fi
+
+   if test "$htop_curses_status" -eq 0; then
+      AM_CFLAGS="$AM_CFLAGS $htop_curses_cflags"
+      if test "$htop_curses_capability" = wide; then
+         AC_DEFINE([HAVE_LIBNCURSESW], 1, [libncursesw is present])
+      else
+         AC_DEFINE([HAVE_LIBNCURSES], 1, [libcurses is present])
+      fi
+   else
+      LIBS=$htop_save_LIBS
+   fi
+   CFLAGS=$htop_save_CFLAGS
+   return "$htop_curses_status"
+} # htop_check_curses_capability
+
+htop_curses_capability=none
+
+if test "x${CURSES_CFLAGS+y}${CURSES_LIBS+y}" = xyy; then
+   curses_pkg_names=""
+   htop_check_curses_capability "$CURSES_CFLAGS" "$CURSES_LIBS"
+fi
+
+# Prioritize $PKG_CONFIG over ncurses*-config, as users might need to
+# cross-compile htop.
+if test "x$PKG_CONFIG" != x; then
+   pkg_config_static_flag=""
+   if test "$enable_static" = yes; then
+      pkg_config_static_flag=--static
+   fi
+
+   for curses_name in $curses_pkg_names; do
+      echo retrieving $curses_name information through $PKG_CONFIG >&AS_MESSAGE_LOG_FD
+      $PKG_CONFIG --exists --print-errors $curses_name >&AS_MESSAGE_LOG_FD 2>&AS_MESSAGE_LOG_FD || continue
+
+      : # Resets "$?" to 0
+      htop_config_cflags=`$PKG_CONFIG --cflags $pkg_config_static_flag $curses_name 2>/dev/null` || continue
+      : # Resets "$?" to 0
+      htop_config_libs=`$PKG_CONFIG --libs $pkg_config_static_flag $curses_name 2>/dev/null` || continue
+
+      AC_MSG_RESULT([found $curses_name information through $PKG_CONFIG])
+
+      if htop_check_curses_capability "$htop_config_cflags" "$htop_config_libs"; then
+         break
+      fi
+   done
+fi
+
+case ${htop_curses_capability}-$enable_unicode in
+none-*|nonwide-yes)
+   for curses_name in $curses_pkg_names; do
+      echo retrieving $curses_name information through ${curses_name}-config >&AS_MESSAGE_LOG_FD
+
+      ${curses_name}-config --cflags >/dev/null 2>&AS_MESSAGE_LOG_FD || continue
+
+      : # Resets "$?" to 0
+      htop_config_cflags=`${curses_name}-config --cflags 2>/dev/null` || continue
+      : # Resets "$?" to 0
+      htop_config_libs=`${curses_name}-config --libs 2>/dev/null` || continue
+
+      AC_MSG_RESULT([found $curses_name information through ${curses_name}-config])
+
+      if htop_check_curses_capability "$htop_config_cflags" "$htop_config_libs"; then
+         break
+      fi
+   done
+   ;;
+esac
+
+case ${htop_curses_capability}-$enable_unicode in
+none-*|nonwide-yes)
+   # OpenBSD and Solaris are known to not provide '*curses*.pc' files.
+   AC_MSG_RESULT([no curses information found through '*-config' utilities; will guess the linker flags])
+   for curses_name in $curses_pkg_names; do
+      if htop_check_curses_capability "" "-l$curses_name"; then
+         break
+      fi
+   done
+   ;;
+esac
+
+case ${htop_curses_capability}-$enable_unicode in
+nonwide-yes)
+   AC_MSG_ERROR([cannot find required ncursesw library; you may want to use --disable-unicode])
+   ;;
+none-*)
+   AC_MSG_ERROR([cannot find required curses/ncurses library])
+   ;;
+esac
+
+htop_save_CFLAGS=$CFLAGS
+CFLAGS="$AM_CFLAGS $CFLAGS"
+if test "x$enable_unicode" = xyes; then
    AC_CHECK_HEADERS([ncursesw/curses.h], [],
       [AC_CHECK_HEADERS([ncurses/ncurses.h], [],
          [AC_CHECK_HEADERS([ncurses/curses.h], [],
@@ -461,14 +584,6 @@ if test "x$enable_unicode" = xyes; then
    # (at this point we already link against a working ncurses library with wide character support)
    AC_SEARCH_LIBS([keypad], [tinfow tinfo])
 else
-   HTOP_CHECK_SCRIPT([ncurses6], [wnoutrefresh], [HAVE_LIBNCURSES], [ncurses6-config],
-    HTOP_CHECK_SCRIPT([ncurses], [wnoutrefresh], [HAVE_LIBNCURSES], [ncurses5-config],
-     HTOP_CHECK_LIB([ncurses6],  [doupdate], [HAVE_LIBNCURSES],
-      HTOP_CHECK_LIB([ncurses],  [doupdate], [HAVE_LIBNCURSES],
-       HTOP_CHECK_LIB([curses],  [doupdate], [HAVE_LIBNCURSES],
-        AC_MSG_ERROR([can not find required curses/ncurses library])
-   )))))
-
    AC_CHECK_HEADERS([curses.h], [],
       [AC_CHECK_HEADERS([ncurses/curses.h], [],
          [AC_CHECK_HEADERS([ncurses/ncurses.h], [],
@@ -483,6 +598,7 @@ else
    # (at this point we already link against a working ncurses library)
    AC_SEARCH_LIBS([keypad], [tinfo])
 fi
+CFLAGS=$htop_save_CFLAGS
 
 if test "$enable_static" = yes; then
    AC_SEARCH_LIBS([Gpm_GetEvent], [gpm])

--- a/configure.ac
+++ b/configure.ac
@@ -379,6 +379,13 @@ fi
 # Checks for cross-platform features and flags.
 # ----------------------------------------------------------------------
 
+dnl PKG_PROG_PKG_CONFIG initializes $PKG_CONFIG and related variables.
+dnl If the macro is not called, some pkg-config checks might be skipped
+dnl and $PKG_CONFIG might be unset.
+m4_ifdef([PKG_PROG_PKG_CONFIG], [
+   PKG_PROG_PKG_CONFIG()
+])
+
 # HTOP_CHECK_SCRIPT(LIBNAME, FUNCTION, DEFINE, CONFIG_SCRIPT, ELSE_PART)
 m4_define([HTOP_CHECK_SCRIPT],
 [
@@ -569,7 +576,6 @@ case "$enable_hwloc" in
       ;;
    yes)
       m4_ifdef([PKG_PROG_PKG_CONFIG], [
-         PKG_PROG_PKG_CONFIG()
          PKG_CHECK_MODULES(HWLOC, hwloc, [
                AM_CFLAGS="$AM_CFLAGS $HWLOC_CFLAGS"
                LIBS="$LIBS $HWLOC_LIBS"

--- a/netbsd/README.md
+++ b/netbsd/README.md
@@ -13,14 +13,21 @@ NetBSD is one of the last operating systems to use and maintain its own
 implementation of Curses.
 
 htop(1) can be compiled against either ncurses or NetBSD's curses(3).
-In order for NetBSD's libcurses to be used, htop(1) must be configured with
-`--disable-unicode`. This is necessary because htop(1) with Unicode enabled
-directly accesses ncurses's cchar_t struct, which has different contents
-in NetBSD's curses.
+By default, htop(1) will use ncurses when it is found, as support for NetBSD's
+curses in htop is limited.
 
-Versions of libcurses in NetBSD 9 and prior have no mouse support
-(this is an ncurses extension). Newer versions contain no-op mouse functions
-for compatibility with ncurses.
+To use NetBSD's libcurses, htop(1) must be configured with `--disable-unicode`.
+Starting with htop 3.4.0, a new option `--with-curses=curses` may be specified
+to let `configure` skip ncurses when both libraries are installed.
+
+Technical caveats regarding NetBSD's curses support:
+
+* htop with Unicode enabled directly accesses ncurses's `cchar_t` struct, which
+  has different contents in NetBSD's curses.
+
+* Versions of libcurses in NetBSD 9 and prior have no mouse support
+  (this is an ncurses extension). Newer versions contain no-op mouse functions
+  for compatibility with ncurses.
 
 What needs improvement
 ---


### PR DESCRIPTION
This PR is intended to supersede #1506

New detection code for `curses` library for `configure`.

* Both `pkg-config` and `ncurses*-config` will be used to find the compiler flags and linker flags for `curses`/`ncurses`. Fall back to simple `-l<libname>` linking if neither utilities are available.
* Environment variables `CURSES_CFLAGS` and `CURSES_LIBS` may be used to override the `--cflags` and `-libs` value.
* New configure option `--with-curses=<libname>` to specify the `curses`/`ncurses` module name. Should be used if the default detect list is not sufficient to find the library.