### PR TITLE
Add Quick Start section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,15 @@ More information on required and optional dependencies can be found in [configur
 ## Usage
 See the manual page (`man htop`) or the help menu (**F1** or **h** inside `htop`) for a list of supported key commands.
 
+### Quick Start
+
+Below are a few commonly used actions to get started quickly with htop.
+
+- **Search / filter processes:** press `/`
+- **Sort by CPU or memory:** press `P` (CPU) or `M` (Memory)
+- **Toggle tree view:** press `t`
+- **Kill a process:** select a process and press `F9`
+
 ## Support
 
 If you have trouble running `htop` please consult your operating system / Linux distribution documentation for getting support and filing bugs.


### PR DESCRIPTION
This pull request adds a short "Quick Start" section to the README.

While the README already points users to `man htop` and the built-in help for a complete list of commands, it currently does not provide a short, immediately visible overview of commonly used actions.

The new section is intended to improve onboarding for new users by highlighting a few frequent default actions (e.g. searching, sorting, tree view, killing a process), while explicitly referring to `man htop` as the primary and complete documentation source.

No functional changes are introduced.

Definition of Done (DoD):
- A new "Quick Start" section exists in the README
- The section lists only common default actions and key bindings
- Existing documentation remains unchanged
- No functional or behavioral changes to htop
- `man htop` remains the primary reference for full documentation

Related issue: #1840