### PR TITLE
Normalize DiskIOMeter bar by number of disks

### DIFF
--- a/DiskIOMeter.h
+++ b/DiskIOMeter.h
@@ -16,6 +16,7 @@ typedef struct DiskIOData_ {
    uint64_t totalBytesRead;
    uint64_t totalBytesWritten;
    uint64_t totalMsTimeSpend;
+   uint64_t numDisks;
 } DiskIOData;
 
 extern const MeterClass DiskIOMeter_class;

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -404,7 +404,7 @@ bool Platform_getDiskIO(DiskIOData* data) {
    if (IOServiceGetMatchingServices(iokit_port, IOServiceMatching("IOBlockStorageDriver"), &drive_list))
       return false;
 
-   unsigned long long int read_sum = 0, write_sum = 0, timeSpend_sum = 0;
+   uint64_t read_sum = 0, write_sum = 0, timeSpend_sum = 0;
    uint64_t numDisks = 0;
 
    io_registry_entry_t drive;
@@ -437,7 +437,7 @@ bool Platform_getDiskIO(DiskIOData* data) {
       numDisks++;
 
       CFNumberRef number;
-      unsigned long long int value;
+      uint64_t value;
 
       /* Get bytes read */
       number = (CFNumberRef) CFDictionaryGetValue(statistics, CFSTR(kIOBlockStorageDriverStatisticsBytesReadKey));

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -405,6 +405,7 @@ bool Platform_getDiskIO(DiskIOData* data) {
       return false;
 
    unsigned long long int read_sum = 0, write_sum = 0, timeSpend_sum = 0;
+   uint64_t numDisks = 0;
 
    io_registry_entry_t drive;
    while ((drive = IOIteratorNext(drive_list)) != 0) {
@@ -432,6 +433,8 @@ bool Platform_getDiskIO(DiskIOData* data) {
          IOObjectRelease(drive);
          continue;
       }
+
+      numDisks++;
 
       CFNumberRef number;
       unsigned long long int value;
@@ -471,6 +474,7 @@ bool Platform_getDiskIO(DiskIOData* data) {
    data->totalBytesRead = read_sum;
    data->totalBytesWritten = write_sum;
    data->totalMsTimeSpend = timeSpend_sum / 1e6; /* Convert from ns to ms */
+   data->numDisks = numDisks;
 
    if (drive_list)
       IOObjectRelease(drive_list);

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -280,6 +280,7 @@ bool Platform_getDiskIO(DiskIOData* data) {
    uint64_t bytesReadSum = 0;
    uint64_t bytesWriteSum = 0;
    uint64_t busyMsTimeSum = 0;
+   uint64_t numDisks = 0;
 
    for (int i = 0; i < dev_stats.dinfo->numdevs; i++) {
       const struct devstat* device = &dev_stats.dinfo->devices[dev_sel[i].position];
@@ -301,11 +302,13 @@ bool Platform_getDiskIO(DiskIOData* data) {
       bytesReadSum  += device->bytes_read;
       bytesWriteSum += device->bytes_written;
       busyMsTimeSum += (device->busy_time.tv_sec * 1000 + device->busy_time.tv_usec / 1000);
+      numDisks++;
    }
 
    data->totalBytesRead = bytesReadSum;
    data->totalBytesWritten = bytesWriteSum;
    data->totalMsTimeSpend = busyMsTimeSum;
+   data->numDisks = numDisks;
 
    free(dev_stats.dinfo);
    return true;

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -312,7 +312,7 @@ bool Platform_getDiskIO(DiskIOData* data) {
 
    int count = current.dinfo->numdevs;
 
-   unsigned long long int bytesReadSum = 0, bytesWriteSum = 0, timeSpendSum = 0;
+   uint64_t bytesReadSum = 0, bytesWriteSum = 0, timeSpendSum = 0;
    uint64_t numDisks = 0;
 
    // get data

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -313,6 +313,7 @@ bool Platform_getDiskIO(DiskIOData* data) {
    int count = current.dinfo->numdevs;
 
    unsigned long long int bytesReadSum = 0, bytesWriteSum = 0, timeSpendSum = 0;
+   uint64_t numDisks = 0;
 
    // get data
    for (int i = 0; i < count; i++) {
@@ -330,11 +331,13 @@ bool Platform_getDiskIO(DiskIOData* data) {
       bytesReadSum += bytes_read;
       bytesWriteSum += bytes_write;
       timeSpendSum += 1000 * busy_time;
+      numDisks++;
    }
 
    data->totalBytesRead = bytesReadSum;
    data->totalBytesWritten = bytesWriteSum;
    data->totalMsTimeSpend = timeSpendSum;
+   data->numDisks = numDisks;
    return true;
 }
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -613,7 +613,7 @@ bool Platform_getDiskIO(DiskIOData* data) {
 
    char lastTopDisk[32] = { '\0' };
 
-   unsigned long long int read_sum = 0, write_sum = 0, timeSpend_sum = 0;
+   uint64_t read_sum = 0, write_sum = 0, timeSpend_sum = 0;
    uint64_t numDisks = 0;
 
    char lineBuffer[256];

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -614,6 +614,8 @@ bool Platform_getDiskIO(DiskIOData* data) {
    char lastTopDisk[32] = { '\0' };
 
    unsigned long long int read_sum = 0, write_sum = 0, timeSpend_sum = 0;
+   uint64_t numDisks = 0;
+
    char lineBuffer[256];
    while (fgets(lineBuffer, sizeof(lineBuffer), fp)) {
       char diskname[32];
@@ -635,6 +637,7 @@ bool Platform_getDiskIO(DiskIOData* data) {
          read_sum += read_tmp;
          write_sum += write_tmp;
          timeSpend_sum += timeSpend_tmp;
+         numDisks++;
       }
    }
    fclose(fp);
@@ -642,6 +645,7 @@ bool Platform_getDiskIO(DiskIOData* data) {
    data->totalBytesRead = 512 * read_sum;
    data->totalBytesWritten = 512 * write_sum;
    data->totalMsTimeSpend = timeSpend_sum;
+   data->numDisks = numDisks;
    return true;
 }
 

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -384,6 +384,7 @@ bool Platform_getDiskIO(DiskIOData* data) {
    uint64_t bytesReadSum = 0;
    uint64_t bytesWriteSum = 0;
    uint64_t busyTimeSum = 0;
+   uint64_t numDisks = 0;
 
    for (size_t i = 0, count = size / sizeof(struct io_sysctl); i < count; i++) {
       /* ignore NFS activity */
@@ -393,11 +394,13 @@ bool Platform_getDiskIO(DiskIOData* data) {
       bytesReadSum += iostats[i].rbytes;
       bytesWriteSum += iostats[i].wbytes;
       busyTimeSum += iostats[i].busysum_usec;
+      numDisks++;
    }
 
    data->totalBytesRead = bytesReadSum;
    data->totalBytesWritten = bytesWriteSum;
    data->totalMsTimeSpend = busyTimeSum / 1000;
+   data->numDisks = numDisks;
 
    free(iostats);
    return true;

--- a/pcp/Metric.h
+++ b/pcp/Metric.h
@@ -26,6 +26,7 @@ typedef enum Metric_ {
    PCP_CONTROL_THREADS,         /* proc.control.perclient.threads */
 
    PCP_HINV_NCPU,               /* hinv.ncpu */
+   PCP_HINV_NDISK,              /* hinv.ndisk */
    PCP_HINV_CPUCLOCK,           /* hinv.cpu.clock */
    PCP_UNAME_SYSNAME,           /* kernel.uname.sysname */
    PCP_UNAME_RELEASE,           /* kernel.uname.release */

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -127,6 +127,7 @@ static const char* Platform_metricNames[] = {
    [PCP_CONTROL_THREADS] = "proc.control.perclient.threads",
 
    [PCP_HINV_NCPU] = "hinv.ncpu",
+   [PCP_HINV_NDISK] = "hinv.ndisk",
    [PCP_HINV_CPUCLOCK] = "hinv.cpu.clock",
    [PCP_UNAME_SYSNAME] = "kernel.uname.sysname",
    [PCP_UNAME_RELEASE] = "kernel.uname.release",
@@ -385,6 +386,7 @@ bool Platform_init(void) {
    Metric_enable(PCP_PID_MAX, true);
    Metric_enable(PCP_BOOTTIME, true);
    Metric_enable(PCP_HINV_NCPU, true);
+   Metric_enable(PCP_HINV_NDISK, true);
    Metric_enable(PCP_PERCPU_SYSTEM, true);
    Metric_enable(PCP_UNAME_SYSNAME, true);
    Metric_enable(PCP_UNAME_RELEASE, true);
@@ -753,6 +755,8 @@ bool Platform_getDiskIO(DiskIOData* data) {
       data->totalBytesWritten = value.ull;
    if (Metric_values(PCP_DISK_ACTIVE, &value, 1, PM_TYPE_U64) != NULL)
       data->totalMsTimeSpend = value.ull;
+   if (Metric_values(PCP_HINV_NDISK, &value, 1, PM_TYPE_U64) != NULL)
+      data->numDisks = value.ull;
    return true;
 }
 


### PR DESCRIPTION
The maximum utilization should be "100% * number of disks". Set the bar and graph of the meter to draw with that maximum. Also remove the 100% cap on the utilization percentage display.

Resolves #1374.
