### PR TITLE
build: Update ax_check_compile_flag module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,7 @@ AC_PREREQ([2.69])
 AC_INIT([htop], [m4_join([-],m4_defn([htop_release_version]),m4_defn([htop_git_version]))], [htop@groups.io], [], [https://htop.dev/])
 
 AC_CONFIG_SRCDIR([htop.c])
+AC_CONFIG_MACRO_DIRS([m4])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])
 
@@ -1432,35 +1433,34 @@ AM_CFLAGS="$AM_CFLAGS\
  -Wunused\
  -Wwrite-strings"
 
-dnl https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
-AC_DEFUN(
+m4_ifdef(
    [AX_CHECK_COMPILE_FLAG],
    [
-      AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
-      AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
-         ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
-         _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
-         AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
-            [AS_VAR_SET(CACHEVAR,[yes])],
-            [AS_VAR_SET(CACHEVAR,[no])])
-         _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags
-      ])
-      AS_VAR_IF(CACHEVAR,yes,
-         [m4_default([$2], :)],
-         [m4_default([$3], :)]
+      dnl During the check of '-Wextra-semi-stmt' we must treat
+      dnl 'extra-semi-stmt' as a non-error because the AC_LANG_PROGRAM
+      dnl template will generate a warning of this (by design).
+      AX_CHECK_COMPILE_FLAG(
+         [-Wextra-semi-stmt],
+         [AM_CFLAGS="$AM_CFLAGS -Wextra-semi-stmt"],
+         [],
+         [-Wno-error=extra-semi-stmt]
       )
-      AS_VAR_POPDEF([CACHEVAR])dnl
+
+      AX_CHECK_COMPILE_FLAG(
+         [-Wimplicit-int-conversion],
+         [AM_CFLAGS="$AM_CFLAGS -Wimplicit-int-conversion"]
+      )
+      AX_CHECK_COMPILE_FLAG(
+         [-Wnull-dereference],
+         [AM_CFLAGS="$AM_CFLAGS -Wnull-dereference"]
+      )
+   ], [
+      m4_warn(
+         [syntax],
+         [module m4/ax_check_compile_flag.m4 is missing]
+      )
    ]
 )
-dnl AX_CHECK_COMPILE_FLAGS
-
-dnl During the check of '-Wextra-semi-stmt' we must treat
-dnl 'extra-semi-stmt' as a non-error because the AC_LANG_PROGRAM
-dnl template will generate a warning of this (by design).
-AX_CHECK_COMPILE_FLAG([-Wextra-semi-stmt],         [AM_CFLAGS="$AM_CFLAGS -Wextra-semi-stmt"],         , [-Werror -Wno-error=extra-semi-stmt])
-
-AX_CHECK_COMPILE_FLAG([-Wimplicit-int-conversion], [AM_CFLAGS="$AM_CFLAGS -Wimplicit-int-conversion"], , [-Werror])
-AX_CHECK_COMPILE_FLAG([-Wnull-dereference],        [AM_CFLAGS="$AM_CFLAGS -Wnull-dereference"],        , [-Werror])
 
 AC_ARG_ENABLE(
    [werror],

--- a/m4/ax_check_compile_flag.m4
+++ b/m4/ax_check_compile_flag.m4
@@ -1,0 +1,63 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_COMPILE_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the current language's compiler
+#   or gives an error.  (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,LINK}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 11
+
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether the _AC_LANG compiler accepts $1], CACHEVAR, [
+  ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+  if test x"m4_case(_AC_LANG,
+                     [C], [$GCC],
+                     [C++], [$GXX],
+                     [Fortran], [$GFC],
+                     [Fortran 77], [$G77],
+                     [Objective C], [$GOBJC],
+                     [Objective C++], [$GOBJCXX],
+                     [no])" = xyes ; then
+    add_gnu_werror="-Werror"
+  fi
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1 $add_gnu_werror"
+  AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS


### PR DESCRIPTION
Update `AX_CHECK_COMPILE_FLAG` in `configure.ac` to latest upstream version (serial 11).
Move the macro to a separate file so that it won't be subject to our coding style such as in 97073ba86e2627db9132217f19f8a3c4f2235f68, and it allows future update easier.

The new version automatically appends `-Werror` during the compile option check, so I removed the `-Werror` from our macro calls in order to make them brief.