### PR TITLE
darwin: Del key should remove meters (#1601)

### DIFF
--- a/CRT.h
+++ b/CRT.h
@@ -175,6 +175,7 @@ void CRT_handleSIGSEGV(int signal) ATTR_NORETURN;
 #define KEY_ALT(x)    (KEY_F(64 - 26) + ((x) - 'A'))
 #define KEY_FOCUS_IN  (KEY_MAX + 'I')
 #define KEY_FOCUS_OUT (KEY_MAX + 'O')
+#define MAC_DEL_KEY 127
 
 extern const char* CRT_degreeSign;
 

--- a/ColumnsPanel.c
+++ b/ColumnsPanel.c
@@ -79,6 +79,7 @@ static HandlerResult ColumnsPanel_eventHandler(Panel* super, int ch) {
          break;
       case KEY_F(9):
       case KEY_DC:
+      case MAC_DEL_KEY:
          if (size > 1 && selected < size)
             Panel_remove(super, selected);
          result = HANDLED;

--- a/MetersPanel.c
+++ b/MetersPanel.c
@@ -152,6 +152,7 @@ static HandlerResult MetersPanel_eventHandler(Panel* super, int ch) {
          break;
       case KEY_F(9):
       case KEY_DC:
+      case MAC_DEL_KEY:
          if (!Vector_size(this->meters))
             break;
          if (selected < Vector_size(this->meters)) {


### PR DESCRIPTION
I open a PR with the changes discussed in #1601.
It seems to be working (apart from the legend issue which I am implementing, and on which I would like feedback from you).
Just an implementation note. I used to use ncurses years ago, so I don't know how the handling of key bindings has changed recently. However, in the past, in order to make the backspace handling robust, I used to listen on all three of these events:
* KEY_BACKSPACE;
* 127;
* '\b'.

What are your thoughts on this?