### PR TITLE
Shadow path prefixes that used by NixOS

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -295,6 +295,12 @@ void Process_makeCommandStr(Process* this, const Settings* settings) {
                   }                                                                           \
                }                                                                              \
                break;                                                                         \
+            case 'n':                                                                         \
+               CHECK_AND_MARK(str_, "/nix/store/");                                           \
+               break;                                                                         \
+            case 'r':                                                                         \
+               CHECK_AND_MARK(str_, "/run/current-system/");                                  \
+               break;                                                                         \
          }                                                                                    \
       } while (0)
 


### PR DESCRIPTION
In NixOS or Linux/MacOS installed with nix, all executable binary is located under `/nix/store` instead of paths like `/usr/bin` that used by distros compliant with FHS: https://old.reddit.com/r/NixOS/comments/190v0n7/ive_been_told_that_nix_isnt_fhs_compliant_what/

And `/run/current-system` is a symlink to an dir in `/nix/store` that represents the current generation: https://xn--w5d.cc/2020/08/31/current-system-nixos.html