### PR TITLE
Use correct hashtable key type (ht_key_t) in Dynamic screen/meter code

### DIFF
--- a/DynamicMeter.c
+++ b/DynamicMeter.c
@@ -48,7 +48,7 @@ void DynamicMeters_delete(Hashtable* dynamics) {
 }
 
 typedef struct {
-   unsigned int key;
+   ht_key_t key;
    const char* name;
    bool found;
 } DynamicIterator;
@@ -62,7 +62,7 @@ static void DynamicMeter_compare(ht_key_t key, void* value, void* data) {
    }
 }
 
-bool DynamicMeter_search(Hashtable* dynamics, const char* name, unsigned int* key) {
+bool DynamicMeter_search(Hashtable* dynamics, const char* name, ht_key_t* key) {
    DynamicIterator iter = { .key = 0, .name = name, .found = false };
    if (dynamics)
       Hashtable_foreach(dynamics, DynamicMeter_compare, &iter);
@@ -71,7 +71,7 @@ bool DynamicMeter_search(Hashtable* dynamics, const char* name, unsigned int* ke
    return iter.found;
 }
 
-const char* DynamicMeter_lookup(Hashtable* dynamics, unsigned int key) {
+const char* DynamicMeter_lookup(Hashtable* dynamics, ht_key_t key) {
    const DynamicMeter* meter = Hashtable_get(dynamics, key);
    return meter ? meter->name : NULL;
 }

--- a/DynamicMeter.h
+++ b/DynamicMeter.h
@@ -26,9 +26,9 @@ Hashtable* DynamicMeters_new(void);
 
 void DynamicMeters_delete(Hashtable* dynamics);
 
-const char* DynamicMeter_lookup(Hashtable* dynamics, unsigned int key);
+const char* DynamicMeter_lookup(Hashtable* dynamics, ht_key_t key);
 
-bool DynamicMeter_search(Hashtable* dynamics, const char* name, unsigned int* key);
+bool DynamicMeter_search(Hashtable* dynamics, const char* name, ht_key_t* key);
 
 extern const MeterClass DynamicMeter_class;
 

--- a/pcp/PCPDynamicScreen.c
+++ b/pcp/PCPDynamicScreen.c
@@ -393,7 +393,7 @@ void PCPDynamicScreens_addAvailableColumns(Panel* availableColumns, Hashtable* s
    Vector_prune(availableColumns->items);
 
    bool success;
-   unsigned int key;
+   ht_key_t key;
    success = DynamicScreen_search(screens, screen, &key);
    if (!success)
       return;


### PR DESCRIPTION
No-op change in terms of generated code, but better to be consistent - thanks to BenBE for noticing this.

Relates to #1702