### PR TITLE
Update constant width font specifier in pcp-htop.5

### DIFF
--- a/pcp-htop.5.in
+++ b/pcp-htop.5.in
@@ -34,7 +34,7 @@ Lines starting with the "#" character are treated as comments.
 .SH "METERS"
 The following is an example configuration for a new Redis meter:
 .LP
-.ft CW
+.ft CR
 .nf
 .in +0.5i
 [redisclient]
@@ -158,7 +158,7 @@ megabytes, etc), a suffix will be automatically appended.
 The following is an example configuration for a new column
 showing open file descriptors for each process:
 .LP
-.ft CW
+.ft CR
 .nf
 .in +0.5i
 [openfds]


### PR DESCRIPTION
Current versions of Fedora "man 5 pcp-htop" produces:

troff:<standard input>:37: warning: cannot select font 'CW'
troff:<standard input>:161: warning: cannot select font 'CW'

Newer versions of groff now issue warnings about this old name for constant width (CW) fonts - switch to a modern alternative that is well supported (courier regular - CR) to resolve this.