### PR TITLE
Change Memory Usage to macOS top(1)'s Method

### DIFF
--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -307,10 +307,8 @@ void Platform_setMemoryValues(Meter* mtr) {
 
    mtr->total = dhost->host_info.max_mem / 1024;
 #ifdef HAVE_STRUCT_VM_STATISTICS64
-   natural_t used = vm->active_count + vm->inactive_count +
-              vm->speculative_count + vm->wire_count +
-              vm->compressor_page_count - vm->purgeable_count - vm->external_page_count;
-   mtr->values[MEMORY_METER_USED] = (double)(used - vm->compressor_page_count) * page_K;
+   natural_t used = vm->wire_count + vm->inactive_count + vm->active_count;
+   mtr->values[MEMORY_METER_USED] = (double)(used + vm->compressor_page_count) * page_K;
 #else
    mtr->values[MEMORY_METER_USED] = (double)(vm->active_count + vm->wire_count) * page_K;
 #endif


### PR DESCRIPTION
See here: https://github.com/apple-opensource/top/blob/e7979606cf63270663a62cfe69f82d35cef9ba58/globalstats.c#L433-L435

Edit:

Please note I'm away from home currently and won't be able to test on my M2 Mac Mini Pro until tomorrow at the earliest. I'm hoping the code change I made here does actually match what top(1) shows now.