### PR TITLE
Partial code improvements with respect to Clang 19 warnings

### DIFF
--- a/CategoriesPanel.c
+++ b/CategoriesPanel.c
@@ -42,13 +42,13 @@ static void CategoriesPanel_delete(Object* object) {
 }
 
 static void CategoriesPanel_makeMetersPage(CategoriesPanel* this) {
-   size_t columns = HeaderLayout_getColumns(this->scr->header->headerLayout);
+   unsigned int columns = HeaderLayout_getColumns(this->scr->header->headerLayout);
    MetersPanel** meterPanels = xMallocArray(columns, sizeof(MetersPanel*));
    Settings* settings = this->host->settings;
 
-   for (size_t i = 0; i < columns; i++) {
+   for (unsigned int i = 0; i < columns; i++) {
       char titleBuffer[32];
-      xSnprintf(titleBuffer, sizeof(titleBuffer), "Column %zu", i + 1);
+      xSnprintf(titleBuffer, sizeof(titleBuffer), "Column %u", i + 1);
       meterPanels[i] = MetersPanel_new(settings, titleBuffer, this->header->columns[i], this->scr);
 
       if (i != 0) {

--- a/Header.c
+++ b/Header.c
@@ -51,8 +51,8 @@ void Header_delete(Header* this) {
 }
 
 void Header_setLayout(Header* this, HeaderLayout hLayout) {
-   size_t oldColumns = HeaderLayout_getColumns(this->headerLayout);
-   size_t newColumns = HeaderLayout_getColumns(hLayout);
+   unsigned int oldColumns = HeaderLayout_getColumns(this->headerLayout);
+   unsigned int newColumns = HeaderLayout_getColumns(hLayout);
 
    this->headerLayout = hLayout;
 
@@ -61,11 +61,11 @@ void Header_setLayout(Header* this, HeaderLayout hLayout) {
 
    if (newColumns > oldColumns) {
       this->columns = xReallocArray(this->columns, newColumns, sizeof(Vector*));
-      for (size_t i = oldColumns; i < newColumns; i++)
+      for (unsigned int i = oldColumns; i < newColumns; i++)
          this->columns[i] = Vector_new(Class(Meter), true, DEFAULT_SIZE);
    } else {
       // move meters from to-be-deleted columns into last one
-      for (size_t i = newColumns; i < oldColumns; i++) {
+      for (unsigned int i = newColumns; i < oldColumns; i++) {
          for (int j = this->columns[i]->items - 1; j >= 0; j--) {
             Vector_add(this->columns[newColumns - 1], Vector_take(this->columns[i], j));
          }
@@ -198,7 +198,7 @@ void Header_draw(const Header* this) {
    for (int y = 0; y < height; y++) {
       mvhline(y, 0, ' ', COLS);
    }
-   const int numCols = HeaderLayout_getColumns(this->headerLayout);
+   const int numCols = (int)HeaderLayout_getColumns(this->headerLayout);
    const int width = COLS - 2 * pad - (numCols - 1);
    int x = pad;
    float roundingLoss = 0.0F;
@@ -254,7 +254,7 @@ void Header_updateData(Header* this) {
  * Returns the number of columns to span, i.e. if the direct neighbor is occupied 1.
  */
 static int calcColumnWidthCount(const Header* this, const Meter* curMeter, const int pad, const unsigned int curColumn, const int curHeight) {
-   for (size_t i = curColumn + 1; i < HeaderLayout_getColumns(this->headerLayout); i++) {
+   for (unsigned int i = curColumn + 1; i < HeaderLayout_getColumns(this->headerLayout); i++) {
       const Vector* meters = this->columns[i];
 
       int height = pad;

--- a/Header.h
+++ b/Header.h
@@ -23,7 +23,7 @@ typedef struct Header_ {
    int height;
 } Header;
 
-#define Header_forEachColumn(this_, i_) for (size_t (i_)=0, H_fEC_numColumns_ = HeaderLayout_getColumns((this_)->headerLayout); (i_) < H_fEC_numColumns_; ++(i_))
+#define Header_forEachColumn(this_, i_) for (unsigned int (i_)=0, H_fEC_numColumns_ = HeaderLayout_getColumns((this_)->headerLayout); (i_) < H_fEC_numColumns_; ++(i_))
 
 Header* Header_new(Machine* host, HeaderLayout hLayout);
 

--- a/HeaderLayout.h
+++ b/HeaderLayout.h
@@ -54,7 +54,7 @@ static const struct {
    [HF_FOUR_25_25_25_25] = { 4, { 25, 25, 25, 25 }, "four_25_25_25_25", "4 columns - 25/25/25/25",     },
 };
 
-static inline size_t HeaderLayout_getColumns(HeaderLayout hLayout) {
+static inline unsigned int HeaderLayout_getColumns(HeaderLayout hLayout) {
    /* assert the layout is initialized */
    assert(0 <= hLayout);
    assert(hLayout < LAST_HEADER_LAYOUT);

--- a/Row.c
+++ b/Row.c
@@ -428,23 +428,23 @@ void Row_printNanoseconds(RichString* str, unsigned long long totalNanoseconds, 
    }
 
    unsigned long long totalSeconds = totalMicroseconds / 1000000;
-   unsigned long microseconds = totalMicroseconds % 1000000;
+   uint32_t microseconds = totalMicroseconds % 1000000;
    if (totalSeconds < 60) {
       int width = 5;
-      unsigned long fraction = microseconds / 10;
+      uint32_t fraction = microseconds / 10;
       if (totalSeconds >= 10) {
          width--;
          fraction /= 10;
       }
-      len = xSnprintf(buffer, sizeof(buffer), "%u.%0*lus ", (unsigned int)totalSeconds, width, fraction);
+      len = xSnprintf(buffer, sizeof(buffer), "%u.%0*lus ", (unsigned int)totalSeconds, width, (unsigned long)fraction);
       RichString_appendnAscii(str, baseColor, buffer, len);
       return;
    }
 
    if (totalSeconds < 600) {
-      unsigned int minutes = totalSeconds / 60;
-      unsigned int seconds = totalSeconds % 60;
-      unsigned int milliseconds = microseconds / 1000;
+      unsigned int minutes = (unsigned int)totalSeconds / 60;
+      unsigned int seconds = (unsigned int)totalSeconds % 60;
+      unsigned int milliseconds = (unsigned int)(microseconds / 1000);
       len = xSnprintf(buffer, sizeof(buffer), "%u:%02u.%03u ", minutes, seconds, milliseconds);
       RichString_appendnAscii(str, baseColor, buffer, len);
       return;

--- a/Settings.c
+++ b/Settings.c
@@ -117,11 +117,11 @@ static void Settings_readMeterModes(Settings* this, const char* line, unsigned i
 }
 
 static bool Settings_validateMeters(Settings* this) {
-   const size_t colCount = HeaderLayout_getColumns(this->hLayout);
+   const unsigned int colCount = HeaderLayout_getColumns(this->hLayout);
 
    bool anyMeter = false;
 
-   for (size_t column = 0; column < colCount; column++) {
+   for (unsigned int column = 0; column < colCount; column++) {
       char** names = this->hColumns[column].names;
       const MeterModeId* modes = this->hColumns[column].modes;
       const size_t len = this->hColumns[column].len;
@@ -154,7 +154,7 @@ static void Settings_defaultMeters(Settings* this, unsigned int initialCpuCount)
    }
 
    // Release any previously allocated memory
-   for (size_t i = 0; i < HeaderLayout_getColumns(this->hLayout); i++) {
+   for (unsigned int i = 0; i < HeaderLayout_getColumns(this->hLayout); i++) {
       String_freeArray(this->hColumns[i].names);
       free(this->hColumns[i].modes);
    }


### PR DESCRIPTION
This branch contains my proposal of the code quality changes with respect to Clang 19 warnings. (Notably, `-Wshorten-64-to-32` is enabled by default in Clang 19.) I would try to break these into small changes so that these commits may be cherry-picked into `main` early.

(This pull request is related to #1513)