### PR TITLE
Update pcp-htop configurations to use libbpf over BCC

### DIFF
--- a/pcp-htop.5.in
+++ b/pcp-htop.5.in
@@ -196,7 +196,6 @@ or
 namespace (\c
 .BR pmdaproc (1)),
 but metrics from other domains (\c
-.BR pmdabcc (1),
 .BR pmdabpf (1),
 etc) that have per-process values are equally applicable.
 .TP
@@ -223,7 +222,6 @@ the Available Columns list.
 .BR pminfo (1),
 .BR pmcd (1),
 .BR pmdaproc (1),
-.BR pmdabcc (1),
 .BR pmdabpf (1)
 and
 .BR pmRegisterDerived (3).

--- a/pcp/columns/tcp
+++ b/pcp/columns/tcp
@@ -2,30 +2,30 @@
 # pcp-htop(1) configuration file - see pcp-htop(5)
 #
 
-[tcp_send_calls]
+[tcp_send_packets]
 heading = TCPS
 caption = TCP_SEND
 width = 6
-metric = bcc.proc.net.tcp.send.calls
-description = Count of TCP send calls
+metric = bpf.proc.net.tcp.send.packets
+description = Count of TCP packets sent
 
 [tcp_send_bytes]
 heading = TCPSB
 caption = TCP_SEND_BYTES
 width = 6
-metric = bcc.proc.net.tcp.send.bytes
+metric = bpf.proc.net.tcp.send.bytes
 description = Cumulative bytes sent via TCP
 
-[tcp_recv_calls]
+[tcp_recv_packets]
 heading = TCPR
 caption = TCP_RECV
 width = 6
-metric = bcc.proc.net.tcp.recv.calls
-description = Count of TCP recv calls
+metric = bpf.proc.net.tcp.recv.packets
+description = Count of TCP packets received
 
 [tcp_recv_bytes]
 heading = TCPRB
 caption = TCP_RECV_BYTES
 width = 6
-metric = bcc.proc.net.tcp.recv.bytes
+metric = bpf.proc.net.tcp.recv.bytes
 description = Cumulative bytes received via TCP

--- a/pcp/columns/udp
+++ b/pcp/columns/udp
@@ -2,30 +2,30 @@
 # pcp-htop(1) configuration file - see pcp-htop(5)
 #
 
-[udp_send_calls]
+[udp_send_packets]
 heading = UDPS
 caption = UDP_SEND
 width = 6
-metric = bcc.proc.net.udp.send.calls
-description = Count of UDP send calls
+metric = bpf.proc.net.udp.send.packets
+description = Count of UDP packets sent
 
 [udp_send_bytes]
 heading = UDPSB
 caption = UDP_SEND_BYTES
 width = 6
-metric = bcc.proc.net.udp.send.bytes
+metric = bpf.proc.net.udp.send.bytes
 description = Cumulative bytes sent via UDP
 
-[udp_recv_calls]
+[udp_recv_packets]
 heading = UDPR
 caption = UDP_RECV
 width = 6
-metric = bcc.proc.net.udp.recv.calls
-description = Count of UDP recv calls
+metric = bpf.proc.net.udp.recv.packets
+description = Count of UDP packets received
 
 [udp_recv_bytes]
 heading = UDPRB
 caption = UDP_RECV_BYTES
 width = 6
-metric = bcc.proc.net.udp.recv.bytes
+metric = bpf.proc.net.udp.recv.bytes
 description = Cumulative bytes received via UDP


### PR DESCRIPTION
The libbpf based per-process networking metrics are preferred over BCC in upstream PCP nowadays (lower memory overhead with the use of C over python userspace code).