### PR TITLE
Prevent assertion error in Machine_scanTables()

### DIFF
--- a/Machine.c
+++ b/Machine.c
@@ -107,7 +107,9 @@ void Machine_scanTables(Machine* this) {
       this->monotonicMs = 1;
       firstScanDone = true;
    }
-   assert(this->monotonicMs > this->prevMonotonicMs);
+   if (this->monotonicMs <= this->prevMonotonicMs) {
+      return;
+   }
 
    this->maxUserId = 0;
    Row_resetFieldWidths();


### PR DESCRIPTION
... when the function is called in quick succession (monotonic time < 1 millisecond).

I discovered this when trying to run the "unsupported" version of htop.