### PR TITLE
ci: Bump FreeBSD to 15.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,7 @@ jobs:
         - name: Compile
           uses: vmactions/freebsd-vm@v1
           with:
-            release: '14.3'
+            release: '15.0'
             usesh: true
             prepare: |
               pkg install -y gmake autoconf automake pkgconf git


### PR DESCRIPTION
- Bump FreeBSD version to the latest supported `15.0`

Release notes can be found here: 
- https://www.freebsd.org/releases/15.0R/relnotes/
