### PR TITLE
FreeBSD: Update the internal priority reference point

### DIFF
--- a/freebsd/FreeBSDProcessTable.h
+++ b/freebsd/FreeBSDProcessTable.h
@@ -16,6 +16,8 @@ in the source distribution for its full text.
 
 typedef struct FreeBSDProcessTable_ {
    ProcessTable super;
+
+   int osreldate;
 } FreeBSDProcessTable;
 
 #endif


### PR DESCRIPTION
This reference value has recently changed, in order for 0 and higher values to indicate timesharing/idletime priorities, and negative values are kernel or realtime priorities. A reference point is still needed as currently only the raw internal priorities, which are unsigned (uint8_t), can be communicated to userland.