### PR TITLE
macOS: OSX 10.4 Tiger compatibility

### DIFF
--- a/darwin/DarwinMachine.c
+++ b/darwin/DarwinMachine.c
@@ -14,6 +14,7 @@ in the source distribution for its full text.
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <mach/mach_init.h>
 #include <sys/mman.h>
 #include <sys/sysctl.h>
 

--- a/darwin/DarwinProcess.c
+++ b/darwin/DarwinProcess.c
@@ -7,10 +7,15 @@ in the source distribution for its full text.
 
 #include "darwin/DarwinProcess.h"
 
+#include <AvailabilityMacros.h>
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
 #include <libproc.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <mach/mach_init.h>
 #include <mach/mach.h>
 #include <sys/dirent.h>
 
@@ -105,6 +110,7 @@ static int DarwinProcess_compareByKey(const Process* v1, const Process* v2, Proc
 }
 
 static void DarwinProcess_updateExe(pid_t pid, Process* proc) {
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
    char path[PROC_PIDPATHINFO_MAXSIZE];
 
    int r = proc_pidpath(pid, path, sizeof(path));
@@ -112,9 +118,11 @@ static void DarwinProcess_updateExe(pid_t pid, Process* proc) {
       return;
 
    Process_updateExe(proc, path);
+#endif
 }
 
 static void DarwinProcess_updateCwd(pid_t pid, Process* proc) {
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
    struct proc_vnodepathinfo vpi;
 
    int r = proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, &vpi, sizeof(vpi));
@@ -131,6 +139,7 @@ static void DarwinProcess_updateCwd(pid_t pid, Process* proc) {
    }
 
    free_and_xStrdup(&proc->procCwd, vpi.pvi_cdir.vip_path);
+#endif
 }
 
 static void DarwinProcess_updateCmdLine(const struct kinfo_proc* k, Process* proc) {
@@ -360,6 +369,7 @@ void DarwinProcess_setFromKInfoProc(Process* proc, const struct kinfo_proc* ps, 
 }
 
 void DarwinProcess_setFromLibprocPidinfo(DarwinProcess* proc, DarwinProcessTable* dpt, double timeIntervalNS) {
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
    struct proc_taskinfo pti;
 
    if (PROC_PIDTASKINFO_SIZE != proc_pidinfo(Process_getPid(&proc->super), PROC_PIDTASKINFO, 0, &pti, PROC_PIDTASKINFO_SIZE)) {
@@ -398,6 +408,9 @@ void DarwinProcess_setFromLibprocPidinfo(DarwinProcess* proc, DarwinProcessTable
    dpt->super.userlandThreads += pti.pti_threadnum; /*pti.pti_threads_user;*/
    dpt->super.totalTasks += pti.pti_threadnum;
    dpt->super.runningTasks += pti.pti_numrunning;
+#else
+   proc->taskAccess = false;
+#endif
 }
 
 /*
@@ -406,6 +419,7 @@ void DarwinProcess_setFromLibprocPidinfo(DarwinProcess* proc, DarwinProcessTable
  * and       https://github.com/max-horvath/htop-osx/blob/e86692e869e30b0bc7264b3675d2a4014866ef46/ProcessList.c
  */
 void DarwinProcess_scanThreads(DarwinProcess* dp, DarwinProcessTable* dpt) {
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
    Process* proc = (Process*) dp;
    kern_return_t ret;
 
@@ -510,6 +524,7 @@ void DarwinProcess_scanThreads(DarwinProcess* dp, DarwinProcessTable* dpt) {
 
    vm_deallocate(mach_task_self(), (vm_address_t) thread_list, sizeof(thread_port_array_t) * thread_count);
    mach_port_deallocate(mach_task_self(), task);
+#endif
 }
 
 

--- a/darwin/DarwinProcessTable.c
+++ b/darwin/DarwinProcessTable.c
@@ -7,8 +7,12 @@ in the source distribution for its full text.
 
 #include "darwin/DarwinProcessTable.h"
 
-#include <errno.h>
+#include <AvailabilityMacros.h>
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
 #include <libproc.h>
+#endif
+
+#include <errno.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -18,6 +18,7 @@ in the source distribution for its full text.
 #include <net/if_types.h>
 #include <net/route.h>
 #include <sys/socket.h>
+#include <mach/mach_init.h>
 #include <mach/port.h>
 
 #include <CoreFoundation/CFBase.h>


### PR DESCRIPTION
2 changes to make htop compatible with OSX 10.4 Tiger

1. `mach_host_self()` and `vm_page_size` are defined in `mach_init.h`.
2. `<libproc.h>` API is not available, related functionality is disabled.

htop builds and works but cannot display per-process CPU% and task%. This can hopefully be improved in the future but at least it builds for now.

![image](https://github.com/user-attachments/assets/abfd75c1-795e-4613-9830-90bb7f08eb85)

/cc @barracuda156 