### PR TITLE
Force rebuild of display table after removals

### DIFF
--- a/Table.c
+++ b/Table.c
@@ -69,7 +69,7 @@ void Table_add(Table* this, Row* row) {
 // removing items.
 // Note: for processes should only be called from ProcessTable_iterate to avoid
 // breaking dying process highlighting.
-void Table_removeIndex(Table* this, const Row* row, int idx) {
+static void Table_removeIndex(Table* this, const Row* row, int idx) {
    int rowid = row->id;
 
    assert(row == (Row*)Vector_get(this->rows, idx));

--- a/Table.h
+++ b/Table.h
@@ -68,8 +68,6 @@ void Table_printHeader(const Settings* settings, RichString* header);
 
 void Table_add(Table* this, struct Row_* row);
 
-void Table_removeIndex(Table* this, const struct Row_* row, int idx);
-
 void Table_updateDisplayList(Table* this);
 
 void Table_expandTree(Table* this);

--- a/Table.h
+++ b/Table.h
@@ -88,6 +88,7 @@ void Table_cleanupRow(Table* this, Row* row, int idx);
 
 static inline void Table_compact(Table* this) {
    Vector_compact(this->rows);
+   this->needsSort = true;
 }
 
 #endif


### PR DESCRIPTION
Table_compact() is called after Table_cleanupRow(), which might remove
rows, which are still referenced by the display table.  Set needsSort to
true so that Table_updateDisplayList() always performs a rebuild and
does access removed rows.

Fixes: https://github.com/htop-dev/htop/issues/1517