### PR TITLE
refactor: remove redundant isRunningInContainer initialization

### DIFF
--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -1714,7 +1714,6 @@ static bool LinuxProcessTable_recurseProcTree(LinuxProcessTable* this, openat_ar
          || ss->flags & PROCESS_FLAG_LINUX_VSERVER
 #endif
       ) {
-         proc->isRunningInContainer = TRI_OFF;
          if (!LinuxProcessTable_readStatusFile(proc, procFd))
             goto errorReadingProcess;
       }


### PR DESCRIPTION
Remove the explicit initialization of proc->isRunningInContainer to TRI_OFF before calling LinuxProcessTable_readStatusFile.

[The function already initializes this field as part of its normal operation](https://github.com/htop-dev/htop/blob/main/linux/LinuxProcessTable.c#L532) when reading /proc/[pid]/status.