### PR TITLE
Fix missing header for native curses build in NetBSD.

### DIFF
--- a/Settings.c
+++ b/Settings.c
@@ -14,6 +14,7 @@ in the source distribution for its full text.
 #include <fcntl.h>
 #include <limits.h>
 #include <pwd.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Currently the build in NetBSD using the native curses build fails with the following error

```
--- Settings.o ---
Settings.c: In function 'signal_safe_fprintf':
Settings.c:627:4: error: unknown type name 'va_list'
  627 |    va_list vl;
      |    ^~~~~~~
Settings.c:29:1: note: 'va_list' is defined in header '<stdarg.h>'; did you forget to '#include <stdarg.h>'?
   28 | #include "Platform.h"
  +++ |+#include <stdarg.h>
   29 | #include "Process.h"
Settings.c:628:4: warning: implicit declaration of function 'va_start' [-Wimplicit-function-declaration]
  628 |    va_start(vl, fmt);
      |    ^~~~~~~~
In file included from /usr/include/stdio.h:595,
                 from XUtils.h:20,
                 from HeaderLayout.h:15,
                 from Settings.h:15,
                 from Settings.c:10:
Settings.c:629:45: warning: passing argument 6 of '__builtin___vsnprintf_chk' makes pointer from integer without a cast [-Wint-conversion]
  629 |    int n = vsnprintf(buf, sizeof(buf), fmt, vl);
      |                                             ^~
      |                                             |
      |                                             int
Settings.c:629:45: note: expected '__va_list_tag *' but argument is of type 'int'
Settings.c:630:4: warning: implicit declaration of function 'va_end' [-Wimplicit-function-declaration]
  630 |    va_end(vl);
      |    ^~~~~~
*** [Settings.o] Error code 1
```

The build works as expected with `ncurses` option enabled which is also what is used in the CI. However for NetBSD the builtin `curses` is the default option when building.