### PR TITLE
Meter: Prevent integer overflow on x positions

### DIFF
--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -305,8 +305,8 @@ static void CPUMeterCommonDraw(Meter* this, int x, int y, int w, int ncol) {
    Meter** meters = data->meters;
    int start, count;
    AllCPUsMeter_getRange(this, &start, &count);
-   int colwidth = (w - ncol) / ncol + 1;
-   int diff = (w - (colwidth * ncol));
+   int colwidth = w / ncol;
+   int diff = w % ncol;
    int nrows = (count + ncol - 1) / ncol;
    for (int i = 0; i < count; i++) {
       int d = (i / nrows) > diff ? diff : (i / nrows); // dynamic spacer

--- a/MemorySwapMeter.c
+++ b/MemorySwapMeter.c
@@ -38,7 +38,7 @@ static void MemorySwapMeter_draw(Meter* this, int x, int y, int w) {
 
    /* Use the same width for each sub meter to align with CPU meter */
    const int colwidth = w / 2;
-   const int diff = w - colwidth * 2;
+   const int diff = w % 2;
 
    assert(data->memoryMeter->draw);
    data->memoryMeter->draw(data->memoryMeter, x, y, colwidth);

--- a/Meter.c
+++ b/Meter.c
@@ -84,8 +84,10 @@ static void BarMeterMode_draw(Meter* this, int x, int y, int w) {
    // Draw the caption
    int captionLen = 3;
    const char* caption = Meter_getCaption(this);
-   attrset(CRT_colors[METER_TEXT]);
-   mvaddnstr(y, x, caption, captionLen);
+   if (w >= captionLen) {
+      attrset(CRT_colors[METER_TEXT]);
+      mvaddnstr(y, x, caption, captionLen);
+   }
    w -= captionLen;
 
    // Draw the bar borders
@@ -206,8 +208,10 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
    // Draw the caption
    const int captionLen = 3;
    const char* caption = Meter_getCaption(this);
-   attrset(CRT_colors[METER_TEXT]);
-   mvaddnstr(y, x, caption, captionLen);
+   if (w >= captionLen) {
+      attrset(CRT_colors[METER_TEXT]);
+      mvaddnstr(y, x, caption, captionLen);
+   }
    w -= captionLen;
 
    GraphData* data = &this->drawData;


### PR DESCRIPTION
* Clamp the `x` and `w` parameters in the meter's `draw()` functions to prevent `(x + w)` overflowing a signed int type. Also add assertions to `x` and `w` in the debug build. `(x >= 0 && w <= INT_MAX - x)`
* In `BarMeterMode_draw()`, the `offset + blockSizes[i]` calculation might also overflow. Cap the maximum of `blockSizes[i]` rather than cap the result of the addition.
* In `LEDMeterMode_draw()`, adjust the loop break conditions (on `xx` variable) so that the loop can terminate properly with `xx` values very close to the `INT_MAX` limit.