### PR TITLE
Change NetworkIOMeter "packets per second" display

### DIFF
--- a/NetworkIOMeter.c
+++ b/NetworkIOMeter.c
@@ -79,7 +79,7 @@ static void NetworkIOMeter_updateValues(Meter* this) {
 
          if (data.packetsReceived > cached_rxp_total) {
             diff = data.packetsReceived - cached_rxp_total;
-            diff = (1000 * diff) / passedTimeInMs; /* convert to pkts/s */
+            diff = (1000 * diff) / passedTimeInMs; /* convert to pkt/s */
             cached_rxp_diff = (uint32_t)diff;
          } else {
             cached_rxp_diff = 0;
@@ -96,7 +96,7 @@ static void NetworkIOMeter_updateValues(Meter* this) {
 
          if (data.packetsTransmitted > cached_txp_total) {
             diff = data.packetsTransmitted - cached_txp_total;
-            diff = (1000 * diff) / passedTimeInMs; /* convert to pkts/s */
+            diff = (1000 * diff) / passedTimeInMs; /* convert to pkt/s */
             cached_txp_diff = (uint32_t)diff;
          } else {
             cached_txp_diff = 0;
@@ -125,7 +125,7 @@ static void NetworkIOMeter_updateValues(Meter* this) {
       return;
    }
 
-   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "rx:%siB/s tx:%siB/s %u/%upkts/s",
+   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "rx:%siB/s tx:%siB/s (%u/%upps)",
       cached_rxb_diff_str, cached_txb_diff_str, cached_rxp_diff, cached_txp_diff);
 }
 
@@ -154,8 +154,13 @@ static void NetworkIOMeter_display(ATTR_UNUSED const Object* cast, RichString* o
    RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], cached_txb_diff_str);
    RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], "iB/s");
 
-   int len = xSnprintf(buffer, sizeof(buffer), " (%u/%u pkts/s) ", cached_rxp_diff, cached_txp_diff);
-   RichString_appendnAscii(out, CRT_colors[METER_TEXT], buffer, len);
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " (");
+   int len = xSnprintf(buffer, sizeof(buffer), "%u", (unsigned int)cached_rxp_diff);
+   RichString_appendnAscii(out, CRT_colors[METER_VALUE_IOREAD], buffer, len);
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], "/");
+   len = xSnprintf(buffer, sizeof(buffer), "%u", (unsigned int)cached_txp_diff);
+   RichString_appendnAscii(out, CRT_colors[METER_VALUE_IOWRITE], buffer, len);
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " pps)");
 }
 
 const MeterClass NetworkIOMeter_class = {


### PR DESCRIPTION
<img width="550" height="129" alt="htop-screenshot-networkio-text-change" src="https://github.com/user-attachments/assets/ca11571f-4442-4b0b-b0bd-12f2dd5f8847" />

I would like @eworm-de to come and discuss about this one.

The lower half of this picture is my proposed change to the NetworkIOMeter. Basically I feel the current "packets per second" display is unintuitive. There is no telling that the number on the left of "/" is RX and the number on the right of "/" is TX. So, I suggest the coloring on the numbers. <s>Also, because the "pkt/s" unit contains a slash, I thought it could be easier to read if I move the text to before the two numbers.</s> (Update: I moved the "pkt/s" unit back to the right after the discussion.)