### PR TITLE
Implement different display types for bar meters

### DIFF
--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -205,7 +205,7 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    Panel_add(super, (Object*) NumberItem_newByRef("Hide main function bar (0 - off, 1 - on ESC until next input, 2 - permanently)", &(settings->hideFunctionBar), 0, 0, 2));
 
    #ifdef HAVE_LIBNCURSESW
-   if(CRT_utf8)
+   if (CRT_utf8)
       Panel_add(super, (Object*) NumberItem_newByRef("Bar Type (0 - default)", (int*)&(settings->barType), 0, 0, BAR_METER_NUM_STYLES-1));
    #endif
 

--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -203,6 +203,12 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    Panel_add(super, (Object*) CheckItem_newByRef("Highlight new and old processes", &(settings->highlightChanges)));
    Panel_add(super, (Object*) NumberItem_newByRef("- Highlight time (in seconds)", &(settings->highlightDelaySecs), 0, 1, 24 * 60 * 60));
    Panel_add(super, (Object*) NumberItem_newByRef("Hide main function bar (0 - off, 1 - on ESC until next input, 2 - permanently)", &(settings->hideFunctionBar), 0, 0, 2));
+
+   #ifdef HAVE_LIBNCURSESW
+   if(CRT_utf8)
+      Panel_add(super, (Object*) NumberItem_newByRef("Bar Type (0 - default)", (int*)&(settings->barType), 0, 0, BAR_METER_NUM_STYLES-1));
+   #endif
+
    #ifdef HAVE_LIBHWLOC
    Panel_add(super, (Object*) CheckItem_newByRef("Show topology when selecting affinity by default", &(settings->topologyAffinity)));
    #endif

--- a/Meter.c
+++ b/Meter.c
@@ -194,7 +194,7 @@ static void BarMeterMode_draw(Meter* this, int x, int y, int w) {
             }
 #ifdef HAVE_LIBNCURSESW
             else if (CRT_utf8 && settings->barType) {
-               if(j==nextOffset-1){
+               if (j == nextOffset - 1) {
                   RichString_setChar(&bar, startPos+nextOffset-1,  currBar[extraWidth]);
                } else {
                   RichString_setChar(&bar, startPos + j, currBar[0]);

--- a/Meter.c
+++ b/Meter.c
@@ -193,7 +193,7 @@ static void BarMeterMode_draw(Meter* this, int x, int y, int w) {
                RichString_setChar(&bar, startPos + j, BarMeterMode_characters[i]);
             }
 #ifdef HAVE_LIBNCURSESW
-            else if(CRT_utf8 && settings->barType) {
+            else if (CRT_utf8 && settings->barType) {
                if(j==nextOffset-1){
                   RichString_setChar(&bar, startPos+nextOffset-1,  currBar[extraWidth]);
                } else {

--- a/Meter.c
+++ b/Meter.c
@@ -195,7 +195,7 @@ static void BarMeterMode_draw(Meter* this, int x, int y, int w) {
 #ifdef HAVE_LIBNCURSESW
             else if (CRT_utf8 && settings->barType) {
                if (j == nextOffset - 1) {
-                  RichString_setChar(&bar, startPos+nextOffset-1,  currBar[extraWidth]);
+                  RichString_setChar(&bar, startPos + nextOffset - 1,  currBar[extraWidth]);
                } else {
                   RichString_setChar(&bar, startPos + j, currBar[0]);
                }

--- a/MeterMode.h
+++ b/MeterMode.h
@@ -26,4 +26,5 @@ typedef unsigned int MeterModeId;
    (1 << LED_METERMODE) |             \
    0) // Avoids edits when updating
 
+#define BAR_METER_NUM_STYLES 7
 #endif

--- a/Settings.c
+++ b/Settings.c
@@ -5,6 +5,7 @@ Released under the GNU GPLv2+, see the COPYING file
 in the source distribution for its full text.
 */
 
+#include "MeterMode.h"
 #include "config.h" // IWYU pragma: keep
 
 #include "Settings.h"
@@ -516,6 +517,13 @@ static bool Settings_read(Settings* this, const char* fileName, const Machine* h
          didReadMeters = true;
       } else if (String_eq(option[0], "hide_function_bar")) {
          this->hideFunctionBar = atoi(option[1]);
+      #ifdef HAVE_LIBNCURSESW
+      } else if (String_eq(option[0], "bar_type")) {
+         long value = strtol(option[1], NULL, 10);
+         if (value < 0 || value > BAR_METER_NUM_STYLES)
+            value = 0;
+         this->barType = (unsigned int)value;
+      #endif
       #ifdef HAVE_LIBHWLOC
       } else if (String_eq(option[0], "topology_affinity")) {
          this->topologyAffinity = !!atoi(option[1]);
@@ -714,6 +722,9 @@ int Settings_write(const Settings* this, bool onCrash) {
    #endif
    printSettingInteger("delay", (int) this->delay);
    printSettingInteger("hide_function_bar", (int) this->hideFunctionBar);
+   #ifdef HAVE_LIBNCURSESW
+   printSettingInteger("bar_type", (int) this->barType);
+   #endif
    #ifdef HAVE_LIBHWLOC
    printSettingInteger("topology_affinity", this->topologyAffinity);
    #endif
@@ -821,6 +832,11 @@ Settings* Settings_new(const Machine* host, Hashtable* dynamicMeters, Hashtable*
    this->showMergedCommand = false;
    this->hideFunctionBar = 0;
    this->headerMargin = true;
+
+   #ifdef HAVE_LIBNCURSESW
+   this->barType = 0;
+   #endif
+
    #ifdef HAVE_LIBHWLOC
    this->topologyAffinity = false;
    #endif

--- a/Settings.h
+++ b/Settings.h
@@ -106,6 +106,9 @@ typedef struct Settings_ {
    bool enableMouse;
    #endif
    int hideFunctionBar;  // 0 - off, 1 - on ESC until next input, 2 - permanently
+   #ifdef HAVE_LIBNCURSESW
+   unsigned int barType;
+   #endif
    #ifdef HAVE_LIBHWLOC
    bool topologyAffinity;
    #endif


### PR DESCRIPTION
Allow bar meters to enable "sub-pixel" rendering.

Bar meter styles can be changed in setup (F2) under Display Options.

Co-Authored-By: Benny Baumann <BenBE@geshi.org>