### PR TITLE
Improve the page size retrieval code via sysconf(3)

### DIFF
--- a/linux/LinuxMachine.c
+++ b/linux/LinuxMachine.c
@@ -759,8 +759,10 @@ Machine* Machine_new(UsersTable* usersTable, uid_t userId) {
    Machine_init(super, usersTable, userId);
 
    // Initialize page size
-   if ((this->pageSize = sysconf(_SC_PAGESIZE)) == -1)
+   long pageSize = sysconf(_SC_PAGESIZE);
+   if (pageSize <= 0)
       CRT_fatalError("Cannot get pagesize by sysconf(_SC_PAGESIZE)");
+   this->pageSize = (size_t)pageSize;
    this->pageSizeKB = this->pageSize / ONE_K;
 
    // Initialize clock ticks

--- a/linux/LinuxMachine.h
+++ b/linux/LinuxMachine.h
@@ -8,6 +8,7 @@ in the source distribution for its full text.
 */
 
 #include <stdbool.h>
+#include <stddef.h>
 
 #include "Machine.h"
 #include "linux/ZramStats.h"
@@ -67,8 +68,8 @@ typedef struct LinuxMachine_ {
    Machine super;
 
    long jiffies;
-   int pageSize;
-   int pageSizeKB;
+   size_t pageSize;
+   size_t pageSizeKB;
 
    /* see Linux kernel source for further detail, fs/proc/stat.c */
    unsigned int runningTasks;   /* procs_running from /proc/stat */

--- a/netbsd/NetBSDMachine.c
+++ b/netbsd/NetBSDMachine.c
@@ -118,8 +118,10 @@ Machine* Machine_new(UsersTable* usersTable, uid_t userId) {
       CRT_fatalError("fscale sysctl call failed");
    }
 
-   if ((this->pageSize = sysconf(_SC_PAGESIZE)) == -1)
+   long pageSize = sysconf(_SC_PAGESIZE);
+   if (pageSize <= 0)
       CRT_fatalError("pagesize sysconf call failed");
+   this->pageSize = (size_t)pageSize;
    this->pageSizeKB = this->pageSize / ONE_K;
 
    this->kd = kvm_openfiles(NULL, NULL, NULL, KVM_NO_FILES, errbuf);

--- a/netbsd/NetBSDMachine.h
+++ b/netbsd/NetBSDMachine.h
@@ -12,7 +12,7 @@ in the source distribution for its full text.
 
 #include <kvm.h>
 #include <stdbool.h>
-#include <sys/types.h>
+#include <stddef.h>
 
 #include "Machine.h"
 #include "ProcessTable.h"
@@ -45,8 +45,8 @@ typedef struct NetBSDMachine_ {
    kvm_t* kd;
 
    long fscale;
-   int pageSize;
-   int pageSizeKB;
+   size_t pageSize;
+   size_t pageSizeKB;
 
    CPUData* cpuData;
 } NetBSDMachine;

--- a/openbsd/OpenBSDMachine.c
+++ b/openbsd/OpenBSDMachine.c
@@ -105,8 +105,10 @@ Machine* Machine_new(UsersTable* usersTable, uid_t userId) {
       CRT_fatalError("fscale sysctl call failed");
    }
 
-   if ((this->pageSize = (size_t)sysconf(_SC_PAGESIZE)) == (size_t)-1)
+   long pageSize = sysconf(_SC_PAGESIZE);
+   if (pageSize <= 0)
       CRT_fatalError("pagesize sysconf call failed");
+   this->pageSize = (size_t)pageSize;
    this->pageSizeKB = this->pageSize / ONE_K;
 
    this->kd = kvm_openfiles(NULL, NULL, NULL, KVM_NO_FILES, errbuf);

--- a/openbsd/OpenBSDMachine.h
+++ b/openbsd/OpenBSDMachine.h
@@ -10,7 +10,7 @@ in the source distribution for its full text.
 
 #include <kvm.h>
 #include <stdbool.h>
-#include <sys/types.h>
+#include <stddef.h>
 
 #include "Machine.h"
 

--- a/solaris/SolarisMachine.c
+++ b/solaris/SolarisMachine.c
@@ -305,10 +305,11 @@ Machine* Machine_new(UsersTable* usersTable, uid_t userId) {
 
    Machine_init(super, usersTable, userId);
 
-   this->pageSize = sysconf(_SC_PAGESIZE);
-   if (this->pageSize == -1)
+   long pageSize = sysconf(_SC_PAGESIZE);
+   if (pageSize <= 0)
       CRT_fatalError("Cannot get pagesize by sysconf(_SC_PAGESIZE)");
-   this->pageSizeKB = this->pageSize / 1024;
+   this->pageSize = (size_t)pageSize;
+   this->pageSizeKB = this->pageSize / ONE_K;
 
    this->kd = kstat_open();
    if (!this->kd)

--- a/solaris/SolarisMachine.h
+++ b/solaris/SolarisMachine.h
@@ -10,6 +10,7 @@ in the source distribution for its full text.
 
 #include <kstat.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <sys/param.h>
 #include <sys/resource.h>
@@ -49,8 +50,8 @@ typedef struct SolarisMachine_ {
    kstat_ctl_t* kd;
    CPUData* cpus;
 
-   int pageSize;
-   int pageSizeKB;
+   size_t pageSize;
+   size_t pageSizeKB;
 
    ZfsArcStats zfs;
 } SolarisMachine;


### PR DESCRIPTION
Machine code that retrieves the page size through
`sysconf(_SC_PAGESIZE)` now behaves consistently across platforms. The return values of 0 and negative are now treated as invalid. The `pageSize` members for these Machine objects are now all `size_t` type (the return value type of `sysconf()` is `long`).