### PR TITLE
Stopgap solution to preserve colors and attributes on highlighting

### DIFF
--- a/Panel.c
+++ b/Panel.c
@@ -289,7 +289,7 @@ void Panel_draw(Panel* this, bool force_redraw, bool focus, bool highlightSelect
          }
          if (item.highlightAttr) {
             attrset(item.highlightAttr);
-            RichString_setAttr(&item, item.highlightAttr);
+            RichString_setAttr_preserveBold(&item, item.highlightAttr);
             this->selectedLen = itemLen;
          }
          mvhline(y + line, x, ' ', this->w);

--- a/RichString.c
+++ b/RichString.c
@@ -169,6 +169,28 @@ void RichString_appendChr(RichString* this, int attrs, char c, int count) {
    }
 }
 
+inline void RichString_setAttrn_preserveBold(RichString* this, int attrs, int start, int finish) {
+   cchar_t* ch = this->chptr + start;
+   finish = CLAMP(finish, 0, this->chlen - 1);
+   for (int i = start; i <= finish; i++) {
+      ch->attr = (ch->attr & A_BOLD) ? (attrs | A_BOLD) : attrs;
+      ch++;
+   }
+}
+
+void RichString_setAttrn_preserveBold(RichString* this, int attrs, int start, int finish) {
+   chtype* ch = this->chptr + start;
+   finish = CLAMP(finish, 0, this->chlen - 1);
+   for (int i = start; i <= finish; i++) {
+      *ch = (*ch & 0xff) | attrs | (*ch & A_BOLD);
+      ch++;
+   }
+}
+
+void RichString_setAttr_preserveBold(RichString* this, int attrs) {
+   RichString_setAttrn_preserveBold(this, attrs, 0, this->chlen - 1);
+}
+
 int RichString_findChar(const RichString* this, char c, int start) {
    const wchar_t wc = btowc(c);
    const cchar_t* ch = this->chptr + start;

--- a/RichString.c
+++ b/RichString.c
@@ -169,20 +169,11 @@ void RichString_appendChr(RichString* this, int attrs, char c, int count) {
    }
 }
 
-inline void RichString_setAttrn_preserveBold(RichString* this, int attrs, int start, int finish) {
+void RichString_setAttrn_preserveBold(RichString* this, int attrs, int start, int finish) {
    cchar_t* ch = this->chptr + start;
    finish = CLAMP(finish, 0, this->chlen - 1);
    for (int i = start; i <= finish; i++) {
-      ch->attr = (ch->attr & A_BOLD) ? (attrs | A_BOLD) : attrs;
-      ch++;
-   }
-}
-
-void RichString_setAttrn_preserveBold(RichString* this, int attrs, int start, int finish) {
-   chtype* ch = this->chptr + start;
-   finish = CLAMP(finish, 0, this->chlen - 1);
-   for (int i = start; i <= finish; i++) {
-      *ch = (*ch & 0xff) | attrs | (*ch & A_BOLD);
+      ch->attr = (ch->attr & A_BOLD) ? ((unsigned int)attrs | A_BOLD) : (unsigned int)attrs;
       ch++;
    }
 }

--- a/RichString.h
+++ b/RichString.h
@@ -52,9 +52,13 @@ void RichString_rewind(RichString* this, int count);
 
 void RichString_setAttrn(RichString* this, int attrs, int start, int charcount);
 
+void RichString_setAttrn_preserveBold(RichString* this, int attrs, int start, int finish);
+
 int RichString_findChar(const RichString* this, char c, int start);
 
 void RichString_setAttr(RichString* this, int attrs);
+
+void RichString_setAttr_preserveBold(RichString* this, int attrs);
 
 void RichString_appendChr(RichString* this, int attrs, char c, int count);
 


### PR DESCRIPTION
[Screencast_20240929_172318.webm](https://github.com/user-attachments/assets/0418af32-457f-4a61-bdbc-c8e890682166)

This is a decent workaround for https://github.com/htop-dev/htop/issues/243 solely by using text attributes taking https://github.com/htop-dev/htop/pull/434 and adapting it.  
This is a stopgap solution until the issue is properly resolved by actually being able to define the desired text colors while keeping the highlight background, which I assume will take a while.

There is a couple problems:
  * Function is from original PR needs renaming `RichString_setAttrn_preserveBold` -> `RichString_setAttrn_preserve` ?
  * There are debug statements left in the current code, will be removed upon finalization
  * I am not a C/C++ dev, someone please verify my actual functional code makes sense
    * Currently I check if text color is not default (ColorPair 0) or if text is Bolded, is there even a situation where text is bolded but not colored?
  * The entire column gets lit up - is this desired? I presume not. 
    * Should I solve this in my code by ensuring the char is not a space, or should this be fixed in other code that ensures it's not setting params and text colors for spaces?  
![image](https://github.com/user-attachments/assets/b3d0da09-d5ad-487d-bad7-32425b0263ac)
  * Biggest thorn is the fact that we can be setting highlight color that is identical to text color, which means we are not highlighting anything. This is detected and text attribute is set to italics to at least differentiate it, but it is not an amazing solution, we would have to be able to italicize the entire column for it to not look like ass:  
![image](https://github.com/user-attachments/assets/ad85a34d-269f-4d1d-ab54-bafae6b0c8fc)


Mildly related to #1541