### PR TITLE
Align structures 8 byte for 64-bit platforms

### DIFF
--- a/DynamicMeter.c
+++ b/DynamicMeter.c
@@ -48,8 +48,8 @@ void DynamicMeters_delete(Hashtable* dynamics) {
 }
 
 typedef struct {
-   ht_key_t key;
    const char* name;
+   ht_key_t key;
    bool found;
 } DynamicIterator;
 

--- a/DynamicScreen.c
+++ b/DynamicScreen.c
@@ -39,8 +39,8 @@ void DynamicScreen_done(DynamicScreen* this) {
 }
 
 typedef struct {
-   ht_key_t key;
    const char* name;
+   ht_key_t key;
    bool found;
 } DynamicIterator;
 

--- a/FunctionBar.h
+++ b/FunctionBar.h
@@ -11,14 +11,14 @@ in the source distribution for its full text.
 
 
 typedef struct FunctionBar_ {
-   int size;
+   uint32_t size;
+   bool staticData;
    char** functions;
    union {
       char** keys;
       const char* const* constKeys;
    } keys;
    int* events;
-   bool staticData;
 } FunctionBar;
 
 #define FUNCTIONBAR_MAXEVENTS 15

--- a/IncSet.h
+++ b/IncSet.h
@@ -24,8 +24,8 @@ typedef enum {
 
 typedef struct IncMode_ {
    char buffer[INCMODE_MAX + 1];
-   size_t index;
    FunctionBar* bar;
+   uint32_t index;
    bool isFilter;
 } IncMode;
 

--- a/ScreenManager.h
+++ b/ScreenManager.h
@@ -21,13 +21,13 @@ typedef struct ScreenManager_ {
    int y1;
    int x2;
    int y2;
+   bool allowFocusChange;
+   uint32_t panelCount;
    Vector* panels;
    const char* name;
-   int panelCount;
    Header* header;
    Machine* host;
    State* state;
-   bool allowFocusChange;
 } ScreenManager;
 
 ScreenManager* ScreenManager_new(Header* header, Machine* host, State* state, bool owner);

--- a/TraceScreen.h
+++ b/TraceScreen.h
@@ -18,9 +18,9 @@ in the source distribution for its full text.
 
 typedef struct TraceScreen_ {
    InfoScreen super;
-   bool tracing;
-   pid_t child;
    FILE* strace;
+   pid_t child;
+   bool tracing;
    bool contLine;
    bool follow;
    bool strace_alive;

--- a/linux/LinuxProcessTable.h
+++ b/linux/LinuxProcessTable.h
@@ -27,8 +27,8 @@ typedef struct LinuxProcessTable_ {
    bool haveAutogroup;
 
    #ifdef HAVE_DELAYACCT
-   struct nl_sock* netlink_socket;
    int netlink_family;
+   struct nl_sock* netlink_socket;
    #endif
 } LinuxProcessTable;
 


### PR DESCRIPTION
Migrated from here: https://salsa.debian.org/debian/htop/-/merge_requests/7

This PR will decrease costs copying, moving, and creating object-structures only for common 64bit processors due to the 8-byte data alignment.

Smaller size structure or class, higher chance putting into CPU cache. Most processors are already 64 bit, so the change won't make it any worse.

## Pahole example:

- Comment `/* XXX {n} bytes hole, try to pack */` shows where optimization is possible by rearranging the order of fields structures and classes

## Master branch

```c
struct ScreenManager_ {
        int                        x1;                   /*     0     4 */
        int                        y1;                   /*     4     4 */
        int                        x2;                   /*     8     4 */
        int                        y2;                   /*    12     4 */
        Vector *                   panels;               /*    16     8 */
        const char  *              name;                 /*    24     8 */
        int                        panelCount;           /*    32     4 */

        /* XXX 4 bytes hole, try to pack */

        Header *                   header;               /*    40     8 */
        Machine *                  host;                 /*    48     8 */
        State *                    state;                /*    56     8 */
        /* --- cacheline 1 boundary (64 bytes) --- */
        _Bool                      allowFocusChange;     /*    64     1 */

        /* size: 72, cachelines: 2, members: 11 */
        /* sum members: 61, holes: 1, sum holes: 4 */
        /* padding: 7 */
        /* last cacheline: 8 bytes */
};
```

## This PR

```c
struct ScreenManager_ {
        int                        x1;                   /*     0     4 */
        int                        y1;                   /*     4     4 */
        int                        x2;                   /*     8     4 */
        int                        y2;                   /*    12     4 */
        _Bool                      allowFocusChange;     /*    16     1 */

        /* XXX 3 bytes hole, try to pack */

        int                        panelCount;           /*    20     4 */
        Vector *                   panels;               /*    24     8 */
        const char  *              name;                 /*    32     8 */
        Header *                   header;               /*    40     8 */
        Machine *                  host;                 /*    48     8 */
        State *                    state;                /*    56     8 */

        /* size: 64, cachelines: 1, members: 11 */
        /* sum members: 61, holes: 1, sum holes: 3 */
};
```

## Info about technique:

https://hpc.rz.rptu.de/Tutorials/AVX/alignment.shtml

https://wr.informatik.uni-hamburg.de/_media/teaching/wintersemester_2013_2014/epc-14-haase-svenhendrik-alignmentinc-presentation.pdf

https://en.wikipedia.org/wiki/Data_structure_alignment

https://stackoverflow.com/a/20882083

https://zijishi.xyz/post/optimization-technique/learning-to-use-data-alignment/

## Affected structs:
- ScreenManager 72 to 64 bytes
- Screen/DynamicIterator 24 to 16 bytes
- Meter/DynamicIterator 24 to 16 bytes
- IncMode 152 to 144 bytes
- TraceScreen 64 to 56 bytes
- LinuxProcessTable 120 to 112 bytes
- FunctionBar 40 to 32 bytes