### PR TITLE
Replaced `xMalloc+xSnprintf` with `xAsprintf` in PCP platform code

### DIFF
--- a/pcp/PCPDynamicColumn.c
+++ b/pcp/PCPDynamicColumn.c
@@ -36,9 +36,8 @@ static bool PCPDynamicColumn_addMetric(PCPDynamicColumns* columns, PCPDynamicCol
    if (!column->super.name[0])
       return false;
 
-   size_t bytes = 16 + strlen(column->super.name);
-   char* metricName = xMalloc(bytes);
-   xSnprintf(metricName, bytes, "htop.column.%s", column->super.name);
+   char* metricName = NULL;
+   xAsprintf(&metricName, "htop.column.%s", column->super.name);
 
    column->metricName = metricName;
    column->id = columns->offset + columns->cursor;

--- a/pcp/PCPDynamicMeter.c
+++ b/pcp/PCPDynamicMeter.c
@@ -30,9 +30,8 @@ in the source distribution for its full text.
 
 
 static PCPDynamicMetric* PCPDynamicMeter_lookupMetric(PCPDynamicMeters* meters, PCPDynamicMeter* meter, const char* name) {
-   size_t bytes = 16 + strlen(meter->super.name) + strlen(name);
-   char* metricName = xMalloc(bytes);
-   xSnprintf(metricName, bytes, "htop.meter.%s.%s", meter->super.name, name);
+   char* metricName = NULL;
+   xAsprintf(&metricName, "htop.meter.%s.%s", meter->super.name, name);
 
    PCPDynamicMetric* metric;
    for (size_t i = 0; i < meter->totalMetrics; i++) {

--- a/pcp/PCPDynamicScreen.c
+++ b/pcp/PCPDynamicScreen.c
@@ -71,13 +71,11 @@ static void PCPDynamicScreens_appendDynamicColumns(PCPDynamicScreens* screens, P
 
 static PCPDynamicColumn* PCPDynamicScreen_lookupMetric(PCPDynamicScreen* screen, const char* name) {
    PCPDynamicColumn* column = NULL;
-   size_t bytes = strlen(name) + strlen(screen->super.name) + 1; /* colon */
-   if (bytes >= sizeof(column->super.name))
+   if ((strlen(name) + strlen(screen->super.name) + 1) >= sizeof(column->super.name)) /* colon */
       return NULL;
-
-   bytes += 16; /* prefix, dots and terminator */
-   char* metricName = xMalloc(bytes);
-   xSnprintf(metricName, bytes, "htop.screen.%s.%s", screen->super.name, name);
+    
+    char* metricName = NULL;
+    xAsprintf(&metricName, "htop.screen.%s.%s", screen->super.name, name);
 
    for (size_t i = 0; i < screen->totalColumns; i++) {
       column = screen->columns[i];

--- a/pcp/PCPDynamicScreen.c
+++ b/pcp/PCPDynamicScreen.c
@@ -73,9 +73,9 @@ static PCPDynamicColumn* PCPDynamicScreen_lookupMetric(PCPDynamicScreen* screen,
    PCPDynamicColumn* column = NULL;
    if ((strlen(name) + strlen(screen->super.name) + 1) >= sizeof(column->super.name)) /* colon */
       return NULL;
-    
-    char* metricName = NULL;
-    xAsprintf(&metricName, "htop.screen.%s.%s", screen->super.name, name);
+
+   char* metricName = NULL;
+   xAsprintf(&metricName, "htop.screen.%s.%s", screen->super.name, name);
 
    for (size_t i = 0; i < screen->totalColumns; i++) {
       column = screen->columns[i];


### PR DESCRIPTION
Hi! I submitted a PR in hopes this would suffice. After refactoring `xMalloc+xSnprintf` to `xAsprintf` within

`~/pcp/PCPDynamicColumn_addMetric.c`
`~/pcp/PCPDynamicMeter_lookupMetric.c` 
`~/pcp/PCPDynamicScreen_lookupMetric.c`

I was able to compile and test the changes (`make clean && make`) with no hassle within macOS. I'm open to any constructive criticism for writing C and overall best practices for maintaining large codebases. Thanks all!