### PR TITLE
Ignore virtual interfaces for network IO accounting

### DIFF
--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -206,6 +206,9 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    #ifdef HAVE_LIBHWLOC
    Panel_add(super, (Object*) CheckItem_newByRef("Show topology when selecting affinity by default", &(settings->topologyAffinity)));
    #endif
+   #ifdef IGNORE_VIRTUAL_INTF
+   Panel_add(super, (Object*) CheckItem_newByRef("Ignore virtual network interfaces to count rx and tx values", &(settings->ignoreVirtualNetworkInterfaces)));
+   #endif
 
    return this;
 }

--- a/NetworkIOMeter.c
+++ b/NetworkIOMeter.c
@@ -45,7 +45,11 @@ static void NetworkIOMeter_updateValues(Meter* this) {
 
    /* update only every 500ms to have a sane span for rate calculation */
    if (passedTimeInMs > 500) {
+#ifdef IGNORE_VIRTUAL_INTF
+      hasNewData = Platform_getNetworkIO(&data, host->settings->ignoreVirtualNetworkInterfaces);
+#else
       hasNewData = Platform_getNetworkIO(&data);
+#endif
       if (!hasNewData) {
          status = RATESTATUS_NODATA;
       } else if (cached_last_update == 0) {

--- a/Settings.h
+++ b/Settings.h
@@ -112,6 +112,9 @@ typedef struct Settings_ {
 
    bool changed;
    uint64_t lastUpdate;
+#ifdef IGNORE_VIRTUAL_INTF
+   bool ignoreVirtualNetworkInterfaces;
+#endif
 } Settings;
 
 #define Settings_cpuId(settings, cpu) ((settings)->countCPUsFromOne ? (cpu)+1 : (cpu))

--- a/configure.ac
+++ b/configure.ac
@@ -1175,6 +1175,16 @@ if test "$enable_sensors" = yes || test "$my_htop_platform" = freebsd; then
    AC_DEFINE([BUILD_WITH_CPU_TEMP], [1], [Define if CPU temperature option should be enabled.])
 fi
 
+AC_ARG_ENABLE([ignore-virtual-intf],
+  [AS_HELP_STRING([--enable-ignore-virtual-intf],
+    [Ignore virtual network interfaces in NetworkIO meter [default=no]])],
+  [enable_ignore_virtual_intf=yes],
+  [enable_ignore_virtual_intf=no])
+
+if test "x$enable_ignore_virtual_intf" = "xyes"; then
+  AC_DEFINE([IGNORE_VIRTUAL_INTF], [1], [Ignore virtual network interfaces])
+fi
+
 # ----------------------------------------------------------------------
 
 

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -85,8 +85,11 @@ void Platform_getPressureStall(const char* file, bool some, double* ten, double*
 void Platform_getFileDescriptors(double* used, double* max);
 
 bool Platform_getDiskIO(DiskIOData* data);
-
+#ifdef IGNORE_VIRTUAL_INTF
+bool Platform_getNetworkIO(NetworkIOData* data, bool ignoreVirtual);
+#else
 bool Platform_getNetworkIO(NetworkIOData* data);
+#endif
 
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
 


### PR DESCRIPTION
Hello,

In Issue #1739 was asked to create an option to avoid virtual interfaces to count Rx/Tx.

[root cause]
Traffic that goes into or leave the virtual interface also passes through the physical interface. This duplicates the Rx and Tx values.

[solution]
Create a new Global Options to ignore the virtual interface to count traffic. The option is disabled by default.
At Platform_getNetworkIO() check for virtual interface before summing up Rx/Tx bytes and packets.
The code is protected by the flag IGNORE_VIRTUAL_INTF and its compilation flag --enable-ignore-virtual-intf.

[unit test]
I used this container in order to help me with this: https://hub.docker.com/r/openspeedtest/latest
1. Run the container
2. Start htop
3. From another device, access the openspeedtest page and start the throughput test. -->> You'll notice that Rx and Tx values goes high.
4. Press F2 and select "Ignore virtual network ..."
5. Repeat step 3. -->> Now you'll notice that only Rx or Tx values goes high, accordingly to the speedtest direction.

This is my first pull request on public project, sorry for any mistake.