### PR TITLE
Cancel pending renaming action for a screen in dtor of ScreensPanel

### DIFF
--- a/ScreensPanel.c
+++ b/ScreensPanel.c
@@ -51,6 +51,20 @@ static const char* const DynamicFunctions[] = {"      ", "Rename", "      ", "  
 
 static void ScreensPanel_delete(Object* object) {
    Panel* super = (Panel*) object;
+   ScreensPanel* const this = (ScreensPanel*) super;
+
+   /* cancel any pending edit action */
+   if (this->renamingItem) {
+      ListItem* item = (ListItem*) Panel_getSelected(super);
+      assert(item == this->renamingItem);
+
+      if (item)
+         item->value = this->saved;
+      this->renamingItem = NULL;
+      super->cursorOn = false;
+
+      Panel_setSelectionColor(super, PANEL_SELECTION_FOCUS);
+   }
 
    /* do not delete screen settings still in use */
    int n = Panel_size(super);


### PR DESCRIPTION
Fixes an UAF issue when editing the screen configuration.

Fixes: #1760