### PR TITLE
build: Improve `-Wextra-semi-stmt` warning option check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1217,7 +1217,11 @@ AS_VAR_IF(CACHEVAR,yes,
 AS_VAR_POPDEF([CACHEVAR])dnl
 ])dnl AX_CHECK_COMPILE_FLAGS
 
-AX_CHECK_COMPILE_FLAG([-Wextra-semi-stmt],         [AM_CFLAGS="$AM_CFLAGS -Wextra-semi-stmt"],         , [-Werror=unknown-warning-option]) dnl the autoconf check itself generates -Wextra-semi-stmt
+dnl During the check of '-Wextra-semi-stmt' we must treat
+dnl 'extra-semi-stmt' as a non-error because the AC_LANG_PROGRAM
+dnl template will generate a warning of this (by design).
+AX_CHECK_COMPILE_FLAG([-Wextra-semi-stmt],         [AM_CFLAGS="$AM_CFLAGS -Wextra-semi-stmt"],         , [-Werror -Wno-error=extra-semi-stmt])
+
 AX_CHECK_COMPILE_FLAG([-Wimplicit-int-conversion], [AM_CFLAGS="$AM_CFLAGS -Wimplicit-int-conversion"], , [-Werror])
 AX_CHECK_COMPILE_FLAG([-Wnull-dereference],        [AM_CFLAGS="$AM_CFLAGS -Wnull-dereference"],        , [-Werror])
 


### PR DESCRIPTION
The `-Wunknown-warning-option` option is specific to Clang, and GCC implemented it as `-Wunknown-warning`. Rather than using `-Wunknown-warning` which is itself unportable, prevent `extra-semi-stmt` from turning to error via the simpler `-Wno-error=extra-semi-stmt` option.

Also amend the code comment to better explain why the `-Wno-error=...` option.