### PR TITLE
Disable increasing numeric values on select clicks

### DIFF
--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -54,13 +54,10 @@ static HandlerResult DisplayOptionsPanel_eventHandler(Panel* super, int ch) {
       case ' ':
          switch (OptionItem_kind(selected)) {
             case OPTION_ITEM_TEXT:
+            case OPTION_ITEM_NUMBER:
                break;
             case OPTION_ITEM_CHECK:
                CheckItem_toggle((CheckItem*)selected);
-               result = HANDLED;
-               break;
-            case OPTION_ITEM_NUMBER:
-               NumberItem_toggle((NumberItem*)selected);
                result = HANDLED;
                break;
          }


### PR DESCRIPTION
This is a bit a preference issue. I find it odd that clicking "Update interval (in seconds)" increases this field (like any other numeric field) when you just select it with the mouse.

This PR disables that unexpected functionality.

On the other hand ... we toggle checkboxes on select click, too...

Discuss! :smiley: 
