### PR TITLE
check totalCapacity before use it as a divisor

### DIFF
--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -512,8 +512,9 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
          *isOnAC = isConnected ? AC_PRESENT : AC_ABSENT;
       }
    }
-
-   *percent = ((double)totalCharge / (double)totalCapacity) * 100.0;
+   if (totalCapacity != 0){
+      *percent = ((double)totalCharge / (double)totalCapacity) * 100.0;
+   }
 
 error:
    if (fd != -1)


### PR DESCRIPTION
In `Platform_getBattery`, `totalCapacity` is initialized to 0:

```c
intmax_t totalCapacity = 0;
```

It only increases inside the loop when both `isBattery` and `isPresent` are true:

```c
if (isBattery && isPresent) {
    totalCharge += curCharge;
    totalCapacity += maxCharge;
}
```

However, there are valid execution paths (no battery entries, an empty iterator, or batteries with zero capacity) where `totalCapacity` remains 0. The code then performs

```c
((double)totalCharge / (double)totalCapacity) * 100.0
```

which can divide by zero. To prevent this, I add a guard before the division:

```c
   if (totalCapacity != 0){
      *percent = ((double)totalCharge / (double)totalCapacity) * 100.0;
   }
```