### PR TITLE
build: Fix '-ffinite-math-only' configure warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -320,7 +320,7 @@ AC_LINK_IFELSE(
          AC_COMPILE_IFELSE(
             [AC_LANG_SOURCE([[
 /* __FINITE_MATH_ONLY__ is documented in Clang. */
-#ifdef __FINITE_MATH_ONLY__
+#if defined(__FINITE_MATH_ONLY__) && __FINITE_MATH_ONLY__
 #error "should not enable -ffinite-math-only"
 #endif
             ]])],


### PR DESCRIPTION
GCC and Clang can predefine `__FINITE_MATH_ONLY__` to 0 when `-fno-finite-math-only` is used. Fix the configure script to avoid a false positive warning.

Regression from b416433fbe7ccf935ad4e268396aa423143c2318