### PR TITLE
Fix for CPU temperature sensor for Amlogic S905W

### DIFF
--- a/linux/LibSensors.c
+++ b/linux/LibSensors.c
@@ -158,6 +158,8 @@ static int tempDriverPriority(const sensors_chip_name* chip) {
       { "cpu5_thermal",       0 },
       { "cpu6_thermal",       0 },
       { "cpu7_thermal",       0 },
+      /* Amlogic S905W */
+      { "scpi_sensors",       0 },
       /* Low priority drivers */
       { "acpitz",             1 },
    };
@@ -307,6 +309,17 @@ void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, uns
                coreTempCount += 4;
                continue;
             }
+         }
+
+         /* Amlogic S905W */
+         if (String_eq(chip->prefix, "scpi_sensors")) {
+            // Package temperature - assign to ALL cores and package
+            for (size_t i = 0; i <= existingCPUs; i++) {
+               data[i] = temp;
+            }
+
+            coreTempCount = existingCPUs;
+            continue;
          }
 
          char *label = sym_sensors_get_label(chip, feature);


### PR DESCRIPTION
I would like to add a fix for CPU temperature sensor for Amlogic S905W.

> sensors -u
> scpi_sensors-isa-0000
> Adapter: ISA adapter
> aml_thermal:
>   temp1_input: 49.000
