### PR TITLE
NetworkIOMeter: Always zero the NetworkIOData buffer before updating

### DIFF
--- a/NetworkIOMeter.c
+++ b/NetworkIOMeter.c
@@ -41,7 +41,7 @@ static void NetworkIOMeter_updateValues(Meter* this) {
    static uint64_t cached_last_update = 0;
    uint64_t passedTimeInMs = host->realtimeMs - cached_last_update;
    bool hasNewData = false;
-   NetworkIOData data;
+   NetworkIOData data = {0};
 
    /* update only every 500ms to have a sane span for rate calculation */
    if (passedTimeInMs > 500) {

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -351,7 +351,6 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    if (r < 0)
       return false;
 
-   memset(data, 0, sizeof(NetworkIOData));
    for (int i = 1; i <= count; i++) {
       struct ifmibdata ifmd;
       size_t ifmdLen = sizeof(ifmd);

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -654,7 +654,6 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    if (!fp)
       return false;
 
-   memset(data, 0, sizeof(NetworkIOData));
    char lineBuffer[512];
    while (fgets(lineBuffer, sizeof(lineBuffer), fp)) {
       char interfaceName[32];

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -761,8 +761,6 @@ bool Platform_getDiskIO(DiskIOData* data) {
 }
 
 bool Platform_getNetworkIO(NetworkIOData* data) {
-   memset(data, 0, sizeof(*data));
-
    pmAtomValue value;
    if (Metric_values(PCP_NET_RECVB, &value, 1, PM_TYPE_U64) != NULL)
       data->bytesReceived = value.ull;


### PR DESCRIPTION
The NetworkIOData of the meter is now zeroed by the caller before calling `Platform_getNetworkIO()`. This prevents any chance that a platform's `getNetworkIO()` code forget to zero-initialize the buffer.

(The `getNetworkIO()` functions of the following platforms did not zero-initialize the buffer before this commit:
DragonFlyBSD, NetBSD, Unsupported, OpenBSD and Solaris)

(This issue was caught by GCC with `-flto -Wmaybe-uninitialized` options.)

```text
  NetworkIOMeter.c: In function ‘NetworkIOMeter_updateValues’:
  NetworkIOMeter.c:98:18: error: ‘data.packetsTransmitted’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     98 |             diff = data.packetsTransmitted - cached_txp_total;
        |                  ^
  NetworkIOMeter.c:44:18: note: ‘data.packetsTransmitted’ was declared here
     44 |    NetworkIOData data;
        |                  ^
  NetworkIOMeter.c:89:18: error: ‘data.bytesTransmitted’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     89 |             diff = data.bytesTransmitted - cached_txb_total;
        |                  ^
  NetworkIOMeter.c:44:18: note: ‘data.bytesTransmitted’ was declared here
     44 |    NetworkIOData data;
        |                  ^
  NetworkIOMeter.c:81:18: error: ‘data.packetsReceived’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     81 |             diff = data.packetsReceived - cached_rxp_total;
        |                  ^
  NetworkIOMeter.c:44:18: note: ‘data.packetsReceived’ was declared here
     44 |    NetworkIOData data;
        |                  ^
  NetworkIOMeter.c:72:18: error: ‘data.bytesReceived’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     72 |             diff = data.bytesReceived - cached_rxb_total;
        |                  ^
  NetworkIOMeter.c:44:18: note: ‘data.bytesReceived’ was declared here
     44 |    NetworkIOData data;
        |                  ^
  lto1: all warnings being treated as errors
```