### PR TITLE
fix: correct typos in docs and build comment

### DIFF
--- a/Meter.h
+++ b/Meter.h
@@ -78,8 +78,8 @@ typedef struct MeterClass_ {
 
    /* Specifies how the meter is rendered in bar or graph mode:
       true: a percent bar or graph with 'total' representing 100% or maximum.
-      false: the meter has no definite maximum; 'total' repesents initial
-      maximum value while actual maximum is updated automatically. */
+      false: the meter has no definite maximum; 'total' represents initial
+        maximum value while actual maximum is updated automatically. */
    const bool isPercentChart;
 } MeterClass;
 

--- a/configure.ac
+++ b/configure.ac
@@ -1029,7 +1029,7 @@ if test "$enable_unwind" != no; then
    CFLAGS="$AM_CFLAGS $LIBUNWIND_CFLAGS $CFLAGS"
    LIBS="$LIBUNWIND_LIBS $LIBS"
 
-   # unw_init_local() is a macro in HP's implemention of libunwind
+   # unw_init_local() is a macro in HP's implementation of libunwind
    # (the most popular one, Mosberger et al.)
    AC_MSG_CHECKING([whether $LIBUNWIND_LIBS supports local unwinding])
    AC_LINK_IFELSE(


### PR DESCRIPTION
- Meter.h: spell “represents” correctly in the percent chart description so the comment matches the intended meaning.
- configure.ac: fix “implementation” spelling in the libunwind macro note for clearer build guidance.

No functional changes, documentation only.

Author: rezky_nightky <with.rezky@gmail.com>
Timestamp: 2025-12-01T18:29:47Z
Repository: htop
Branch: main
Signing: GPG (989AF9F0)
Performance: 2 files, +3/-3 lines