### PR TITLE
Skip loopback and MD (multi-device) driver entries in /proc/diskstats

### DIFF
--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -667,10 +667,10 @@ bool Platform_getDiskIO(DiskIOData* data) {
       char diskname[32];
       unsigned long long int read_tmp, write_tmp, timeSpend_tmp;
       if (sscanf(lineBuffer, "%*d %*d %31s %*u %*u %llu %*u %*u %*u %llu %*u %*u %llu", diskname, &read_tmp, &write_tmp, &timeSpend_tmp) == 4) {
-         if (String_startsWith(diskname, "dm-"))
-            continue;
-
-         if (String_startsWith(diskname, "zram"))
+         if (String_startsWith(diskname, "dm-") ||
+             String_startsWith(diskname, "loop") ||
+             String_startsWith(diskname, "md") ||
+             String_startsWith(diskname, "zram"))
             continue;
 
          /* only count root disks, e.g. do not count IO from sda and sda1 twice */


### PR DESCRIPTION
Address issues in the Linux DiskIO meter calculations.  Apparently loopback devices can appear in multiple separate diskstats sections which defeats the "root disks" logic.  By good luck we can avoid that problem for loopback if we cull them completely, which we should do as they're not physical devices - treat them like DM and ZRAM (also treat MD driver entries the same way while we are there).

Related to #1800.