### PR TITLE
configure script improvements regarding pkg-config support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
             release: '14.1'
             usesh: true
             prepare: |
-              pkg install -y gmake autoconf automake git
+              pkg install -y gmake autoconf automake pkgconf git
               git config --global --add safe.directory /home/runner/work/htop/htop
             run: |
               set -e

--- a/Makefile.am
+++ b/Makefile.am
@@ -508,8 +508,9 @@ cppcheck:
 	cppcheck -q -v . --enable=all -DHAVE_OPENVZ
 
 dist-hook: $(top_distdir)/configure
-	@if grep 'pkg_m4_absent' '$(top_distdir)/configure'; then \
-	   echo 'ERROR: configure is generated without pkg.m4. Please supply pkg.m4 and run ./autogen.sh to rebuild the configure script.'>&2; \
+	@if test "x$$FORCE_MAKE_DIST" = x && \
+	   grep 'pkg_m4_absent' '$(top_distdir)/configure' >/dev/null; then \
+	   echo 'ERROR: This distribution would have incomplete pkg-config support. Rebuilding the configure script is advised. Set FORCE_MAKE_DIST=1 to ignore this warning.'>&2; \
 	   (exit 1); \
 	else :; \
 	fi

--- a/README.md
+++ b/README.md
@@ -46,10 +46,13 @@ List of build-time dependencies:
 > This is also something that is reflected in the package name on Debian/Ubuntu (via the additional 'w' - 'w'ide character support).
 
 List of additional build-time dependencies (based on feature flags):
+*  `pkg-config`
 *  `sensors`
 *  `hwloc`
 *  `libcap` (v2.21 or later)
 *  `libnl-3` and `libnl-genl-3`
+
+`pkg-config` is optional but recommended. The configure script of `htop` might utilize `pkg-config` to obtain the compiler and linker flags required for a library. Some OS distributions provide `pkg-config` functionalities through an alternative implementation such as `pkgconf`. Look for both names in your package manager.
 
 Install these and other required packages for C development from your package manager.
 

--- a/configure.ac
+++ b/configure.ac
@@ -384,6 +384,11 @@ dnl If the macro is not called, some pkg-config checks might be skipped
 dnl and $PKG_CONFIG might be unset.
 m4_ifdef([PKG_PROG_PKG_CONFIG], [
    PKG_PROG_PKG_CONFIG()
+], [
+   pkg_m4_absent=1 # Makefile might grep this keyword. Don't remove.
+   m4_warn(
+      [syntax],
+      [pkg.m4 is absent or older than version 0.16; this 'configure' would have incomplete pkg-config support])
 ])
 
 # HTOP_CHECK_SCRIPT(LIBNAME, FUNCTION, DEFINE, CONFIG_SCRIPT, ELSE_PART)

--- a/configure.ac
+++ b/configure.ac
@@ -614,7 +614,7 @@ AC_DEFINE_UNQUOTED([OSRELEASEFILE], ["$with_os_release"], [File with OS release 
 
 AC_ARG_WITH([config],
             [AS_HELP_STRING([--with-config=DIR],
-			    [configuration path @<:@default=/.config@:>@])],
+                            [configuration path @<:@default=/.config@:>@])],
             [],
             [with_config="/.config"])
 dnl Performance Co-Pilot configuration location to prevent overwrite

--- a/configure.ac
+++ b/configure.ac
@@ -379,6 +379,13 @@ fi
 # Checks for cross-platform features and flags.
 # ----------------------------------------------------------------------
 
+dnl PKG_PROG_PKG_CONFIG initializes $PKG_CONFIG and related variables.
+dnl If the macro is not called, some pkg-config checks might be skipped
+dnl and $PKG_CONFIG might be unset.
+m4_ifdef([PKG_PROG_PKG_CONFIG], [
+   PKG_PROG_PKG_CONFIG()
+])
+
 # HTOP_CHECK_SCRIPT(LIBNAME, FUNCTION, DEFINE, CONFIG_SCRIPT, ELSE_PART)
 m4_define([HTOP_CHECK_SCRIPT],
 [
@@ -569,7 +576,6 @@ case "$enable_hwloc" in
       ;;
    yes)
       m4_ifdef([PKG_PROG_PKG_CONFIG], [
-         PKG_PROG_PKG_CONFIG()
          PKG_CHECK_MODULES(HWLOC, hwloc, [
                AM_CFLAGS="$AM_CFLAGS $HWLOC_CFLAGS"
                LIBS="$LIBS $HWLOC_LIBS"


### PR DESCRIPTION
* Move the macro call of PKG_PROG_PKG_CONFIG.
* Bring back the warning when configure is generated without pkg.m4
* CI FreeBSD job now installs pkg-config.