### PR TITLE
CRT: make termination signal handler async signal safe

### DIFF
--- a/CRT.c
+++ b/CRT.c
@@ -970,15 +970,16 @@ static void CRT_tryTermExit(void) {
 
    if (!CRT_terminateRequested) {
       return;
-}
-   CRT_terminateRequested = 0;
-   int sgn = (int)CRT_terminateSignal;
+   }
 
+   int sgn = (int)CRT_terminateSignal;
+   signal(SIGINT, SIG_DFL);
+   signal(SIGTERM, SIG_DFL);
+   signal(SIGQUIT, SIG_DFL);
    CRT_done();
 
-   if (!CRT_settings->changed) {
+   if (!CRT_settings->changed)
       _exit(0);
-}
 
    const char* signal_str = strsignal(sgn);
    if (!signal_str)


### PR DESCRIPTION
Move SIGINT/SIGTERM/SIGQUIT handling out of the signal handler to make it
async-signal-safe.

The signal handler now only records the signal via volatile sig_atomic_t flags.
New function for termination logic (CRT_done, warning formatting/output, and _exit(0)) built, and is
performed at a safe point before blocking on getch().

Behavior preserved:
- unchanged settings exit silently
- changed settings emit a warning and exit without persisting htoprc

Built and tested with gcc -fanalyzer; no analyzer unsafe-call warnings remain.

Fixes #1563 