### PR TITLE
pcp/Metric.c and pcp/Plaform.c: changes for pending PCP 7.0.0

### DIFF
--- a/pcp/Metric.c
+++ b/pcp/Metric.c
@@ -175,8 +175,13 @@ bool Metric_fetch(struct timeval* timestamp) {
                  pmErrStr(sts));
       return false;
    }
-   if (timestamp)
+   if (timestamp) {
+#if PMAPI_VERSION >= 3
+      pmtimespecTotimeval(&pcp->result->timestamp, timestamp);
+#else
       *timestamp = pcp->result->timestamp;
+#endif
+   }
    return true;
 }
 

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -853,8 +853,11 @@ void Platform_gettime_realtime(struct timeval* tv, uint64_t* msec) {
 
 void Platform_gettime_monotonic(uint64_t* msec) {
    if (pcp->result) {
-      struct timeval* tv = &pcp->result->timestamp;
-      *msec = ((uint64_t)tv->tv_sec * 1000) + ((uint64_t)tv->tv_usec / 1000);
+#if PMAPI_VERSION >= 3
+      *msec = ((uint64_t)pcp->result->timestamp.tv_sec * 1000) + ((uint64_t)pcp->result->timestamp.tv_nsec / 1000000);
+#else
+      *msec = ((uint64_t)pcp->result->timestamp.tv_sec * 1000) + ((uint64_t)pcp->result->timestamp.tv_usec / 1000);
+#endif
    } else {
       *msec = 0;
    }


### PR DESCRIPTION
timestamps in a pmResult will become struct timespec, not struct timeval, so small change to support both PMAPI_VERSION_2 (timeval) and PMAPI_VERSION_4 (timespec).