### PR TITLE
PCP: Remove semicolons from empty statements

### DIFF
--- a/pcp/PCPDynamicMeter.c
+++ b/pcp/PCPDynamicMeter.c
@@ -198,16 +198,18 @@ static void PCPDynamicMeter_parseFile(PCPDynamicMeters* meters, const char* path
             meter = PCPDynamicMeter_new(meters, key + 1);
       } else if (!ok) {
          /* skip this one, we're looking for a new header */
-      } else if (value && meter && String_eq(key, "caption")) {
+      } else if (!value || !meter) {
+         /* skip this one as we always need value strings */
+      } else if (String_eq(key, "caption")) {
          char* caption = String_cat(value, ": ");
          if (caption) {
             free_and_xStrdup(&meter->super.caption, caption);
             free(caption);
             caption = NULL;
          }
-      } else if (value && meter && String_eq(key, "description")) {
+      } else if (String_eq(key, "description")) {
          free_and_xStrdup(&meter->super.description, value);
-      } else if (value && meter && String_eq(key, "type")) {
+      } else if (String_eq(key, "type")) {
          if (String_eq(config[1], "bar"))
             meter->super.type = BAR_METERMODE;
          else if (String_eq(config[1], "text"))
@@ -216,9 +218,9 @@ static void PCPDynamicMeter_parseFile(PCPDynamicMeters* meters, const char* path
             meter->super.type = GRAPH_METERMODE;
          else if (String_eq(config[1], "led"))
             meter->super.type = LED_METERMODE;
-      } else if (value && meter && String_eq(key, "maximum")) {
+      } else if (String_eq(key, "maximum")) {
          meter->super.maximum = strtod(value, NULL);
-      } else if (value && meter) {
+      } else {
          PCPDynamicMeter_parseMetric(meters, meter, path, lineno, key, value);
       }
       String_freeArray(config);

--- a/pcp/PCPDynamicMeter.c
+++ b/pcp/PCPDynamicMeter.c
@@ -197,7 +197,7 @@ static void PCPDynamicMeter_parseFile(PCPDynamicMeters* meters, const char* path
          if (ok)
             meter = PCPDynamicMeter_new(meters, key + 1);
       } else if (!ok) {
-         ;  /* skip this one, we're looking for a new header */
+         /* skip this one, we're looking for a new header */
       } else if (value && meter && String_eq(key, "caption")) {
          char* caption = String_cat(value, ": ");
          if (caption) {

--- a/pcp/PCPDynamicScreen.c
+++ b/pcp/PCPDynamicScreen.c
@@ -252,9 +252,9 @@ static void PCPDynamicScreen_parseFile(PCPDynamicScreens* screens, const char* p
          if (pmDebugOptions.appl0)
             fprintf(stderr, "[%s] screen: %s\n", path, key + 1);
       } else if (!ok) {
-         ;  /* skip this one, we're looking for a new header */
+         /* skip this one, we're looking for a new header */
       } else if (!value || !screen) {
-         ;  /* skip this one as we always need value strings */
+         /* skip this one as we always need value strings */
       } else if (String_eq(key, "heading")) {
          free_and_xStrdup(&screen->super.heading, value);
       } else if (String_eq(key, "caption")) {


### PR DESCRIPTION
These are warnings generated when compiling PCP code in Clang 

```text
pcp/PCPDynamicMeter.c:200:10: error: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Werror,-Wextra-semi-stmt]
  200 |          ;  /* skip this one, we're looking for a new header */
      |          ^
pcp/PCPDynamicScreen.c:255:10: error: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Werror,-Wextra-semi-stmt]
  255 |          ;  /* skip this one, we're looking for a new header */
      |          ^
pcp/PCPDynamicScreen.c:257:10: error: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Werror,-Wextra-semi-stmt]
  257 |          ;  /* skip this one as we always need value strings */
      |          ^
```

No changes to compiled code.