### PR TITLE
Disable user name lookup in static builds against glibc

### DIFF
--- a/UsersTable.c
+++ b/UsersTable.c
@@ -30,6 +30,7 @@ void UsersTable_delete(UsersTable* this) {
 }
 
 char* UsersTable_getRef(UsersTable* this, unsigned int uid) {
+#if !defined(BUILD_STATIC) || !defined(__GLIBC__)
    char* name = Hashtable_get(this->users, uid);
    if (name == NULL) {
       const struct passwd* userData = getpwuid(uid);
@@ -39,6 +40,11 @@ char* UsersTable_getRef(UsersTable* this, unsigned int uid) {
       }
    }
    return name;
+#else
+   (void)this;
+   (void)uid;
+   return NULL;
+#endif
 }
 
 inline void UsersTable_foreach(UsersTable* this, Hashtable_PairFunction f, void* userData) {


### PR DESCRIPTION
Static linking against glibc might crash due to usage of NSS modules, e.g. via getpwuid() (see #503).
The linker also warns about it:

    warning: Using 'getpwuid' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking