### PR TITLE
Fix possible memory leak in Settings

### DIFF
--- a/Settings.c
+++ b/Settings.c
@@ -650,11 +650,15 @@ int Settings_write(const Settings* this, bool onCrash) {
       xAsprintf(&tmpFilename, "%s.tmp.XXXXXX", this->filename);
       int fdtmp = mkstemp(tmpFilename);
       umask(cur_umask);
-      if (fdtmp == -1)
+      if (fdtmp == -1) {
+         free(tmpFilename);
          return -errno;
+      }
       fp = fdopen(fdtmp, "w");
-      if (!fp)
+      if (!fp) {
+         free(tmpFilename);
          return -errno;
+      }
       separator = '\n';
       of = fprintf;
    }


### PR DESCRIPTION
The pointer returned by ```vasprintf()``` should be passed to ```free()``` to release the allocated storage when it is no longer needed.
There were two return statements without previous freeing ```tmpFilename```.