### PR TITLE
Fix various typos

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,7 +13,7 @@ What's new in version 3.4.0
 * Updated documentation for pcp-htop
 * Disable FOCUS_IN/FOCUS_OUT event handling
 * Add GPU meter for Linux and PCP
-* Add colum for GPU time per process on Linux and PCP
+* Add column for GPU time per process on Linux and PCP
 * Avoid glibc FILE API voodoo
 * Ignore previously unhandled signals USR1 and USR2
 * Force locating the config file to only use absolute paths

--- a/linux/LibSensors.c
+++ b/linux/LibSensors.c
@@ -312,7 +312,7 @@ void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, uns
          char *label = sym_sensors_get_label(chip, feature);
          if (label) {
             bool skip = true;
-            /* Intel coretemp names, labels mention package and phyiscal id */
+            /* Intel coretemp names, labels mention package and physical id */
             if (String_startsWith(label, "Package id ")) {
                physicalID = strtoul(label + strlen("Package id "), NULL, 10);
             } else if (String_startsWith(label, "Physical id ")) {

--- a/pcp/screens/devices
+++ b/pcp/screens/devices
@@ -118,5 +118,5 @@ qlen.caption = Average read and write I/O queue length to the device
 
 util.heading = UTIL%
 util.metric = 100 * rate(disk.dev.avactive)
-util.caption = Perentage of time device was busy processing requests
+util.caption = Percentage of time device was busy processing requests
 util.format = percent


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.desktop" -L commend,offsetp`