### PR TITLE
Silence clang analyzer warnings

### DIFF
--- a/XUtils.h
+++ b/XUtils.h
@@ -14,6 +14,7 @@ in the source distribution for its full text.
 #error "Must have #include \"config.h\" line at the top of the file that includes these XUtils helper functions"
 #endif
 
+#include <dirent.h>
 #include <stdbool.h>
 #include <stddef.h> // IWYU pragma: keep
 #include <stdio.h>
@@ -151,5 +152,21 @@ unsigned int countTrailingZeros(unsigned int x);
 
 /* IEC unit prefixes */
 static const char unitPrefixes[] = { 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y', 'R', 'Q' };
+
+static inline bool skipEndOfLine(FILE* fp) {
+   char buffer[1024];
+   while (fgets(buffer, sizeof(buffer), fp)) {
+      if (strchr(buffer, '\n')) {
+         return true;
+      }
+   }
+   return false;
+}
+
+static inline int xDirfd(DIR* dirp) {
+   int r = dirfd(dirp);
+   assert(r >= 0);
+   return r;
+}
 
 #endif

--- a/linux/LinuxMachine.c
+++ b/linux/LinuxMachine.c
@@ -78,7 +78,7 @@ static void LinuxMachine_updateCPUcount(LinuxMachine* this) {
          continue;
 
 #ifdef HAVE_OPENAT
-      int cpuDirFd = openat(dirfd(dir), entry->d_name, O_DIRECTORY | O_PATH | O_NOFOLLOW);
+      int cpuDirFd = openat(xDirfd(dir), entry->d_name, O_DIRECTORY | O_PATH | O_NOFOLLOW);
       if (cpuDirFd < 0)
          continue;
 #else
@@ -497,11 +497,13 @@ static void LinuxMachine_scanCPUTime(LinuxMachine* this) {
 
    this->period = (double)this->cpuData[0].totalPeriod / super->activeCPUs;
 
-   char buffer[PROC_LINE_LENGTH + 1];
-   while (fgets(buffer, sizeof(buffer), file)) {
-      if (String_startsWith(buffer, "procs_running")) {
-         this->runningTasks = strtoul(buffer + strlen("procs_running"), NULL, 10);
-         break;
+   if (!ferror(file) && !feof(file)) {
+      char buffer[PROC_LINE_LENGTH + 1];
+      while (fgets(buffer, sizeof(buffer), file)) {
+         if (String_startsWith(buffer, "procs_running")) {
+            this->runningTasks = (unsigned int) strtoul(buffer + strlen("procs_running"), NULL, 10);
+            break;
+         }
       }
    }
 

--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -795,12 +795,11 @@ static bool LinuxProcessTable_readSmapsFile(LinuxProcess* process, openat_arg_t 
    while (fgets(buffer, sizeof(buffer), fp)) {
       if (!strchr(buffer, '\n')) {
          // Partial line, skip to end of this line
-         while (fgets(buffer, sizeof(buffer), fp)) {
-            if (strchr(buffer, '\n')) {
-               break;
-            }
+         if (!skipEndOfLine(fp)) {
+            fclose(fp);
+            return false;
          }
-         continue;
+
       }
 
       if (String_startsWith(buffer, "Pss:")) {
@@ -840,12 +839,9 @@ static void LinuxProcessTable_readOpenVZData(LinuxProcess* process, openat_arg_t
    while (fgets(linebuf, sizeof(linebuf), file) != NULL) {
       if (strchr(linebuf, '\n') == NULL) {
          // Partial line, skip to end of this line
-         while (fgets(linebuf, sizeof(linebuf), file) != NULL) {
-            if (strchr(linebuf, '\n') != NULL) {
-               break;
-            }
+         if (!skipEndOfLine(file)) {
+            break;
          }
-         continue;
       }
 
       char* name_value_sep = strchr(linebuf, ':');

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -464,7 +464,7 @@ char* Platform_getProcessEnv(pid_t pid) {
       size += bytes;
       capacity += 4096;
       env = xRealloc(env, capacity);
-   } while ((bytes = fread(env + size, 1, capacity - size, fp)) > 0);
+   } while (!ferror(fp) && !feof(fp) && (bytes = fread(env + size, 1, capacity - size, fp)) > 0);
 
    fclose(fp);
 
@@ -580,7 +580,7 @@ void Platform_getPressureStall(const char* file, bool some, double* ten, double*
       return;
    }
    int total = fscanf(fp, "some avg10=%32lf avg60=%32lf avg300=%32lf total=%*f ", ten, sixty, threehundred);
-   if (!some) {
+   if (total != EOF && !some) {
       total = fscanf(fp, "full avg10=%32lf avg60=%32lf avg300=%32lf total=%*f ", ten, sixty, threehundred);
    }
    (void) total;
@@ -785,7 +785,7 @@ static void Platform_Battery_getSysData(double* percent, ACPresence* isOnAC) {
       const char* entryName = dirEntry->d_name;
 
 #ifdef HAVE_OPENAT
-      int entryFd = openat(dirfd(dir), entryName, O_DIRECTORY | O_PATH);
+      int entryFd = openat(xDirfd(dir), entryName, O_DIRECTORY | O_PATH);
       if (entryFd < 0)
          continue;
 #else


### PR DESCRIPTION
```
    linux/LinuxProcessTable.c:795:11: warning: File position of the stream might be 'indeterminate' after a failed operation. Can cause undefined behavior [unix.Stream]
      795 |    while (fgets(buffer, sizeof(buffer), fp)) {
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    linux/LinuxProcessTable.c:795:11: warning: Read function called when stream is in EOF state. Function has no effect [unix.Stream]
      795 |    while (fgets(buffer, sizeof(buffer), fp)) {
          |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    linux/LinuxProcessTable.c:840:11: warning: File position of the stream might be 'indeterminate' after a failed operation. Can cause undefined behavior [unix.Stream]
      840 |    while (fgets(linebuf, sizeof(linebuf), file) != NULL) {
          |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    linux/LinuxProcessTable.c:840:11: warning: Read function called when stream is in EOF state. Function has no effect [unix.Stream]
      840 |    while (fgets(linebuf, sizeof(linebuf), file) != NULL) {
          |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

    linux/LinuxMachine.c:81:22: warning: The 1st argument to 'openat' is between -99 and -1 but should be a valid file descriptor or AT_FDCWD [unix.StdCLibraryFunctions]
       81 |       int cpuDirFd = openat(dirfd(dir), entry->d_name, O_DIRECTORY | O_PATH | O_NOFOLLOW);
          |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    linux/LinuxMachine.c:501:11: warning: File position of the stream might be 'indeterminate' after a failed operation. Can cause undefined behavior [unix.Stream]
      501 |    while (fgets(buffer, sizeof(buffer), file)) {
          |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    linux/LinuxMachine.c:501:11: warning: Read function called when stream is in EOF state. Function has no effect [unix.Stream]
      501 |    while (fgets(buffer, sizeof(buffer), file)) {
          |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

    linux/Platform.c:467:22: warning: File position of the stream might be 'indeterminate' after a failed operation. Can cause undefined behavior [unix.Stream]
      467 |    } while ((bytes = fread(env + size, 1, capacity - size, fp)) > 0);
          |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    linux/Platform.c:467:22: warning: Read function called when stream is in EOF state. Function has no effect [unix.Stream]
      467 |    } while ((bytes = fread(env + size, 1, capacity - size, fp)) > 0);
          |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    linux/Platform.c:585:15: warning: File position of the stream might be 'indeterminate' after a failed operation. Can cause undefined behavior [unix.Stream]
      585 |       total = fscanf(fp, "full avg10=%32lf avg60=%32lf avg300=%32lf total=%*f ", ten, sixty, threehundred);
          |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    linux/Platform.c:585:15: warning: Read function called when stream is in EOF state. Function has no effect [unix.Stream]
      585 |       total = fscanf(fp, "full avg10=%32lf avg60=%32lf avg300=%32lf total=%*f ", ten, sixty, threehundred);
          |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    linux/Platform.c:789:21: warning: The 1st argument to 'openat' is between -99 and -1 but should be a valid file descriptor or AT_FDCWD [unix.StdCLibraryFunctions]
      789 |       int entryFd = openat(dirfd(dir), entryName, O_DIRECTORY | O_PATH);
          |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Split from #1513