### PR TITLE
Fix MacOS X <12 build issue and the regression from PR1609 

### DIFF
--- a/darwin/DarwinProcess.c
+++ b/darwin/DarwinProcess.c
@@ -61,6 +61,7 @@ Process* DarwinProcess_new(const Machine* host) {
    this->stime = 0;
    this->taskAccess = true;
    this->translated = false;
+   this->super.state = UNKNOWN;
 
    return (Process*)this;
 }


### PR DESCRIPTION
Closes #1611

Thank you to Explorer09 and aestriplex for debugging.

Commit 2e62fae includes some housekeeping:
IOKit is available since MacOS X was born, so remove the guarding. Fix the defines to actually work compiling on MacOS X v11.
