### PR TITLE
darwin: nanoseconds to centi-seconds minor improvement

### DIFF
--- a/darwin/DarwinProcess.c
+++ b/darwin/DarwinProcess.c
@@ -383,7 +383,8 @@ void DarwinProcess_setFromLibprocPidinfo(DarwinProcess* proc, DarwinProcessTable
    Process_updateCPUFieldWidths(proc->super.percent_cpu);
 
    proc->super.state = pti.pti_numrunning > 0 ? RUNNING : SLEEPING;
-   proc->super.time = total_current_time_ns / 1e7;
+   // Convert from nanoseconds to hundredths of seconds
+   proc->super.time = total_current_time_ns / 10000000ULL;
    proc->super.nlwp = pti.pti_threadnum;
    proc->super.m_virt = pti.pti_virtual_size / ONE_K;
    proc->super.m_resident = pti.pti_resident_size / ONE_K;


### PR DESCRIPTION
Avoid the use of floating point division when integer division can do it.
A follow-up of commit 9944d5507f9d57f8c03b0e183523fb28eee79005.

(This very minor change doesn't need to be made in 3.4.0 release. I'm okay when this one is pulled to 3.4.1 instead.)