### PR TITLE
adding bar_label parameter to htoprc

### DIFF
--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -156,6 +156,7 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    Panel_add(super, (Object*) CheckItem_newByRef("Highlight new and old processes", &(settings->highlightChanges)));
    Panel_add(super, (Object*) NumberItem_newByRef("- Highlight time (in seconds)", &(settings->highlightDelaySecs), 0, 1, 24 * 60 * 60));
    Panel_add(super, (Object*) NumberItem_newByRef("Hide main function bar (0 - off, 1 - on ESC until next input, 2 - permanently)", &(settings->hideFunctionBar), 0, 0, 2));
+   Panel_add(super, (Object*) NumberItem_newByRef("Bar Type (0-7)", &(settings->barType), 0, 0, 7));
    #ifdef HAVE_LIBHWLOC
    Panel_add(super, (Object*) CheckItem_newByRef("Show topology when selecting affinity by default", &(settings->topologyAffinity)));
    #endif

--- a/Settings.h
+++ b/Settings.h
@@ -111,6 +111,8 @@ typedef struct Settings_ {
 
    bool changed;
    uint64_t lastUpdate;
+
+   int barType;
 } Settings;
 
 #define Settings_cpuId(settings, cpu) ((settings)->countCPUsFromOne ? (cpu)+1 : (cpu))


### PR DESCRIPTION
adding bar_label feature to change the pipe in htop to any other ascii character user wants


this is addressing feature request #647 

The PR only has support for normal ascii characters

i can extend this feature to add UTF-8 characters but the CONTRIBUTING.md suggested that newer features shouldn't unnecessarily increase the footprint of the program
(this is my first commit btw so i don't know much)

also Please look if the change in the file Settings.c is correct
options[1][0] doesn't seem a good way to get the character on right of = sign