### PR TITLE
Async refix

### DIFF
--- a/CRT.h
+++ b/CRT.h
@@ -12,6 +12,7 @@ in the source distribution for its full text.
 #include "Macros.h"
 #include "ProvideCurses.h"
 #include "Settings.h"
+#include "signal.h"
 
 
 #define SCREEN_TAB_MARGIN_LEFT 2
@@ -201,6 +202,10 @@ extern int CRT_scrollHAmount;
 extern int CRT_scrollWheelVAmount;
 
 extern ColorScheme CRT_colorScheme;
+
+extern volatile sig_atomic_t terminate_requested;
+
+extern volatile sig_atomic_t terminate_signal;
 
 #ifdef HAVE_GETMOUSE
 void CRT_setMouse(bool enabled);

--- a/CommandLine.c
+++ b/CommandLine.c
@@ -419,6 +419,11 @@ int CommandLine_run(int argc, char** argv) {
 
    CRT_done();
 
+   if (terminate_requested) {
+      fprintf(stderr, "\nInterrupted by signal %d, terminating.\n", (int)terminate_signal);
+      exit(128 + (int)terminate_signal);
+   }
+
    if (settings->changed) {
 #ifndef NDEBUG
       if (!String_eq(settings->initialFilename, settings->filename))

--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -257,7 +257,7 @@ void ScreenManager_run(ScreenManager* this, Panel** lastFocus, int* lastKey, con
 
    this->name = name;
 
-   while (!quit) {
+   while (!quit && !terminate_requested) {
       if (this->header) {
          checkRecalculation(this, &oldTime, &sortTimeout, &redraw, &rescan, &timedOut, &force_redraw);
       }


### PR DESCRIPTION
Part of #1570: Graceful Signal Handling

This PR implements a graceful shutdown path for non-fatal termination signals, ensuring the terminal state is restored before the process exits.

Key Improvements:
Graceful Lifecycle: Transitions from immediate termination to a flag-based loop break, allowing the program to run its standard cleanup routines (Platform_done, CRT_done).

Double-Tap Safety: If a second termination signal is received during the shutdown phase, the handler invokes _exit() to ensure an immediate emergency stop.

Fatal Signal Integrity: Does not modify fatal signal handling (e.g., SIGSEGV); fatal handlers still take precedence and behave as they did previously.

POSIX Compliance: Returns a standard 128 + signal exit code.

Technical Implementation:
Flagging (CRT.c): The signal handler captures the signal number and sets a volatile sig_atomic_t terminate_requested flag.

Loop Interruption (ScreenManager.c): The main TUI loop checks the flag and breaks immediately upon signal receipt.

Shutdown Path (CommandLine.c): Once the loop exits and cleanup is complete, the program checks if termination was user-requested to print a status message to stderr and exit with the appropriate status.