### PR TITLE
Use pkg-config to discover libnl-3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -961,14 +961,16 @@ case "$enable_delayacct" in
          enable_delayacct=no
       else
          old_CFLAGS="$CFLAGS"
-         CFLAGS="$CFLAGS -I/usr/include/libnl3"
+         htop_config_cflags=`$PKG_CONFIG --cflags libnl-3.0 2>/dev/null` || continue
+         CFLAGS="$CFLAGS $htop_config_cflags"
          AC_CHECK_HEADERS([netlink/attr.h netlink/handlers.h netlink/msg.h], [enable_delayacct=yes], [enable_delayacct=no])
          CFLAGS="$old_CFLAGS"
       fi
       ;;
    yes)
       old_CFLAGS="$CFLAGS"
-      CFLAGS="$CFLAGS -I/usr/include/libnl3"
+      htop_config_cflags=`$PKG_CONFIG --cflags libnl-3.0 2>/dev/null` || continue
+      CFLAGS="$CFLAGS $htop_config_cflags"
       AC_CHECK_HEADERS([netlink/attr.h netlink/handlers.h netlink/msg.h], [], [AC_MSG_ERROR([can not find required header files netlink/attr.h, netlink/handlers.h, netlink/msg.h])])
       CFLAGS="$old_CFLAGS"
       ;;
@@ -978,7 +980,8 @@ case "$enable_delayacct" in
 esac
 if test "$enable_delayacct" = yes; then
   AC_DEFINE([HAVE_DELAYACCT], [1], [Define if delay accounting support should be enabled.])
-  AM_CFLAGS="$AM_CFLAGS -I/usr/include/libnl3"
+  htop_config_cflags=`$PKG_CONFIG --cflags libnl-3.0 2>/dev/null`
+  AM_CFLAGS="$AM_CFLAGS $htop_config_cflags"
 fi
 AM_CONDITIONAL([HAVE_DELAYACCT], [test "$enable_delayacct" = yes])
 

--- a/configure.ac
+++ b/configure.ac
@@ -982,6 +982,8 @@ if test "$enable_delayacct" = yes; then
   AC_DEFINE([HAVE_DELAYACCT], [1], [Define if delay accounting support should be enabled.])
   htop_config_cflags=`$PKG_CONFIG --cflags libnl-3.0 2>/dev/null`
   AM_CFLAGS="$AM_CFLAGS $htop_config_cflags"
+  libdir_libnl=`$PKG_CONFIG --variable=libdir libnl-3.0 2>/dev/null`
+  AC_DEFINE_UNQUOTED([LIBDIR_LIBNL], ["$libdir_libnl"], [Path to the libnl-3 libraries])
 fi
 AM_CONDITIONAL([HAVE_DELAYACCT], [test "$enable_delayacct" = yes])
 

--- a/linux/LibNl.c
+++ b/linux/LibNl.c
@@ -78,17 +78,17 @@ static int load_libnl(void) {
    if (libnlHandle && libnlGenlHandle)
       return 0;
 
-   libnlHandle = dlopen("libnl-3.so", RTLD_LAZY);
+   libnlHandle = dlopen(LIBDIR_LIBNL "/libnl-3.so", RTLD_LAZY);
    if (!libnlHandle) {
-      libnlHandle = dlopen("libnl-3.so.200", RTLD_LAZY);
+      libnlHandle = dlopen(LIBDIR_LIBNL "/libnl-3.so.200", RTLD_LAZY);
       if (!libnlHandle) {
          goto dlfailure;
       }
    }
 
-   libnlGenlHandle = dlopen("libnl-genl-3.so", RTLD_LAZY);
+   libnlGenlHandle = dlopen(LIBDIR_LIBNL "/libnl-genl-3.so", RTLD_LAZY);
    if (!libnlGenlHandle) {
-      libnlGenlHandle = dlopen("libnl-genl-3.so.200", RTLD_LAZY);
+      libnlGenlHandle = dlopen(LIBDIR_LIBNL "/libnl-genl-3.so.200", RTLD_LAZY);
       if (!libnlGenlHandle) {
          goto dlfailure;
       }


### PR DESCRIPTION
Since #1427, the location of libnl-3 is not discovered anymore with pkg-config. Instead, the hardcoded path `/usr/include/libnl3` was introduced for headers without any possibility to override it except by patching.

This PR adds support for pkg-config to discover the location of the headers. Additionally, it discovers the path to libnl-3 libraries and modifies the `dlopen` calls to load the configured libraries from their fully qualified path.

Also note the [discussion on the pull request](https://github.com/htop-dev/htop/pull/1427#discussion_r1991155580).