### PR TITLE
Build unsupported

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,20 @@ jobs:
     - name: Build
       run: make -k
 
+  build-unsupported-latest-gcc:
+    # build as if we were on an unsupported platform
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Dependencies
+      run: sudo apt-get install --no-install-recommends libncursesw5-dev libtinfo-dev libgpm-dev
+    - name: Bootstrap
+      run: ./autogen.sh
+    - name: Configure
+      run: ./configure --host=`uname -m`-none --enable-werror --enable-unicode || ( cat config.log; exit 1; )
+    - name: Build
+      run: make -k
+
   build-ubuntu-latest-clang-analyzer:
     runs-on: ubuntu-latest
     env:

--- a/configure.ac
+++ b/configure.ac
@@ -1137,7 +1137,7 @@ fi
 AC_MSG_RESULT([
   ${PACKAGE_NAME} ${VERSION}
 
-  platform:                  $my_htop_platform
+  platform:                  $my_htop_platform ($host_os)
   os-release file:           $with_os_release
   (Linux) proc directory:    $with_proc
   (Linux) openvz:            $enable_openvz

--- a/unsupported/UnsupportedMachine.c
+++ b/unsupported/UnsupportedMachine.c
@@ -5,6 +5,8 @@ Released under the GNU GPLv2+, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "config.h" // IWYU pragma: keep
+
 #include "UnsupportedMachine.h"
 
 #include <stdlib.h>


### PR DESCRIPTION
This allows to run configure in a way such that the current platform is treated as an unsupported one.

This is mainly intended to allow for testing consistency of the code inside the `unsupported` platform directory.