### PR TITLE
Some '-Wshorten-64-to-32' warning fixes

### DIFF
--- a/AffinityPanel.c
+++ b/AffinityPanel.c
@@ -400,7 +400,7 @@ Panel* AffinityPanel_new(Machine* host, const Affinity* affinity, int* width) {
 
       char number[16];
       xSnprintf(number, 9, "CPU %d", Settings_cpuId(host->settings, i));
-      unsigned cpu_width = 4 + strlen(number);
+      unsigned int cpu_width = 4 + (unsigned int)strlen(number);
       if (cpu_width > this->width) {
          this->width = cpu_width;
       }

--- a/IncSet.h
+++ b/IncSet.h
@@ -24,7 +24,7 @@ typedef enum {
 
 typedef struct IncMode_ {
    char buffer[INCMODE_MAX + 1];
-   int index;
+   size_t index;
    FunctionBar* bar;
    bool isFilter;
 } IncMode;

--- a/Meter.c
+++ b/Meter.c
@@ -270,7 +270,7 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
    // Starting positions of graph data and terminal column
    if ((size_t)w > nValues / 2) {
       x += w - nValues / 2;
-      w = nValues / 2;
+      w = (int)(nValues / 2);
    }
    size_t i = nValues - (size_t)w * 2;
 

--- a/Panel.c
+++ b/Panel.c
@@ -455,7 +455,7 @@ HandlerResult Panel_selectByTyping(Panel* this, int ch) {
    char* buffer = this->eventHandlerState;
 
    if (0 < ch && ch < 255 && isgraph((unsigned char)ch)) {
-      int len = strlen(buffer);
+      size_t len = strlen(buffer);
       if (!len) {
          if ('/' == ch) {
             ch = '\001';

--- a/Process.c
+++ b/Process.c
@@ -209,7 +209,7 @@ void Process_makeCommandStr(Process* this, const Settings* settings) {
    /* The field separator "│" has been chosen such that it will not match any
     * valid string used for searching or filtering */
    const char* SEPARATOR = CRT_treeStr[TREE_STR_VERT];
-   const int SEPARATOR_LEN = strlen(SEPARATOR);
+   const size_t SEPARATOR_LEN = strlen(SEPARATOR);
 
    /* Accommodate the column text, two field separators and terminating NUL */
    size_t maxLen = 2 * SEPARATOR_LEN + 1;
@@ -568,19 +568,18 @@ void Process_writeField(const Process* this, RichString* str, RowField field) {
       const bool lastItem = (super->indent < 0);
 
       for (uint32_t indent = (super->indent < 0 ? -super->indent : super->indent); indent > 1; indent >>= 1) {
-         int written, ret;
+         if (!n)
+            break;
+
+         int ret;
          if (indent & 1U) {
             ret = xSnprintf(buf, n, "%s  ", CRT_treeStr[TREE_STR_VERT]);
          } else {
             ret = xSnprintf(buf, n, "   ");
          }
-         if (ret < 0 || (size_t)ret >= n) {
-            written = n;
-         } else {
-            written = ret;
-         }
-         buf += written;
-         n -= written;
+         assert(ret > 0 && (size_t)ret < n);
+         buf += ret;
+         n -= ret;
       }
 
       const char* draw = CRT_treeStr[lastItem ? TREE_STR_BEND : TREE_STR_RTEE];

--- a/Row.c
+++ b/Row.c
@@ -89,7 +89,7 @@ void Row_setPidColumnWidth(pid_t maxPid) {
       return;
    }
 
-   Row_pidDigits = countDigits((size_t)maxPid, 10);
+   Row_pidDigits = (int)countDigits((size_t)maxPid, 10);
    assert(Row_pidDigits <= ROW_MAX_PID_DIGITS);
 }
 
@@ -99,7 +99,7 @@ void Row_setUidColumnWidth(uid_t maxUid) {
       return;
    }
 
-   Row_uidDigits = countDigits((size_t)maxUid, 10);
+   Row_uidDigits = (int)countDigits((size_t)maxUid, 10);
    assert(Row_uidDigits <= ROW_MAX_UID_DIGITS);
 }
 
@@ -428,23 +428,23 @@ void Row_printNanoseconds(RichString* str, unsigned long long totalNanoseconds, 
    }
 
    unsigned long long totalSeconds = totalMicroseconds / 1000000;
-   unsigned long microseconds = totalMicroseconds % 1000000;
+   uint32_t microseconds = totalMicroseconds % 1000000;
    if (totalSeconds < 60) {
       int width = 5;
-      unsigned long fraction = microseconds / 10;
+      uint32_t fraction = microseconds / 10;
       if (totalSeconds >= 10) {
          width--;
          fraction /= 10;
       }
-      len = xSnprintf(buffer, sizeof(buffer), "%u.%0*lus ", (unsigned int)totalSeconds, width, fraction);
+      len = xSnprintf(buffer, sizeof(buffer), "%u.%0*lus ", (unsigned int)totalSeconds, width, (unsigned long)fraction);
       RichString_appendnAscii(str, baseColor, buffer, len);
       return;
    }
 
    if (totalSeconds < 600) {
-      unsigned int minutes = totalSeconds / 60;
-      unsigned int seconds = totalSeconds % 60;
-      unsigned int milliseconds = microseconds / 1000;
+      unsigned int minutes = (unsigned int)totalSeconds / 60;
+      unsigned int seconds = (unsigned int)totalSeconds % 60;
+      unsigned int milliseconds = (unsigned int)(microseconds / 1000);
       len = xSnprintf(buffer, sizeof(buffer), "%u:%02u.%03u ", minutes, seconds, milliseconds);
       RichString_appendnAscii(str, baseColor, buffer, len);
       return;

--- a/Settings.c
+++ b/Settings.c
@@ -588,9 +588,9 @@ static void writeFields(OutputFunc of, FILE* fp,
 }
 
 static void writeList(OutputFunc of, FILE* fp,
-                      char** list, int len, char separator) {
+                      char** list, size_t len, char separator) {
    const char* sep = "";
-   for (int i = 0; i < len; i++) {
+   for (size_t i = 0; i < len; i++) {
       of(fp, "%s%s", sep, list[i]);
       sep = " ";
    }
@@ -633,7 +633,8 @@ static int signal_safe_fprintf(FILE* stream, const char* fmt, ...) {
    if (n <= 0)
       return n;
 
-   return full_write_str(fileno(stream), buf);
+   ssize_t ret = full_write_str(fileno(stream), buf);
+   return (int)MINIMUM(INT_MAX, ret);
 }
 
 int Settings_write(const Settings* this, bool onCrash) {

--- a/generic/gettime.c
+++ b/generic/gettime.c
@@ -20,7 +20,7 @@ void Generic_gettime_realtime(struct timeval* tvp, uint64_t* msec) {
    struct timespec ts;
    if (clock_gettime(CLOCK_REALTIME, &ts) == 0) {
       tvp->tv_sec = ts.tv_sec;
-      tvp->tv_usec = ts.tv_nsec / 1000;
+      tvp->tv_usec = (suseconds_t)(ts.tv_nsec / 1000);
       *msec = ((uint64_t)ts.tv_sec * 1000) + ((uint64_t)ts.tv_nsec / 1000000);
    } else {
       memset(tvp, 0, sizeof(struct timeval));

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -162,7 +162,7 @@ IOPriority LinuxProcess_updateIOPriority(Process* p) {
    IOPriority ioprio = 0;
 // Other OSes masquerading as Linux (NetBSD?) don't have this syscall
 #ifdef SYS_ioprio_get
-   ioprio = syscall(SYS_ioprio_get, IOPRIO_WHO_PROCESS, Process_getPid(p));
+   ioprio = (int)syscall(SYS_ioprio_get, IOPRIO_WHO_PROCESS, Process_getPid(p));
 #endif
    LinuxProcess* this = (LinuxProcess*) p;
    this->ioPriority = ioprio;

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -397,6 +397,6 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
       mib[3] = SENSOR_INDICATOR;
       mib[4] = 0; /* "power supply" (status indicator) */
       if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1)
-         *isOnAC = s.value;
+         *isOnAC = s.value != 0 ? AC_PRESENT : AC_ABSENT;
    }
 }


### PR DESCRIPTION
This patch contains a small set of changes that are intended to fix the `-Wshorten-64-to-32` warnings in Clang (enabled by default in Clang 19 and later). This only contains changes that I considered "trivial", that is, not needing any major change to the data structures or code.