### PR TITLE
Fix missing include in CRT.c (sys/stat.h)

### DIFF
--- a/CRT.c
+++ b/CRT.c
@@ -19,6 +19,7 @@ in the source distribution for its full text.
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/stat.h> // IWYU pragma: keep
 
 #include "CommandLine.h"
 #include "ProvideCurses.h"


### PR DESCRIPTION
Include `<sys/stat.h>` for the umask(2) call.
This used to be included indirectly through Compat.h until the commit 3956cff00e89e169e21e733ec1ed01d08d44f5bf that refactored Compat.h.

Build error is reproducible in macOS Tahoe 26.1. (The macOS version provided by GitHub's CI is currently Sequoia 15.7.2 and didn't catch this error.)