### PR TITLE
Fix buffer overflow in DisplayOptionsPanel

### DIFF
--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -26,7 +26,7 @@ static const char* const DisplayOptionsFunctions[] =       {"      ", "      ", 
 
 static const char* const DisplayOptionsDecIncFunctions[] = {"      ", "      ", "      ", "      ", "      ", "      ", "Dec   ", "Inc   ", "      ", "Done  ", NULL};
 static const char* const DisplayOptionsDecIncKeys[] =      {"  "    , "  "    , "  "    , "  "    , "  "    , "  "    , "F7"    , "F8"    , "  "    , "F10"   , NULL};
-static const int DisplayOptionsDecIncEvents[] = {'-', KEY_F(7), '+', KEY_F(8), ERR, KEY_F(10)};
+static const int DisplayOptionsDecIncEvents[] = {'-', KEY_F(7), '+', KEY_F(8), ERR, KEY_F(10), ERR, ERR, ERR, ERR};
 
 static void DisplayOptionsPanel_delete(Object* object) {
    DisplayOptionsPanel* this = (DisplayOptionsPanel*) object;


### PR DESCRIPTION
Hello,

This Pull request fixes a buffer overflow produced by DisplayOptionsPanel.

Inside the function `FunctionBar* FunctionBar_new(const char* const* functions, const char* const* keys, const int* events);`, the parameters `functions` array is iterated until  a `NULL` terminator is encountered
In the [loop](https://github.com/htop-dev/htop/blob/main/FunctionBar.c#L52), the `events` parameter is also iterated, and the index depends on the `functions` array.

The problem is that if the events array is smaller than the function arrays,  the loop iterates too far in the `events` array and produces a buffer overflow. This is what happened in `DisplayOptionsPanel`.

To fix this problem, I added 4 `ERR` values inside `DisplayOptionsDecIncEvents`.

I checked all `FunctionBar_new` calls and I found only this one.

Here, this is the sanitizer log : 
```
=================================================================
==44975==ERROR: AddressSanitizer: global-buffer-overflow on address 0x00000054c6c4 at pc 0x0000004487d2 bp 0x7fffffff9180 sp 0x7fffffff9178
READ of size 4 at 0x00000054c6c4 thread T0
    #0 0x4487d1 in FunctionBar_new ../FunctionBar.c:54
    #1 0x443be2 in DisplayOptionsPanel_new ../DisplayOptionsPanel.c:136
    #2 0x42ed24 in CategoriesPanel_makeDisplayOptionsPage ../CategoriesPanel.c:67
    #3 0x4303c3 in CategoriesPanel_new ../CategoriesPanel.c:187
    #4 0x41b6e6 in Action_runSetup ../Action.c:96
    #5 0x41b6e6 in actionSetup ../Action.c:567
    #6 0x463e74 in MainPanel_eventHandler ../MainPanel.c:116
    #7 0x4b7df4 in ScreenManager_run ../ScreenManager.c:341
    #8 0x433dcb in CommandLine_run ../CommandLine.c:411
    #9 0x7ffff6c2a47d in __libc_start_call_main (/nix/store/cg9s562sa33k78m63njfn1rw47dp9z0i-glibc-2.40-66/lib/libc.so.6+0x2a47d) (BuildId: 295697e46737532f05317823a9a421b7e462a933)
    #10 0x7ffff6c2a538 in __libc_start_main_alias_1 (/nix/store/cg9s562sa33k78m63njfn1rw47dp9z0i-glibc-2.40-66/lib/libc.so.6+0x2a538) (BuildId: 295697e46737532f05317823a9a421b7e462a933)
    #11 0x418194 in _start (/home/odric/htop/build/htop+0x418194)

0x00000054c6c4 is located 60 bytes before global variable '*.LC43' defined in '../DisplayOptionsPanel.c' (0x54c700) of size 3
  '*.LC43' is ascii string '  '
0x00000054c6c4 is located 0 bytes after global variable 'DisplayOptionsDecIncEvents' defined in '../DisplayOptionsPanel.c:29:18' (0x54c6a0) of size 36
SUMMARY: AddressSanitizer: global-buffer-overflow ../FunctionBar.c:54 in FunctionBar_new
Shadow bytes around the buggy address:
  0x00000054c400: f9 f9 f9 f9 00 00 00 00 00 00 00 03 f9 f9 f9 f9
  0x00000054c480: 00 00 00 00 00 02 f9 f9 f9 f9 f9 f9 00 00 01 f9
  0x00000054c500: f9 f9 f9 f9 00 00 00 05 f9 f9 f9 f9 00 00 00 00
  0x00000054c580: f9 f9 f9 f9 00 00 00 06 f9 f9 f9 f9 00 00 00 00
  0x00000054c600: 00 00 00 00 00 07 f9 f9 f9 f9 f9 f9 00 00 00 01
=>0x00000054c680: f9 f9 f9 f9 00 00 00 00[04]f9 f9 f9 f9 f9 f9 f9
  0x00000054c700: 03 f9 f9 f9 f9 f9 f9 f9 03 f9 f9 f9 f9 f9 f9 f9
  0x00000054c780: 03 f9 f9 f9 f9 f9 f9 f9 04 f9 f9 f9 f9 f9 f9 f9
  0x00000054c800: 07 f9 f9 f9 f9 f9 f9 f9 07 f9 f9 f9 f9 f9 f9 f9
  0x00000054c880: 07 f9 f9 f9 f9 f9 f9 f9 07 f9 f9 f9 f9 f9 f9 f9
  0x00000054c900: 00 00 00 00 00 00 00 00 00 00 03 f9 f9 f9 f9 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==44975==ABORTING
```