### PR TITLE
Fix static build crash on startup due to NSS lookup conflict (#1771)

### DIFF
--- a/UsersTable.c
+++ b/UsersTable.c
@@ -31,10 +31,70 @@ void UsersTable_delete(UsersTable* this) {
 
 char* UsersTable_getRef(UsersTable* this, unsigned int uid) {
    char* name = Hashtable_get(this->users, uid);
+
    if (name == NULL) {
-      const struct passwd* userData = getpwuid(uid);
+
+/* ==============================================================
+ * STATIC BUILD PATH (Crash Prevention Logic)
+ * This block is compiled ONLY when --enable-static is detected
+ * by configure.ac, which defines HTOP_STATIC.
+ * ============================================================== */
+#ifdef HTOP_STATIC
+      /* 1. Try resolving standard users with getpwuid (safe range < 65536)
+       * Standard local users are safe to query directly even in static builds.
+       */
+     if (uid < 65536) {
+         const struct passwd* userData = getpwuid(uid);
+         if (userData != NULL) {
+            name = xStrdup(userData->pw_name);
+         }
+      }
+
+      /* 2. If not found (or high UID), try resolving via "getent" command.
+       * This "Out-of-Process" lookup avoids crashing htop by isolating the NSS lookup
+       * from the static binary's memory space. This is critical for Systemd dynamic users.
+       */
+      if (name == NULL) {
+         char command[64];
+         // Construct command: getent passwd <uid>
+         snprintf(command, sizeof(command), "getent passwd %u", uid);
+
+         FILE* fp = popen(command, "r");
+         if (fp) {
+            char buffer[1024];
+            if (fgets(buffer, sizeof(buffer), fp) != NULL) {
+               // getent output format: name:password:uid...
+               // We only need the part before the first colon
+               char* colon = strchr(buffer, ':');
+               if (colon) {
+                  *colon = '\0'; // Truncate string at the first colon
+                  name = xStrdup(buffer);
+               }
+            }
+            pclose(fp);
+         }
+      }
+
+      /* 3. If still not found, fallback to displaying the UID number */
+      if (name == NULL) {
+         char buf[32];
+         xSnprintf(buf, sizeof(buf), "%u", uid);
+         name = xStrdup(buf);
+      }
+
+/* ==============================================================
+ * DYNAMIC BUILD PATH (Standard Logic)
+ * Default behavior for standard dynamic builds. Zero performance overhead.
+ * ============================================================== */
+#else
+     const struct passwd* userData = getpwuid(uid);
       if (userData != NULL) {
          name = xStrdup(userData->pw_name);
+      }
+#endif
+
+      /* Common caching logic for both paths */
+      if (name != NULL) {
          Hashtable_put(this->users, uid, name);
       }
    }

--- a/configure.ac
+++ b/configure.ac
@@ -1552,6 +1552,22 @@ AC_SUBST([AM_CFLAGS])
 AC_SUBST([AM_CPPFLAGS])
 
 # ----------------------------------------------------------------------
+# Static Build Detection (Workaround for Issue #1771)
+# ----------------------------------------------------------------------
+# Check if the user requested a static build via --enable-static.
+# If enabled, we define the 'HTOP_STATIC' macro.
+#
+# This macro triggers the "Out-of-Process" lookup logic in UsersTable.c,
+# which prevents Segmentation Faults caused by Glibc's NSS mechanism trying
+# to dynamically load external libraries (like libnss_systemd.so) in a
+# statically linked binary.
+# ----------------------------------------------------------------------
+if test "x$enable_static" = "xyes"; then
+   AC_DEFINE([HTOP_STATIC], [1], [Define to 1 if building statically to enable NSS crash workaround.])
+   AC_MSG_NOTICE([Static build detected: HTOP_STATIC defined to prevent NSS crashes.])
+fi
+
+# ----------------------------------------------------------------------
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
### Description
This PR fixes the segmentation fault reported in #1771, where statically linked builds (`--enable-static`) crash immediately upon startup in environments containing processes with high UIDs (e.g., Systemd dynamic users).

### The Issue
The crash is caused by Glibc's `getpwuid()` attempting to dynamically load external NSS modules (like `libnss_systemd.so`) to resolve high UIDs. In a static binary, the required dynamic linker context (TLS) is missing, leading to illegal memory access.

### The Fix

1.  **Build System**: Updated `configure.ac` to automatically detect `--enable-static` and define the `HTOP_STATIC` macro.
2.  **Source Code**: Modified `UsersTable.c` to use a safe fallback for static builds:
    * **Standard UIDs (< 65536)**: Continue using `getpwuid` (fast & safe).
    * **High UIDs (> 65536)**: Bypass `getpwuid` and use `popen("getent passwd ...")` to resolve the name via a child process. This isolates the static binary from the NSS crash risk.

### Verification
**Static Build**: Verified on Ubuntu 24.04. The crash is gone, and high-UID users are correctly resolved to their names.

Fixes #1771