### PR TITLE
Add NetworkIOMeter description

### DIFF
--- a/NetworkIOMeter.c
+++ b/NetworkIOMeter.c
@@ -178,5 +178,6 @@ const MeterClass NetworkIOMeter_class = {
    .attributes = NetworkIOMeter_attributes,
    .name = "NetworkIO",
    .uiName = "Network IO",
+   .description = "Network bytes & packets received/sent per second",
    .caption = "Network: "
 };


### PR DESCRIPTION
This saves user time from looking up what "rx", "tx" and "pps" stand for. :)

By the way, I'm not sure whether I should say "Network IO" or just "Network" in the description.