### PR TITLE
Automatically reconnect PCP metrics contexts on disconnect

### DIFF
--- a/Action.h
+++ b/Action.h
@@ -37,6 +37,7 @@ typedef struct State_ {
    struct MainPanel_* mainPanel;
    Header* header;
    bool pauseUpdate;
+   bool validUpdate;
    bool hideSelection;
    bool hideMeters;
 } State;

--- a/CRT.c
+++ b/CRT.c
@@ -1072,7 +1072,11 @@ static void CRT_installSignalHandlers(void) {
    sigaction(SIGFPE, &act, &old_sig_handler[SIGFPE]);
    sigaction(SIGILL, &act, &old_sig_handler[SIGILL]);
    sigaction(SIGBUS, &act, &old_sig_handler[SIGBUS]);
+#ifndef HTOP_PCP
    sigaction(SIGPIPE, &act, &old_sig_handler[SIGPIPE]);
+#else
+   signal(SIGPIPE, SIG_IGN);
+#endif
    sigaction(SIGSYS, &act, &old_sig_handler[SIGSYS]);
    sigaction(SIGABRT, &act, &old_sig_handler[SIGABRT]);
 

--- a/CommandLine.c
+++ b/CommandLine.c
@@ -378,6 +378,7 @@ int CommandLine_run(int argc, char** argv) {
       .mainPanel = panel,
       .header = header,
       .pauseUpdate = false,
+      .validUpdate = true,
       .hideSelection = false,
       .hideMeters = false,
    };

--- a/MainPanel.c
+++ b/MainPanel.c
@@ -194,6 +194,8 @@ static void MainPanel_drawFunctionBar(Panel* super, bool hideFunctionBar) {
    IncSet_drawBar(this->inc, CRT_colors[FUNCTION_BAR]);
    if (this->state->pauseUpdate) {
       FunctionBar_append("PAUSED", CRT_colors[PAUSED]);
+   } else if (!this->state->validUpdate) {
+      FunctionBar_append("FAILED", CRT_colors[FAILED_READ]);
    }
 }
 

--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -147,6 +147,7 @@ static void checkRecalculation(ScreenManager* this, double* oldTime, int* sortTi
       Machine_scan(host);
       if (!this->state->pauseUpdate)
          Machine_scanTables(host);
+      this->state->validUpdate = Platform_getValidState();
 
       // always update header, especially to avoid gaps in graph meters
       Header_updateData(this->header);

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -88,6 +88,10 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
+static inline bool Platform_getValidState(void) {
+   return true;
+}
+
 #define PLATFORM_LONG_OPTIONS
 
 static inline void Platform_longOptionsUsage(ATTR_UNUSED const char* name) { }

--- a/dragonflybsd/Platform.h
+++ b/dragonflybsd/Platform.h
@@ -77,6 +77,10 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
+static inline bool Platform_getValidState(void) {
+   return true;
+}
+
 #define PLATFORM_LONG_OPTIONS
 
 static inline void Platform_longOptionsUsage(ATTR_UNUSED const char* name) { }

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -77,6 +77,10 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
+static inline bool Platform_getValidState(void) {
+   return true;
+}
+
 #define PLATFORM_LONG_OPTIONS
 
 static inline void Platform_longOptionsUsage(ATTR_UNUSED const char* name) { }

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -98,6 +98,10 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
+static inline bool Platform_getValidState(void) {
+   return true;
+}
+
 #ifdef HAVE_LIBCAP
    #define PLATFORM_LONG_OPTIONS \
       {"drop-capabilities", optional_argument, 0, 160},

--- a/netbsd/Platform.h
+++ b/netbsd/Platform.h
@@ -83,6 +83,10 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
+static inline bool Platform_getValidState(void) {
+   return true;
+}
+
 static inline void Platform_longOptionsUsage(ATTR_UNUSED const char* name) { }
 
 static inline CommandLineStatus Platform_getLongOption(ATTR_UNUSED int opt, ATTR_UNUSED int argc, ATTR_UNUSED char** argv) {

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -75,6 +75,10 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
+static inline bool Platform_getValidState(void) {
+   return true;
+}
+
 #define PLATFORM_LONG_OPTIONS
 
 static inline void Platform_longOptionsUsage(ATTR_UNUSED const char* name) { }

--- a/pcp/Metric.c
+++ b/pcp/Metric.c
@@ -166,6 +166,11 @@ bool Metric_fetch(struct timeval* timestamp) {
       pcp->result = NULL;
    }
    int sts, count = 0;
+   if (pcp->reconnect) {
+      if (pmReconnectContext(pcp->context) < 0)
+         return false;
+      pcp->reconnect = false;
+   }
    do {
       sts = pmFetch(pcp->totalMetrics, pcp->fetch, &pcp->result);
    } while (sts == PM_ERR_IPC && ++count < 3);
@@ -173,6 +178,7 @@ bool Metric_fetch(struct timeval* timestamp) {
       if (pmDebugOptions.appl0)
          fprintf(stderr, "Error: cannot fetch metric values: %s\n",
                  pmErrStr(sts));
+      pcp->reconnect = true;
       return false;
    }
    if (timestamp) {

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -794,6 +794,10 @@ void Platform_getBattery(double* level, ACPresence* isOnAC) {
    *isOnAC = AC_ERROR;
 }
 
+bool Platform_getValidState(void) {
+    return pcp->reconnect == false;
+}
+
 void Platform_longOptionsUsage(ATTR_UNUSED const char* name) {
    printf(
 "   --host=HOSTSPEC              metrics source is PMCD at HOSTSPEC [see PCPIntro(1)]\n"

--- a/pcp/Platform.h
+++ b/pcp/Platform.h
@@ -44,6 +44,7 @@ in the source distribution for its full text.
 
 typedef struct Platform_ {
    int context;               /* PMAPI(3) context identifier */
+   bool reconnect;            /* need to reconnect the context */
    size_t totalMetrics;       /* total number of all metrics */
    const char** names;        /* name array indexed by Metric */
    pmID* pmids;               /* all known metric identifiers */

--- a/pcp/Platform.h
+++ b/pcp/Platform.h
@@ -115,6 +115,8 @@ void Platform_getHostname(char* buffer, size_t size);
 
 void Platform_getRelease(char** string);
 
+bool Platform_getValidState(void);
+
 enum {
    PLATFORM_LONGOPT_HOST = 128,
    PLATFORM_LONGOPT_TIMEZONE,

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -102,6 +102,10 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
+static inline bool Platform_getValidState(void) {
+   return true;
+}
+
 #define PLATFORM_LONG_OPTIONS
 
 static inline void Platform_longOptionsUsage(ATTR_UNUSED const char* name) { }

--- a/unsupported/Platform.h
+++ b/unsupported/Platform.h
@@ -67,6 +67,10 @@ void Platform_getHostname(char* buffer, size_t size);
 
 void Platform_getRelease(char** string);
 
+static inline bool Platform_getValidState(void) {
+   return true;
+}
+
 #define PLATFORM_LONG_OPTIONS
 
 static inline void Platform_longOptionsUsage(ATTR_UNUSED const char* name) { }


### PR DESCRIPTION
If the PCP pmcd metrics server is restarted, pcp-htop can receive SIGPIPE and failed calls to pmFetch which currently often results in process exit.  This commit adds automatic pmcd reconnect after failure, increasing resilience and avoiding manual restarts we'll otherwise need.