### PR TITLE
Typographical Fixes

### DIFF
--- a/CommandLine.c
+++ b/CommandLine.c
@@ -426,7 +426,7 @@ int CommandLine_run(int argc, char** argv) {
 #endif /* NDEBUG */
       int r = Settings_write(settings, false);
       if (r < 0)
-         fprintf(stderr, "Can not save configuration to %s: %s\n", settings->filename, strerror(-r));
+         fprintf(stderr, "Cannot save configuration to %s: %s\n", settings->filename, strerror(-r));
    }
 
    Header_delete(header);

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -215,7 +215,7 @@ Thus when you want to use such features you should try to have an alternative av
 
 An example for this are functions like `fstatat` on Linux that extend the kernel API on modern systems.
 But even though it has been around for over a decade you are asked to provide a POSIX alternative like emulating such calls by `fstat` if this is doable.
-If an alternative can not be provided you should gracefully downgrade. That could make a feature that requires this shiny API unavailable on systems that lack support for that API. Make this case visually clear to the user.
+If an alternative cannot be provided you should gracefully downgrade. That could make a feature that requires this shiny API unavailable on systems that lack support for that API. Make this case visually clear to the user.
 
 In general, code written for the project should be able to compile on any C99-compliant compiler.
 

--- a/dragonflybsd/DragonFlyBSDMachine.c
+++ b/dragonflybsd/DragonFlyBSDMachine.c
@@ -233,7 +233,7 @@ static void DragonFlyBSDMachine_scanMemoryInfo(Machine* super) {
    //  user_free (avail to procs)     = buffers + inactive + cache + free
    size_t len = sizeof(super->totalMem);
 
-   //disabled for now, as it is always smaller than phycal amount of memory...
+   //disabled for now, as it is always smaller than physical amount of memory...
    //...to avoid "where is my memory?" questions
    //sysctl(MIB_vm_stats_vm_v_page_count, 4, &(this->totalMem), &len, NULL, 0);
    //this->totalMem *= pageSizeKb;

--- a/freebsd/FreeBSDMachine.c
+++ b/freebsd/FreeBSDMachine.c
@@ -331,7 +331,7 @@ static void FreeBSDMachine_scanMemoryInfo(Machine* super) {
    size_t len;
    struct vmtotal vmtotal;
 
-   //disabled for now, as it is always smaller than phycal amount of memory...
+   //disabled for now, as it is always smaller than physical amount of memory...
    //...to avoid "where is my memory?" questions
    //sysctl(MIB_vm_stats_vm_v_page_count, 4, &(super->totalMem), &len, NULL, 0);
    //super->totalMem *= this->pageSizeKb;

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -138,8 +138,8 @@ void Process_delete(Object* cast) {
 [1] Note that before kernel 2.6.26 a process that has not asked for
 an io priority formally uses "none" as scheduling class, but the
 io scheduler will treat such processes as if it were in the best
-effort class. The priority within the best effort class will  be
-dynamically  derived  from  the  cpu  nice level of the process:
+effort class. The priority within the best effort class will be
+dynamically derived  from  the  cpu  nice level of the process:
 io_priority = (cpu_nice + 20) / 5. -- From ionice(1) man page
 */
 static int LinuxProcess_effectiveIOPriority(const LinuxProcess* this) {

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -1042,19 +1042,19 @@ static int dropCapabilities(enum CapMode mode) {
 
    cap_t caps = cap_init();
    if (caps == NULL) {
-      fprintf(stderr, "Error: can not initialize capabilities: %s\n", strerror(errno));
+      fprintf(stderr, "Error: cannot initialize capabilities: %s\n", strerror(errno));
       return -1;
    }
 
    if (cap_clear(caps) < 0) {
-      fprintf(stderr, "Error: can not clear capabilities: %s\n", strerror(errno));
+      fprintf(stderr, "Error: cannot clear capabilities: %s\n", strerror(errno));
       cap_free(caps);
       return -1;
    }
 
    cap_t currCaps = cap_get_proc();
    if (currCaps == NULL) {
-      fprintf(stderr, "Error: can not get current process capabilities: %s\n", strerror(errno));
+      fprintf(stderr, "Error: cannot get current process capabilities: %s\n", strerror(errno));
       cap_free(caps);
       return -1;
    }
@@ -1065,7 +1065,7 @@ static int dropCapabilities(enum CapMode mode) {
 
       cap_flag_value_t current;
       if (cap_get_flag(currCaps, keepcaps[i], CAP_PERMITTED, &current) < 0) {
-         fprintf(stderr, "Error: can not get current value of capability %d: %s\n", keepcaps[i], strerror(errno));
+         fprintf(stderr, "Error: cannot get current value of capability %d: %s\n", keepcaps[i], strerror(errno));
          cap_free(currCaps);
          cap_free(caps);
          return -1;
@@ -1075,14 +1075,14 @@ static int dropCapabilities(enum CapMode mode) {
          continue;
 
       if (cap_set_flag(caps, CAP_PERMITTED, 1, &keepcaps[i], CAP_SET) < 0) {
-         fprintf(stderr, "Error: can not set permitted capability %d: %s\n", keepcaps[i], strerror(errno));
+         fprintf(stderr, "Error: cannot set permitted capability %d: %s\n", keepcaps[i], strerror(errno));
          cap_free(currCaps);
          cap_free(caps);
          return -1;
       }
 
       if (cap_set_flag(caps, CAP_EFFECTIVE, 1, &keepcaps[i], CAP_SET) < 0) {
-         fprintf(stderr, "Error: can not set effective capability %d: %s\n", keepcaps[i], strerror(errno));
+         fprintf(stderr, "Error: cannot set effective capability %d: %s\n", keepcaps[i], strerror(errno));
          cap_free(currCaps);
          cap_free(caps);
          return -1;
@@ -1090,7 +1090,7 @@ static int dropCapabilities(enum CapMode mode) {
    }
 
    if (cap_set_proc(caps) < 0) {
-      fprintf(stderr, "Error: can not set process capabilities: %s\n", strerror(errno));
+      fprintf(stderr, "Error: cannot set process capabilities: %s\n", strerror(errno));
       cap_free(currCaps);
       cap_free(caps);
       return -1;

--- a/linux/PressureStallMeter.c
+++ b/linux/PressureStallMeter.c
@@ -48,7 +48,7 @@ static void PressureStallMeter_updateValues(Meter* this) {
 
    Platform_getPressureStall(file, some, &this->values[0], &this->values[1], &this->values[2]);
 
-   /* only print bar for ten (not sixty and threehundred), cause the sum is meaningless */
+   /* only print bar for ten (not sixty and three hundred), cause the sum is meaningless */
    this->curItems = 1;
 
    xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%s %s %5.2lf%% %5.2lf%% %5.2lf%%", some ? "some" : "full", file, this->values[0], this->values[1], this->values[2]);

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -12,7 +12,7 @@ in the source distribution for its full text.
 #include <kstat.h>
 
 /* On OmniOS /usr/include/sys/regset.h redefines ERR to 13 - \r, breaking the Enter key.
- * Since ncruses macros use the ERR macro, we can not use another name.
+ * Since ncruses macros use the ERR macro, we cannot use another name.
  */
 #undef ERR
 #include <libproc.h>

--- a/solaris/SolarisProcess.h
+++ b/solaris/SolarisProcess.h
@@ -12,7 +12,7 @@ in the source distribution for its full text.
 #include <sys/proc.h>
 
 /* On OmniOS /usr/include/sys/regset.h redefines ERR to 13 - \r, breaking the Enter key.
- * Since ncruses macros use the ERR macro, we can not use another name.
+ * Since ncruses macros use the ERR macro, we cannot use another name.
  */
 #undef ERR
 #include <libproc.h>


### PR DESCRIPTION
Summary:
- Replace "can not" with "cannot" in user-facing errors, comments, and docs
- Fix minor spelling/spacing typos in comments

AI usage:
- None.


![steepled-hands.png](https://raw.githubusercontent.com/THE-Spellchecker/THE-Website/refs/heads/main/steeple.png)