### PR TITLE
Display a platform-specific failed state message

### DIFF
--- a/Action.h
+++ b/Action.h
@@ -36,8 +36,8 @@ typedef struct State_ {
    Machine* host;
    struct MainPanel_* mainPanel;
    Header* header;
+   const char* failedUpdate; /* function bar diagnostic or NULL if no error */
    bool pauseUpdate;
-   bool validUpdate;
    bool hideSelection;
    bool hideMeters;
 } State;

--- a/CommandLine.c
+++ b/CommandLine.c
@@ -377,8 +377,8 @@ int CommandLine_run(int argc, char** argv) {
       .host = host,
       .mainPanel = panel,
       .header = header,
+      .failedUpdate = NULL,
       .pauseUpdate = false,
-      .validUpdate = true,
       .hideSelection = false,
       .hideMeters = false,
    };

--- a/MainPanel.c
+++ b/MainPanel.c
@@ -194,8 +194,8 @@ static void MainPanel_drawFunctionBar(Panel* super, bool hideFunctionBar) {
    IncSet_drawBar(this->inc, CRT_colors[FUNCTION_BAR]);
    if (this->state->pauseUpdate) {
       FunctionBar_append("PAUSED", CRT_colors[PAUSED]);
-   } else if (!this->state->validUpdate) {
-      FunctionBar_append("FAILED", CRT_colors[FAILED_READ]);
+   } else if (this->state->failedUpdate) {
+      FunctionBar_append(this->state->failedUpdate, CRT_colors[FAILED_READ]);
    }
 }
 

--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -147,7 +147,7 @@ static void checkRecalculation(ScreenManager* this, double* oldTime, int* sortTi
       Machine_scan(host);
       if (!this->state->pauseUpdate)
          Machine_scanTables(host);
-      this->state->validUpdate = Platform_getValidState();
+      this->state->failedUpdate = Platform_getFailedState();
 
       // always update header, especially to avoid gaps in graph meters
       Header_updateData(this->header);

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -88,8 +88,8 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
-static inline bool Platform_getValidState(void) {
-   return true;
+static inline const char* Platform_getFailedState(void) {
+   return NULL;
 }
 
 #define PLATFORM_LONG_OPTIONS

--- a/dragonflybsd/Platform.h
+++ b/dragonflybsd/Platform.h
@@ -77,8 +77,8 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
-static inline bool Platform_getValidState(void) {
-   return true;
+static inline const char* Platform_getFailedState(void) {
+   return NULL;
 }
 
 #define PLATFORM_LONG_OPTIONS

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -77,8 +77,8 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
-static inline bool Platform_getValidState(void) {
-   return true;
+static inline const char* Platform_getFailedState(void) {
+   return NULL;
 }
 
 #define PLATFORM_LONG_OPTIONS

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -98,8 +98,8 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
-static inline bool Platform_getValidState(void) {
-   return true;
+static inline const char* Platform_getFailedState(void) {
+   return NULL;
 }
 
 #ifdef HAVE_LIBCAP

--- a/netbsd/Platform.h
+++ b/netbsd/Platform.h
@@ -83,8 +83,8 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
-static inline bool Platform_getValidState(void) {
-   return true;
+static inline const char* Platform_getFailedState(void) {
+   return NULL;
 }
 
 static inline void Platform_longOptionsUsage(ATTR_UNUSED const char* name) { }

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -75,8 +75,8 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
-static inline bool Platform_getValidState(void) {
-   return true;
+static inline const char* Platform_getFailedState(void) {
+   return NULL;
 }
 
 #define PLATFORM_LONG_OPTIONS

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -794,8 +794,8 @@ void Platform_getBattery(double* level, ACPresence* isOnAC) {
    *isOnAC = AC_ERROR;
 }
 
-bool Platform_getValidState(void) {
-    return pcp->reconnect == false;
+const char* Platform_getFailedState(void) {
+   return pcp->reconnect ? "PMCD DOWN" : NULL;
 }
 
 void Platform_longOptionsUsage(ATTR_UNUSED const char* name) {

--- a/pcp/Platform.h
+++ b/pcp/Platform.h
@@ -115,7 +115,7 @@ void Platform_getHostname(char* buffer, size_t size);
 
 void Platform_getRelease(char** string);
 
-bool Platform_getValidState(void);
+const char* Platform_getFailedState(void);
 
 enum {
    PLATFORM_LONGOPT_HOST = 128,

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -102,8 +102,8 @@ static inline void Platform_getRelease(char** string) {
    *string = Generic_uname();
 }
 
-static inline bool Platform_getValidState(void) {
-   return true;
+static inline const char* Platform_getFailedState(void) {
+   return NULL;
 }
 
 #define PLATFORM_LONG_OPTIONS

--- a/unsupported/Platform.h
+++ b/unsupported/Platform.h
@@ -67,8 +67,8 @@ void Platform_getHostname(char* buffer, size_t size);
 
 void Platform_getRelease(char** string);
 
-static inline bool Platform_getValidState(void) {
-   return true;
+static inline const char* Platform_getFailedState(void) {
+   return NULL;
 }
 
 #define PLATFORM_LONG_OPTIONS


### PR DESCRIPTION
Further discussion around earlier PR #1745 (relating to improved handling of PCP pmcd connection loss) centered on more descriptive function names and diagnostics.  In this commit the boolean logic in Platform_getValidState has been reversed to *FailedState, along with a pointer to a less generic error message allowing for more clear failure diagnostics.