### PR TITLE
Cleanup unsigned

### DIFF
--- a/Scheduling.c
+++ b/Scheduling.c
@@ -47,7 +47,7 @@ Panel* Scheduling_newPolicyPanel(int preSelectedPolicy) {
    Panel_add(this, (Object*) ListItem_new(reset_on_fork ? "Reset on fork: on" : "Reset on fork: off", -1));
 #endif
 
-   for (unsigned i = 0; i < ARRAYSIZE(policies); i++) {
+   for (size_t i = 0; i < ARRAYSIZE(policies); i++) {
       if (!policies[i].name)
          continue;
 
@@ -72,7 +72,7 @@ void Scheduling_togglePolicyPanelResetOnFork(Panel* schedPanel) {
 }
 
 Panel* Scheduling_newPriorityPanel(int policy, int preSelectedPriority) {
-   if (policy < 0 || (unsigned)policy >= ARRAYSIZE(policies) || policies[policy].name == NULL)
+   if (policy < 0 || (size_t)policy >= ARRAYSIZE(policies) || policies[policy].name == NULL)
       return NULL;
 
    if (!policies[policy].prioritySupport)
@@ -82,7 +82,7 @@ Panel* Scheduling_newPriorityPanel(int policy, int preSelectedPriority) {
    if (min < 0)
       return NULL;
    int max = sched_get_priority_max(policy);
-   if (max < 0 )
+   if (max < 0)
       return NULL;
 
    Panel* this = Panel_new(0, 0, 0, 0, Class(ListItem), true, FunctionBar_newEnterEsc("Select ", "Cancel "));
@@ -104,7 +104,7 @@ static bool Scheduling_setPolicy(Process* p, Arg arg) {
    int policy = sarg->policy;
 
    assert(policy >= 0);
-   assert((unsigned)policy < ARRAYSIZE(policies));
+   assert((size_t)policy < ARRAYSIZE(policies));
    assert(policies[policy].name);
 
    const struct sched_param param = { .sched_priority = policies[policy].prioritySupport ? sarg->priority : 0 };

--- a/darwin/DarwinMachine.c
+++ b/darwin/DarwinMachine.c
@@ -47,9 +47,9 @@ static void DarwinMachine_freeCPULoadInfo(processor_cpu_load_info_t* p) {
    *p = NULL;
 }
 
-static unsigned DarwinMachine_allocateCPULoadInfo(processor_cpu_load_info_t* p) {
+static size_t DarwinMachine_allocateCPULoadInfo(processor_cpu_load_info_t* p) {
    mach_msg_type_number_t info_size = sizeof(processor_cpu_load_info_t);
-   unsigned cpu_count;
+   natural_t cpu_count;
 
    // TODO Improving the accuracy of the load counts would help a lot.
    if (0 != host_processor_info(mach_host_self(), PROCESSOR_CPU_LOAD_INFO, &cpu_count, (processor_info_array_t*)p, &info_size)) {

--- a/linux/HugePageMeter.c
+++ b/linux/HugePageMeter.c
@@ -43,17 +43,17 @@ static void HugePageMeter_updateValues(Meter* this) {
    size_t size = sizeof(this->txtBuffer);
    int written;
    memory_t usedTotal = 0;
-   unsigned nextUsed = 0;
+   size_t nextUsed = 0;
 
    const LinuxMachine* host = (const LinuxMachine*) this->host;
    this->total = host->totalHugePageMem;
    this->values[0] = 0;
    HugePageMeter_active_labels[0] = " used:";
-   for (unsigned i = 1; i < ARRAYSIZE(HugePageMeter_active_labels); i++) {
+   for (size_t i = 1; i < ARRAYSIZE(HugePageMeter_active_labels); i++) {
       this->values[i] = NAN;
       HugePageMeter_active_labels[i] = NULL;
    }
-   for (unsigned i = 0; i < HTOP_HUGEPAGE_COUNT; i++) {
+   for (size_t i = 0; i < HTOP_HUGEPAGE_COUNT; i++) {
       memory_t value = host->usedHugePageMem[i];
       if (value != MEMORY_MAX) {
          this->values[nextUsed] = value;
@@ -81,7 +81,7 @@ static void HugePageMeter_display(const Object* cast, RichString* out) {
    Meter_humanUnit(buffer, this->total, sizeof(buffer));
    RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
 
-   for (unsigned i = 0; i < ARRAYSIZE(HugePageMeter_active_labels); i++) {
+   for (size_t i = 0; i < ARRAYSIZE(HugePageMeter_active_labels); i++) {
       if (!HugePageMeter_active_labels[i]) {
          break;
       }

--- a/linux/LinuxMachine.c
+++ b/linux/LinuxMachine.c
@@ -220,7 +220,7 @@ static void LinuxMachine_scanMemoryInfo(LinuxMachine* this) {
 
 static void LinuxMachine_scanHugePages(LinuxMachine* this) {
    this->totalHugePageMem = 0;
-   for (unsigned i = 0; i < HTOP_HUGEPAGE_COUNT; i++) {
+   for (size_t i = 0; i < HTOP_HUGEPAGE_COUNT; i++) {
       this->usedHugePageMem[i] = MEMORY_MAX;
    }
 


### PR DESCRIPTION
Cleanup code that only references `unsigned` for its integer type. While plain `unsigned` is defined in the standard to always map to `unsigned int`, this is not necessarily obvious and sometimes there are much better suited types to use (like `size_t` when dealing with array indices).

The only offender left is the code related to CPU affinity handling as the hwloc API is just a plain PITA in that regard (they can't even decide for themselves if they want to be signed or unsigned at times).