### PR TITLE
Fix #1599 DarwinProcess.c compiler warning when debug is enabled

### DIFF
--- a/darwin/DarwinProcess.c
+++ b/darwin/DarwinProcess.c
@@ -496,7 +496,11 @@ void DarwinProcess_scanThreads(DarwinProcess* dp, DarwinProcessTable* dpt) {
          continue;
       }
 
-      assert(Process_getPid(tprocess) == tid);
+      pid_t tprocessPid = Process_getPid(tprocess);
+      assert(tprocessPid >= 0);
+      assert((uint64_t)tprocessPid == tid);
+      (void)tprocessPid;
+
       Process_setParent(tprocess, pid);
       Process_setThreadGroup(tprocess, pid);
       tprocess->super.show       = true;


### PR DESCRIPTION
Fixes #1599 for debug builds

Adds an additional assert to confirm that tid (which is a signed value and potentially negative) is above zero and therefore not an error code, before casting it to uint64_t to do an equivalent comparison