### PR TITLE
docs: add COLORS section for USER and COMMAND columns (#1765)

### DIFF
--- a/htop.1.in
+++ b/htop.1.in
@@ -308,9 +308,9 @@ Additional color highlighting:
 .IP \[bu] 2
 Magenta: regular process command names
 .IP \[bu] 2
-Bold Blue: userland thread names
+Bold blue: userland thread names
 .IP \[bu] 2
-Bold Gray: kernel threads or processes with no command name
+Bold gray: kernel threads or processes with no command name
 .RE
 .TP
 .B COMM
@@ -479,7 +479,7 @@ Additional color highlighting:
 .IP \[bu] 2
 Magenta: elevated privilege processes
 .IP \[bu] 2
-Bold Gray: processes owned by other users
+Bold gray: processes owned by other users
 .IP \[bu] 2
 White (default): processes owned by the current user
 .RE


### PR DESCRIPTION
This pull request adds a **COLORS** subsection to the man page documenting
the color usage for the **USER** and **COMMAND** columns.

- **USER column**  
  - Magenta: processes with elevated privileges (setuid/capabilities).  
  - Gray: user IDs different from the htop user.  
  - Normal: regular processes of the current user.  

- **COMMAND column**  
  - Cyan/Bold Cyan: highlights the process basename.  
  - Magenta: command name (/proc/[pid]/comm).  
  - Gray: kernel threads or missing data.  
  - Red/Yellow: deleted or replaced executables/libraries.  

This change improves discoverability for new users, making it clear what
the color highlights mean directly from `man htop`.

Fixes #1765

ℹ️ I am a beginner contributor, so I warmly welcome any kind of feedback.
If there are mistakes or things that can be improved, I’ll be glad to fix
and resubmit. Thank you for reviewing!