### PR TITLE
NetBSD: Loop through kernel times rather than calling them one after the other

### DIFF
--- a/netbsd/NetBSDMachine.c
+++ b/netbsd/NetBSDMachine.c
@@ -205,11 +205,9 @@ static void NetBSDMachine_scanCPUTime(NetBSDMachine* this) {
       CPUData* cpu = &this->cpuData[i + 1];
       kernelCPUTimesToHtop(kernelTimes, cpu);
 
-      avg[CP_USER] += cpu->userTime;
-      avg[CP_NICE] += cpu->niceTime;
-      avg[CP_SYS] += cpu->sysTime;
-      avg[CP_INTR] += cpu->intrTime;
-      avg[CP_IDLE] += cpu->idleTime;
+      for (int j = 0; j < CPUSTATES; j++) {
+         avg[j] += kernelTimes[j];
+      }
    }
 
    for (int i = 0; i < CPUSTATES; i++) {


### PR DESCRIPTION
Instead of naming each field we want to set, we simply go through the array (just like how it's done two lines below).

Not too sure if it was done this way on purpose or not, so just in case, here is a PR.