### PR TITLE
README: clarification on kernel requirements for I/O

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ To install on the local system run `make install`. By default `make install` ins
 * `libsensors`, readout of temperatures and CPU speeds, is optional even when `--enable-sensors` was used to configure `htop`.
 * `libsystemd` is optional when `--enable-static` was not used to configure `htop`. If building statically and `libsystemd` is not found by `configure`, support for the systemd meter is disabled entirely.
 * `libnl-3` and `libnl-genl-3`, if `htop` was configured with `--enable-delayacct` and delay accounting process fields are active.
+* I/O counters are available when the kernel is compiled with `CONFIG_TASK_IO_ACCOUNTING=Y`.
 
 `htop` checks for the availability of the actual runtime libraries as `htop` runs.
 


### PR DESCRIPTION
After reducing the kernel features, I found that htop showed for DISK R/W, DISK READ, DISK WRITE `N/A`.  Then I figured out when the file `/proc/$PID/task/$PID/io` was maintained and here comes the outcome.