### PR TITLE
Meter: Reset attributes after drawing bar borders

### DIFF
--- a/Meter.c
+++ b/Meter.c
@@ -103,6 +103,7 @@ static void BarMeterMode_draw(Meter* this, int x, int y, int w) {
    if (w < 1) {
       goto end;
    }
+   attrset(CRT_colors[RESET_COLOR]); // Clear the bold attribute
    x++;
 
    // The text in the bar is right aligned;


### PR DESCRIPTION
Prevent the contents of the bar meter to be printed with bold attribute if the border characters were bold.

Fixes #1676 (regression from 358156efe8c55173199a9fa4f8508daca114248e)