### PR TITLE
Make the physicalID default to 0 because old Intel processors only have that

### DIFF
--- a/linux/LibSensors.c
+++ b/linux/LibSensors.c
@@ -235,7 +235,7 @@ void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, uns
 
       topPriority = priority;
 
-      int physicalID = -1;
+      int physicalID = 0;
 
       int m = 0;
       for (const sensors_feature* feature = sym_sensors_get_features(chip, &m); feature; feature = sym_sensors_get_features(chip, &m)) {


### PR DESCRIPTION
... and libsensors doesn't tell
Fixes #1680
