### PR TITLE
Handle special cases for CPU frequency data in /proc/cpuinfo

### DIFF
--- a/linux/LinuxMachine.c
+++ b/linux/LinuxMachine.c
@@ -594,6 +594,8 @@ static void scanCPUFrequencyFromCPUinfo(LinuxMachine* this) {
          continue;
       } else if (
          (sscanf(buffer, "cpu MHz : %lf", &frequency) == 1) ||
+         (sscanf(buffer, "CPU MHz : %lf", &frequency) == 1) || // LooooongArch: https://github.com/torvalds/linux/blob/v6.15/arch/loongarch/kernel/proc.c#L42
+         (sscanf(buffer, "cpu MHz dynamic : %lf", &frequency) == 1) || // s390: https://github.com/torvalds/linux/blob/v6.15/arch/s390/kernel/processor.c#L335
          (sscanf(buffer, "clock : %lfMHz", &frequency) == 1)
       ) {
          if (cpuid < 0 || (unsigned int)cpuid > (super->existingCPUs - 1)) {

--- a/linux/LinuxMachine.c
+++ b/linux/LinuxMachine.c
@@ -590,7 +590,10 @@ static void scanCPUFrequencyFromCPUinfo(LinuxMachine* this) {
       if (fgets(buffer, PROC_LINE_LENGTH, file) == NULL)
          break;
 
-      if (sscanf(buffer, "processor : %d", &cpuid) == 1) {
+      if (
+         (sscanf(buffer, "processor : %d", &cpuid) == 1) ||
+         (sscanf(buffer, "cpu number : %d", &cpuid) == 1) // s390: https://github.com/torvalds/linux/blob/v6.15/arch/s390/kernel/processor.c#L349
+      ) {
          continue;
       } else if (
          (sscanf(buffer, "cpu MHz : %lf", &frequency) == 1) ||


### PR DESCRIPTION
This adds special cases for:

- loongarch: https://github.com/torvalds/linux/blob/cd2e103d57e5615f9bb027d772f93b9efd567224/arch/loongarch/kernel/proc.c#L42
- s390: https://github.com/torvalds/linux/blob/cd2e103d57e5615f9bb027d772f93b9efd567224/arch/s390/kernel/processor.c#L335

These differ from all the other platforms in the Linux kernel and weren't matched properly previously. There's an additional value of "CPU MHz static" available for s390, which is always given AFTER the dynamic value and thus would override the dynamic value; we thus ignore the static CPU frequency given for s390 in favour of the dynamic entry.

Fixes: #1711