### PR TITLE
pcp/Platform.c: defensive code for forthcoming PCP 7.0 change

### DIFF
--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -349,7 +349,14 @@ bool Platform_init(void) {
 
    if (opts.context == PM_CONTEXT_ARCHIVE) {
       gettimeofday(&pcp->offset, NULL);
+#if PMAPI_VERSION >= PMAPI_VERSION_3
+    {
+      struct timeval temp_tv = { opts.start.tv_sec, opts.start.tv_nsec / 1000 };
+      pmtimevalDec(&pcp->offset, &temp_tv);
+    }
+#else
       pmtimevalDec(&pcp->offset, &opts.start);
+#endif
    }
 
    for (unsigned int i = 0; i < PCP_METRIC_COUNT; i++)

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -349,7 +349,7 @@ bool Platform_init(void) {
 
    if (opts.context == PM_CONTEXT_ARCHIVE) {
       gettimeofday(&pcp->offset, NULL);
-#if PMAPI_VERSION >= PMAPI_VERSION_3
+#if PMAPI_VERSION >= 3
     {
       struct timeval temp_tv = { opts.start.tv_sec, opts.start.tv_nsec / 1000 };
       pmtimevalDec(&pcp->offset, &temp_tv);


### PR DESCRIPTION
Add conditional code (no-op for the current PMAPI_VERSION_2 aka 2) that will allow the code to continue to work with PMAPI_VERSION_3 aka 3 in PCP 7.0 that is under development.
