### PR TITLE
Fix display of CPU utilization on FreeBSD

### DIFF
--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -210,7 +210,7 @@ double Platform_setCPUValues(Meter* this, unsigned int cpu) {
       this->curItems = 4;
       percent = v[CPU_METER_NICE] + v[CPU_METER_NORMAL] + v[CPU_METER_KERNEL] + v[CPU_METER_IRQ];
    } else {
-      v[CPU_METER_NORMAL] = cpuData->systemAllPercent;
+      v[CPU_METER_KERNEL] = cpuData->systemAllPercent;
       this->curItems = 3;
       percent = v[CPU_METER_NICE] + v[CPU_METER_NORMAL] + v[CPU_METER_KERNEL];
    }


### PR DESCRIPTION
After commit c803ec6d htop on FreeBSD doesn't show correct CPU utilization. It seems that author used `CPU_METER_NORMAL` instead of `CPU_METER_KERNEL` (like for other BSDs in that commit).
This commit fixes that. Tested on my 14.0-RELEASE and 15.0-CURRENT.