### PR TITLE
add sensors for Snapdragon 410

### DIFF
--- a/linux/LibSensors.c
+++ b/linux/LibSensors.c
@@ -160,6 +160,9 @@ static int tempDriverPriority(const sensors_chip_name* chip) {
       { "cpu7_thermal",       0 },
       /* Amlogic S905W */
       { "scpi_sensors",       0 },
+      /* Snapdragon 410 */
+      { "cpu0_1_thermal",     0 },
+      { "cpu2_3_thermal",     0 },
       /* Low priority drivers */
       { "acpitz",             1 },
    };
@@ -307,6 +310,22 @@ void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, uns
                data[3] = temp;
                data[4] = temp;
                coreTempCount += 4;
+               continue;
+            }
+         }
+
+         /* Snapdragon 410 */
+         if (existingCPUs == 4) {
+            if (String_eq(chip->prefix, "cpu0_1_thermal")) {
+               data[1] = temp;
+               data[2] = temp;
+               coreTempCount += 2;
+               continue;
+            }
+            if (String_eq(chip->prefix, "cpu2_3_thermal")) {
+               data[3] = temp;
+               data[4] = temp;
+               coreTempCount += 2;
                continue;
             }
          }


### PR DESCRIPTION
Hi, I would like to add a fix for CPU temperature sensor for Snapdragon 410, they have below sensors.

```
cpu0_1_thermal-virtual-0
Adapter: Virtual device
temp1:        +42.0°C

gpu_thermal-virtual-0
Adapter: Virtual device
temp1:        +40.0°C

modem_thermal-virtual-0
Adapter: Virtual device
temp1:        +42.0°C

pm8916_bms_vm-isa-0000
Adapter: ISA adapter
in0:           4.34 V

pm8916_thermal-virtual-0
Adapter: Virtual device
temp1:        +37.7°C

cpu2_3_thermal-virtual-0
Adapter: Virtual device
temp1:        +40.0°C

camera_thermal-virtual-0
Adapter: Virtual device
temp1:        +42.0°C
```