### PR TITLE
Make GPU residue values consistent across meter instances

### DIFF
--- a/linux/GPUMeter.c
+++ b/linux/GPUMeter.c
@@ -11,14 +11,9 @@ in the source distribution for its full text.
 
 #include "CRT.h"
 #include "RichString.h"
+#include "XUtils.h"
 #include "linux/LinuxMachine.h"
 
-
-static size_t activeMeters;
-
-bool GPUMeter_active(void) {
-   return activeMeters > 0;
-}
 
 struct EngineData {
    const char* key;  /* owned by LinuxMachine */
@@ -37,6 +32,12 @@ static const int GPUMeter_attributes[] = {
    GPU_ENGINE_4,
    GPU_RESIDUE,
 };
+
+static size_t activeMeters;
+
+bool GPUMeter_active(void) {
+   return activeMeters > 0;
+}
 
 static int humanTimeUnit(char* buffer, size_t size, unsigned long long int value) {
 

--- a/linux/GPUMeter.c
+++ b/linux/GPUMeter.c
@@ -18,10 +18,13 @@ in the source distribution for its full text.
 struct EngineData {
    const char* key;  /* owned by LinuxMachine */
    unsigned long long int timeDiff;
+   double percentage;
 };
 
 static struct EngineData GPUMeter_engineData[4];
-static unsigned long long int prevResidueTime, curResidueTime;
+static uint64_t prevMonotonicMs;
+static double residuePercentage;
+static unsigned long long int prevResidueTime;
 static double totalUsage;
 static unsigned long long int totalGPUTimeDiff;
 
@@ -89,26 +92,37 @@ static void GPUMeter_updateValues(Meter* this) {
 
    assert(ARRAYSIZE(GPUMeter_engineData) + 1 == ARRAYSIZE(GPUMeter_attributes));
 
-   totalGPUTimeDiff = saturatingSub(lhost->curGpuTime, lhost->prevGpuTime);
-   uint64_t monotonictimeDelta = host->monotonicMs - host->prevMonotonicMs;
+   // The results are cached so that we can update values of multiple meter
+   // instances. We also need a local cache of the monotonic timestamp, thus we
+   // don't use host->prevMonotonicMs.
+   if (host->monotonicMs > prevMonotonicMs) {
+      uint64_t monotonictimeDelta = host->monotonicMs - prevMonotonicMs;
 
-   prevResidueTime = curResidueTime;
-   curResidueTime = lhost->curGpuTime;
+      unsigned long long int curResidueTime = lhost->curGpuTime;
 
-   const GPUEngineData* gpuEngineData;
-   size_t i;
-   for (gpuEngineData = lhost->gpuEngineData, i = 0; gpuEngineData && i < ARRAYSIZE(GPUMeter_engineData); gpuEngineData = gpuEngineData->next, i++) {
-      GPUMeter_engineData[i].key      = gpuEngineData->key;
-      GPUMeter_engineData[i].timeDiff = saturatingSub(gpuEngineData->curTime, gpuEngineData->prevTime);
+      const GPUEngineData* gpuEngineData;
+      size_t i;
+      for (gpuEngineData = lhost->gpuEngineData, i = 0; gpuEngineData && i < ARRAYSIZE(GPUMeter_engineData); gpuEngineData = gpuEngineData->next, i++) {
+         GPUMeter_engineData[i].key        = gpuEngineData->key;
+         GPUMeter_engineData[i].timeDiff   = saturatingSub(gpuEngineData->curTime, gpuEngineData->prevTime);
+         GPUMeter_engineData[i].percentage = 100.0 * GPUMeter_engineData[i].timeDiff / (1000 * 1000) / monotonictimeDelta;
 
-      curResidueTime = saturatingSub(curResidueTime, gpuEngineData->curTime);
+         curResidueTime = saturatingSub(curResidueTime, gpuEngineData->curTime);
+      }
 
-      this->values[i] = 100.0 * GPUMeter_engineData[i].timeDiff / (1000 * 1000) / monotonictimeDelta;
+      residuePercentage = 100.0 * saturatingSub(curResidueTime, prevResidueTime) / (1000 * 1000) / monotonictimeDelta;
+
+      totalGPUTimeDiff = saturatingSub(lhost->curGpuTime, lhost->prevGpuTime);
+      totalUsage = 100.0 * totalGPUTimeDiff / (1000 * 1000) / monotonictimeDelta;
+
+      prevResidueTime = curResidueTime;
+      prevMonotonicMs = host->monotonicMs;
    }
 
-   this->values[ARRAYSIZE(GPUMeter_engineData)] = 100.0 * saturatingSub(curResidueTime, prevResidueTime) / (1000 * 1000) / monotonictimeDelta;
-
-   totalUsage = 100.0 * totalGPUTimeDiff / (1000 * 1000) / monotonictimeDelta;
+   for (size_t i = 0; i < ARRAYSIZE(GPUMeter_engineData); i++) {
+      this->values[i] = GPUMeter_engineData[i].percentage;
+   }
+   this->values[ARRAYSIZE(GPUMeter_engineData)] = residuePercentage;
 
    xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%.1f%%", totalUsage);
 }


### PR DESCRIPTION
`GPUMeter_updateValues()` used a locally cached "residue time" variable for computing the percentage of the "GPU residue" usage. The "residue" percentages of subsequent `GPUMeter` instances could be 0 due to the cached "residue time" off-sync with the time data from the `LinuxMachine` instance.

Rewrite the logic of the function so that all computed GPU percentage values are cached, and the cache updated only when there's increment on `host->monotonicMs`.