### PR TITLE
Support for Snapdragon 8cx

### DIFF
--- a/linux/LibSensors.c
+++ b/linux/LibSensors.c
@@ -145,6 +145,15 @@ static int tempDriverPriority(const sensors_chip_name* chip) {
       { "bigcore2_thermal",   0 },
       /* Rockchip RK3566 */
       { "soc_thermal",        0 },
+      /* Snapdragon 8cx */
+      { "cpu0_thermal",       0 },
+      { "cpu1_thermal",       0 },
+      { "cpu2_thermal",       0 },
+      { "cpu3_thermal",       0 },
+      { "cpu4_thermal",       0 },
+      { "cpu5_thermal",       0 },
+      { "cpu6_thermal",       0 },
+      { "cpu7_thermal",       0 },
       /* Low priority drivers */
       { "acpitz",             1 },
    };
@@ -215,13 +224,20 @@ void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, uns
          if (r != 0)
             continue;
 
-         /* Map temperature values to Rockchip cores
-          *
-          *   littlecore -> cores 1..4
-          *   bigcore0   -> cores 5,6
-          *   bigcore1   -> cores 7,8
-          */
          if (existingCPUs == 8) {
+            /* Map temperature values to Snapdragon 8cx cores */
+            if (String_startsWith(chip->prefix, "cpu") && chip->prefix[3] >= '0' && chip->prefix[3] <= '7' && String_eq(chip->prefix + 4, "_thermal")) {
+               data[1 + chip->prefix[3] - '0'] = temp;
+               coreTempCount++;
+               continue;
+            }
+
+            /* Map temperature values to Rockchip cores
+             *
+             *   littlecore -> cores 1..4
+             *   bigcore0   -> cores 5,6
+             *   bigcore1   -> cores 7,8
+             */
             if (String_eq(chip->prefix, "littlecore_thermal")) {
                data[1] = temp;
                data[2] = temp;


### PR DESCRIPTION
Probably also works for other Snapdragons, but I can only test it on my 8cx.

The code is not beautiful, but "works on my machine" :-) (Thinkpad X13s). 

Based the output of  `sensors`:

```
$ sensors
skin_temp_thermal-virtual-0
Adapter: Virtual device
temp1:        +32.7°C

cluster0_thermal-virtual-0
Adapter: Virtual device
temp1:        +33.7°C

cpu2_thermal-virtual-0
Adapter: Virtual device
temp1:        +32.6°C

cpu6_thermal-virtual-0
Adapter: Virtual device
temp1:        +32.3°C

cpu0_thermal-virtual-0
Adapter: Virtual device
temp1:        +32.6°C

cpu4_thermal-virtual-0
Adapter: Virtual device
temp1:        +32.6°C

nvme-pci-20100
Adapter: PCI adapter
Composite:    +29.9°C  (low  = -20.1°C, high = +77.8°C)
                       (crit = +81.8°C)
Sensor 1:     +29.9°C  (low  = -273.1°C, high = +65261.8°C)

ath11k_hwmon-pci-60100
Adapter: PCI adapter
temp1:        +33.0°C

pm8280_1_thermal-virtual-0
Adapter: Virtual device
temp1:        +32.6°C

qcom_battmgr_bat-virtual-0
Adapter: Virtual device
in0:           7.60 V
temp:         +30.3°C
power1:       -4.25 W

mem_thermal-virtual-0
Adapter: Virtual device
temp1:        +32.1°C

cpu3_thermal-virtual-0
Adapter: Virtual device
temp1:        +32.6°C

cpu7_thermal-virtual-0
Adapter: Virtual device
temp1:        +32.3°C

cpu1_thermal-virtual-0
Adapter: Virtual device
temp1:        +32.3°C

cpu5_thermal-virtual-0
Adapter: Virtual device
temp1:        +33.0°C

gpu_thermal-virtual-0
Adapter: Virtual device
temp1:        +31.5°C

pm8280_2_thermal-virtual-0
Adapter: Virtual device
temp1:        +30.6°C

```