### PR TITLE
Add an option to hide or show Cache and Buffers in Graph mode

### DIFF
--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -149,6 +149,7 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
                                                  &(settings->showCPUTemperature)));
    Panel_add(super, (Object*) CheckItem_newByRef("- Show temperature in degree Fahrenheit instead of Celsius", &(settings->degreeFahrenheit)));
    #endif
+   Panel_add(super, (Object *)CheckItem_newByRef("Show cached memory in graph", &(settings->showCachedMemory)));
    #ifdef HAVE_GETMOUSE
    Panel_add(super, (Object*) CheckItem_newByRef("Enable the mouse", &(settings->enableMouse)));
    #endif

--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -149,7 +149,7 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
                                                  &(settings->showCPUTemperature)));
    Panel_add(super, (Object*) CheckItem_newByRef("- Show temperature in degree Fahrenheit instead of Celsius", &(settings->degreeFahrenheit)));
    #endif
-   Panel_add(super, (Object *)CheckItem_newByRef("Show cached memory in graph", &(settings->showCachedMemory)));
+   Panel_add(super, (Object*) CheckItem_newByRef("Show cached memory in graph", &(settings->showCachedMemory)));
    #ifdef HAVE_GETMOUSE
    Panel_add(super, (Object*) CheckItem_newByRef("Enable the mouse", &(settings->enableMouse)));
    #endif

--- a/MemoryMeter.c
+++ b/MemoryMeter.c
@@ -46,7 +46,7 @@ static void MemoryMeter_updateValues(Meter* this) {
    }
    /* Do not print available memory in bar mode */
    static_assert(MEMORY_METER_AVAILABLE + 1 == MEMORY_METER_ITEMCOUNT,
-                  "MEMORY_METER_AVAILABLE is not the last item in MemoryMeterValues");
+      "MEMORY_METER_AVAILABLE is not the last item in MemoryMeterValues");
    this->curItems = MEMORY_METER_AVAILABLE;
 
    /* we actually want to show "used + shared + compressed" */

--- a/MemoryMeter.c
+++ b/MemoryMeter.c
@@ -40,9 +40,9 @@ static void MemoryMeter_updateValues(Meter* this) {
    this->values[MEMORY_METER_COMPRESSED] = NAN;
    this->values[MEMORY_METER_AVAILABLE] = NAN;
    Platform_setMemoryValues(this);
-   if (this->mode == GRAPH_METERMODE && !settings->showCachedMemory) {
-      this->values[MEMORY_METER_BUFFERS] = NAN;
-      this->values[MEMORY_METER_CACHE] = NAN;
+   if ((this->mode == GRAPH_METERMODE || this->mode == BAR_METERMODE) && !settings->showCachedMemory) {
+      this->values[MEMORY_METER_BUFFERS] = 0;
+      this->values[MEMORY_METER_CACHE] = 0;
    }
    /* Do not print available memory in bar mode */
    static_assert(MEMORY_METER_AVAILABLE + 1 == MEMORY_METER_ITEMCOUNT,

--- a/MemoryMeter.c
+++ b/MemoryMeter.c
@@ -33,15 +33,21 @@ static void MemoryMeter_updateValues(Meter* this) {
    size_t size = sizeof(this->txtBuffer);
    int written;
 
+   Settings *settings = this->host->settings;
+
    /* shared, compressed and available memory are not supported on all platforms */
    this->values[MEMORY_METER_SHARED] = NAN;
    this->values[MEMORY_METER_COMPRESSED] = NAN;
    this->values[MEMORY_METER_AVAILABLE] = NAN;
    Platform_setMemoryValues(this);
-
+   if (this->mode == GRAPH_METERMODE && !settings->showCachedMemory)
+   {
+      this->values[MEMORY_METER_BUFFERS] = NAN;
+      this->values[MEMORY_METER_CACHE] = NAN;
+   }
    /* Do not print available memory in bar mode */
    static_assert(MEMORY_METER_AVAILABLE + 1 == MEMORY_METER_ITEMCOUNT,
-      "MEMORY_METER_AVAILABLE is not the last item in MemoryMeterValues");
+                  "MEMORY_METER_AVAILABLE is not the last item in MemoryMeterValues");
    this->curItems = MEMORY_METER_AVAILABLE;
 
    /* we actually want to show "used + shared + compressed" */

--- a/MemoryMeter.c
+++ b/MemoryMeter.c
@@ -40,8 +40,7 @@ static void MemoryMeter_updateValues(Meter* this) {
    this->values[MEMORY_METER_COMPRESSED] = NAN;
    this->values[MEMORY_METER_AVAILABLE] = NAN;
    Platform_setMemoryValues(this);
-   if (this->mode == GRAPH_METERMODE && !settings->showCachedMemory)
-   {
+   if (this->mode == GRAPH_METERMODE && !settings->showCachedMemory) {
       this->values[MEMORY_METER_BUFFERS] = NAN;
       this->values[MEMORY_METER_CACHE] = NAN;
    }

--- a/Settings.c
+++ b/Settings.c
@@ -699,6 +699,7 @@ int Settings_write(const Settings* this, bool onCrash) {
    printSettingInteger("show_cpu_temperature", this->showCPUTemperature);
    printSettingInteger("degree_fahrenheit", this->degreeFahrenheit);
    #endif
+   printSettingInteger("show_cached_memory", this->showCachedMemory);
    printSettingInteger("update_process_names", this->updateProcessNames);
    printSettingInteger("account_guest_in_cpu_meter", this->accountGuestInCPUMeter);
    printSettingInteger("color_scheme", this->colorScheme);

--- a/Settings.c
+++ b/Settings.c
@@ -466,6 +466,8 @@ static bool Settings_read(Settings* this, const char* fileName, const Machine* h
          this->showCPUUsage = atoi(option[1]);
       } else if (String_eq(option[0], "show_cpu_frequency")) {
          this->showCPUFrequency = atoi(option[1]);
+      } else if (String_eq(option[0], "show_cached_memory")) {
+         this->showCachedMemory = atoi(option[1]);
       #ifdef BUILD_WITH_CPU_TEMP
       } else if (String_eq(option[0], "show_cpu_temperature")) {
          this->showCPUTemperature = atoi(option[1]);
@@ -801,6 +803,7 @@ Settings* Settings_new(const Machine* host, Hashtable* dynamicMeters, Hashtable*
    this->showCPUTemperature = false;
    this->degreeFahrenheit = false;
    #endif
+   this->showCachedMemory = true;
    this->updateProcessNames = false;
    this->showProgramPath = true;
    this->highlightThreads = true;

--- a/Settings.h
+++ b/Settings.h
@@ -101,6 +101,7 @@ typedef struct Settings_ {
    bool accountGuestInCPUMeter;
    bool headerMargin;
    bool screenTabs;
+   bool showCachedMemory;
    #ifdef HAVE_GETMOUSE
    bool enableMouse;
    #endif


### PR DESCRIPTION
This PR covers issue #407.
```
[x]    Show cached memory in graph
```
Added this option to "Display Options". It's enabled by default to be compatible with current behavior. Disabling it will remove Cache and Buffers memory from Memory Graph and Mem&Swp Graph.