### PR TITLE
build: Remove duplicate clock_gettime configure check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -403,7 +403,6 @@ fi
 AC_SEARCH_LIBS([clock_gettime], [rt])
 
 AC_CHECK_FUNCS([ \
-   clock_gettime \
    dladdr \
    faccessat \
    fstatat \


### PR DESCRIPTION
A trivial code shrink in configure script.