### PR TITLE
Fix logic bug while iterating processes

### DIFF
--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -1600,7 +1600,7 @@ static bool LinuxProcessTable_recurseProcTree(LinuxProcessTable* this, openat_ar
       proc->isUserlandThread = Process_getPid(proc) != Process_getThreadGroup(proc);
       assert(proc->isUserlandThread == (mainTask != NULL));
 
-      if (mainTask) {
+      if (!mainTask) {
          // As the list of tasks/threads is presented as a flat view in procfs
          // below each directories main entry, it makes no sense to
          // look for further directories that will not be there.


### PR DESCRIPTION
This patch fixes a logic bug introduced in #1696, while addressing a performance issue raised in #1678, causing no threads to be visible at runtime.

The problem is caused by the way that LinuxProcessTable_recurseProcTree handles iteration of entries in the procfs, where the top-most list with processes is iterated with the mainTask argument set to NULL, while for threads it's set to the thread group's main thread object.

This fix repairs that logic and still cut's the recursion into subdirectories short, as originally intended with #1696, given that procfs's task directories aren't nested.

Fixes: #1750

CC: @abbeyj Please take a look regarding performance issues. This is a follow-up on #1678/#1696.