### PR TITLE
Memory usage reporting for FreeBSD is incorrect

### DIFF
--- a/freebsd/FreeBSDMachine.c
+++ b/freebsd/FreeBSDMachine.c
@@ -340,12 +340,10 @@ static void FreeBSDMachine_scanMemoryInfo(Machine* super) {
    len = sizeof(memActive);
    sysctl(MIB_vm_stats_vm_v_active_count, 4, &(memActive), &len, NULL, 0);
    memActive *= this->pageSizeKb;
-   this->memActive = memActive;
 
    len = sizeof(memWire);
    sysctl(MIB_vm_stats_vm_v_wire_count, 4, &(memWire), &len, NULL, 0);
    memWire *= this->pageSizeKb;
-   this->memWire = memWire;
 
    len = sizeof(buffersMem);
    sysctl(MIB_vfs_bufspace, 2, &(buffersMem), &len, NULL, 0);
@@ -361,7 +359,7 @@ static void FreeBSDMachine_scanMemoryInfo(Machine* super) {
    sysctl(MIB_vm_vmtotal, 2, &(vmtotal), &len, NULL, 0);
    super->sharedMem = vmtotal.t_rmshr * this->pageSizeKb;
 
-   super->usedMem = this->memActive + this->memWire;
+   super->usedMem = memActive + memWire;
 
    struct kvm_swap swap[16];
    int nswap = kvm_getswapinfo(this->kd, swap, ARRAYSIZE(swap), 0);

--- a/freebsd/FreeBSDMachine.h
+++ b/freebsd/FreeBSDMachine.h
@@ -36,9 +36,6 @@ typedef struct FreeBSDMachine_ {
    int pageSizeKb;
    int kernelFScale;
 
-   unsigned long long int memWire;
-   unsigned long long int memActive;
-
    ZfsArcStats zfs;
 
    CPUData* cpus;


### PR DESCRIPTION
Firstly the biggest issue, htop didn't count the 'inactive' memory (`vm.stats.vm.v_inactive_count`) as used memory, but as free; this is incorrect. The inactive pages reported by the kernel are memory pages allocated by user space programs that are not **recently** used, and are therefore available for swapping out in case system is short in memory; these are definitely **not** free pages. This part of memory is usually considerably big in most systems, as a result htop had wrongly reported a big part of memory as 'free'.

Additionally the VFS buffer size as reported in `vfs.bufspace` (which belongs to caches in htop's view) is actually included in the 'wired' memory (`vm.stats.vm.v_wire_count`). The total used memory in htop should be subtracted by this size.

htop also mistakenly mapped kFreeBSD 'VFS buffer' into its own 'buffers' memory class, but this Linux-originated 'buffers' memory don't have the same meaning. VFS buffer is actually used for file system caches, utilized by most file systems other than ZFS.

Along with the bug fixes, the corresponding comments has also been corrected and extended to better document the memory class mapping between htop and kFreeBSD.

