### PR TITLE
Startup boost

### DIFF
--- a/CommandLine.c
+++ b/CommandLine.c
@@ -297,16 +297,6 @@ static CommandLineStatus parseArguments(int argc, char** argv, CommandLineSettin
    return STATUS_OK;
 }
 
-static void CommandLine_delay(Machine* host, unsigned long millisec) {
-   struct timespec req = {
-      .tv_sec = 0,
-      .tv_nsec = millisec * 1000000L
-   };
-   while (nanosleep(&req, &req) == -1)
-      continue;
-   Platform_gettime_realtime(&host->realtime, &host->realtimeMs);
-}
-
 static void setCommFilter(State* state, char** commFilter) {
    Table* table = state->host->activeTable;
    IncSet* inc = state->mainPanel->inc;
@@ -401,7 +391,6 @@ int CommandLine_run(int argc, char** argv) {
 
    Machine_scan(host);
    Machine_scanTables(host);
-   CommandLine_delay(host, 75);
 
    if (settings->ss->allBranchesCollapsed)
       Table_collapseAllBranches(&pt->super);

--- a/CommandLine.c
+++ b/CommandLine.c
@@ -402,8 +402,6 @@ int CommandLine_run(int argc, char** argv) {
    Machine_scan(host);
    Machine_scanTables(host);
    CommandLine_delay(host, 75);
-   Machine_scan(host);
-   Machine_scanTables(host);
 
    if (settings->ss->allBranchesCollapsed)
       Table_collapseAllBranches(&pt->super);

--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -1600,7 +1600,12 @@ static bool LinuxProcessTable_recurseProcTree(LinuxProcessTable* this, openat_ar
       proc->isUserlandThread = Process_getPid(proc) != Process_getThreadGroup(proc);
       assert(proc->isUserlandThread == (mainTask != NULL));
 
-      LinuxProcessTable_recurseProcTree(this, procFd, lhost, "task", lp);
+      if (mainTask) {
+         // As the list of tasks/threads is presented as a flat view in procfs
+         // below each directories main entry, it makes no sense to
+         // look for further directories that will not be there.
+         LinuxProcessTable_recurseProcTree(this, procFd, lhost, "task", lp);
+      }
 
       /*
        * These conditions will not trigger on first occurrence, cause we need to


### PR DESCRIPTION
Improve startup performance by optimizing how the process list is gathered and how often.

This PR is based on the suggestions from #1678 by @abbeyj.

While this PR is tagged for Linux, it also affects all other platforms due to the second commit. The first commit (improving the process list scanning) only affects Linux, but should be noticeable throughout htop's lifetime.

I'm open for further patches related to performance optimization, in particular ones that affect/improve the startup time.