### PR TITLE
build: Ensure strchrnul() is available in header (fixes macOS build)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -371,8 +371,27 @@ AC_CHECK_FUNCS([ \
     readlinkat \
     sched_getscheduler \
     sched_setscheduler \
-    strchrnul \
    ])
+
+# strchrnul is available in macOS since 15.4, but the user may specify an older
+# macOS version ('-mmacos-version-min') to build for. We need to ensure it is
+# actually exposed in the header.
+htop_save_CFLAGS=$CFLAGS
+CFLAGS="$CFLAGS -Werror"
+
+AC_MSG_CHECKING([for strchrnul])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+#include <string.h>
+   ]], [[
+static char ch;
+char* ptr = strchrnul(&ch, 0);
+return ptr != &ch; /* Should be 0 (exit success) */
+   ]])],
+   [AC_MSG_RESULT(yes)
+   AC_DEFINE([HAVE_STRCHRNUL], [1], [Define to 1 if you have the 'strchrnul' function.])],
+   [AC_MSG_RESULT(no)])
+
+CFLAGS=$htop_save_CFLAGS
 
 if test "$my_htop_platform" = darwin; then
    AC_CHECK_FUNCS([host_statistics64], [


### PR DESCRIPTION
The strchrnul() function is also introduced in macOS 15.4, however, for macOS build, a compiler may default to building for an older macOS version (such as 15.0). The configure script can wrongly assume the function may be used.

Fix the configure script's detection of strchrnul() by ensuring it's actually available through the header.

Fixes: #1659