### PR TITLE
Handle when there's no CPUMeter to display

### DIFF
--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -261,6 +261,10 @@ static void CPUMeterCommonUpdateMode(Meter* this, MeterModeId mode, int ncol) {
    this->mode = mode;
    int start, count;
    AllCPUsMeter_getRange(this, &start, &count);
+   if (!count) {
+      this->h = 1;
+      return;
+   }
    for (int i = 0; i < count; i++) {
       Meter_setMode(meters[i], mode);
    }

--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -222,7 +222,7 @@ static void AllCPUsMeter_getRange(const Meter* this, int* start, int* count) {
          break;
       case 'R': // Second Half
          *start = (cpus + 1) / 2;
-         *count = cpus / 2;
+         *count = cpus - *start;
          break;
    }
 }

--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -208,8 +208,7 @@ static void CPUMeter_display(const Object* cast, RichString* out) {
 }
 
 static void AllCPUsMeter_getRange(const Meter* this, int* start, int* count) {
-   const CPUMeterData* data = this->meterData;
-   unsigned int cpus = data->cpus;
+   unsigned int cpus = this->host->existingCPUs;
    switch (Meter_name(this)[0]) {
       default:
       case 'A': // All
@@ -237,16 +236,17 @@ static void AllCPUsMeter_updateValues(Meter* this) {
 }
 
 static void CPUMeterCommonInit(Meter* this) {
-   unsigned int cpus = this->host->existingCPUs;
+   int start, count;
+   AllCPUsMeter_getRange(this, &start, &count);
+
    CPUMeterData* data = this->meterData;
    if (!data) {
       data = this->meterData = xMalloc(sizeof(CPUMeterData));
-      data->cpus = cpus;
-      data->meters = xCalloc(cpus, sizeof(Meter*));
+      data->cpus = this->host->existingCPUs;
+      data->meters = count ? xCalloc(count, sizeof(Meter*)) : NULL;
    }
+
    Meter** meters = data->meters;
-   int start, count;
-   AllCPUsMeter_getRange(this, &start, &count);
    for (int i = 0; i < count; i++) {
       if (!meters[i])
          meters[i] = Meter_new(this->host, start + i + 1, (const MeterClass*) Class(CPUMeter));


### PR DESCRIPTION
When there's no CPU to display for RightCPUMeter, display as blank instead of crashing …

Fixes #1629

/cc @Explorer09 