### PR TITLE
Bugfix: Inappropriate truncate if argv[0] contains a '/'

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -123,6 +123,7 @@ static size_t matchCmdlinePrefixWithExeSuffix(const char* cmdline, size_t* cmdli
     * component of the cmdline relative path, and retry the procedure. */
    size_t cmdlineBaseOffset = *cmdlineBasenameStart;
    bool delimFound = true; /* if valid basename delimiter found */
+   *cmdlineBasenameStart = 0;
    do {
       /* match basename */
       size_t matchLen = exeBaseLen + cmdlineBaseOffset;

--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -1312,7 +1312,7 @@ static bool LinuxProcessTable_readCmdlineFile(Process* process, openat_arg_t pro
 
       /* Detect the last / before the end of the token as
        * the start of the basename in cmdline, see Process_writeCommand */
-      if (((amtRead > 1 && command[0] == '/') || (amtRead > 2 && !strncmp(command, "./", 2))) && argChar == '/' && tokenEnd == (size_t)-1) {
+      if (argChar == '/' && tokenEnd == (size_t)-1) {
          tokenStart = i + 1;
       }
 

--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -1312,7 +1312,7 @@ static bool LinuxProcessTable_readCmdlineFile(Process* process, openat_arg_t pro
 
       /* Detect the last / before the end of the token as
        * the start of the basename in cmdline, see Process_writeCommand */
-      if (argChar == '/' && tokenEnd == (size_t)-1) {
+      if (((amtRead > 1 && command[0] == '/') || (amtRead > 2 && !strncmp(command, "./", 2))) && argChar == '/' && tokenEnd == (size_t)-1) {
          tokenStart = i + 1;
       }
 


### PR DESCRIPTION
This PR aims to fix the bug described in issue #1817.

To start, I want to present a small program that triggers the described issue.
Let's call it `issue1817testfile.c`:

```c
#include <stdio.h>
#include <string.h>
#include <unistd.h>

int main(int argc, char **argv) {
    printf("hit return to modify cmdline\n");
    fgetc(stdin);

    memset(argv[0], 0, strlen(argv[0]));
    strcpy(argv[0], "[xyz 1/2/3]");
    printf("argv changed\n");

    while (1)
        sleep(1);
    return (0);
}
```

The described issue occurs in the code of `LinuxProcessTable.c`:

```c
if (argChar == '/' && tokenEnd == (size_t)-1) {
   tokenStart = i + 1;
}
```

When the option "Show program path" is not enabled, this program is displayed
as `"3]"` in `htop`, instead of showing the full text.

### Problem Explanation

The issue arises because we search for the `/` character to split the command
line, which works fine in most cases. However, the command line in
`/proc/<pid>/cmdline` can have the following formats:

1. **Absolute path**: `/home/foobar/path/to/executable`
2. **Relative path**: `./relative/path/to/executable`
3. **Filename**: `relative/path/to/executable`

The current implementation assumes that encountering a `/` is always a valid
separator for the path. This can cause problems when a program modifies
`argv[0]` , leading to incomplete or truncated commands being
displayed in `htop`.

### Proposed Fix

The most efficient approach is to filter out cases where we deal with absolute
(`/`) or relative (`./`) paths. These are the most common command line formats.
We can treat these as paths that should be split by the `/` character.

For case (3) where no leading `./` is given (e.g., `path/to/executable`),
we can continue outputting the full string, acknowledging that this may occur
rarely. My argument is:
"It's better to show too much information than too little."

Alternatively, we could read the target from the symlink `/proc/<pid>/exe`
and compare it to the content of the first string in `/proc/<pid>/cmdline`:

For example, if `/proc/<pid>/exe` points to `/home/foobar/path/to/exefile`,
we would need to locate `exefile` in the first string of `/proc/<pid>/cmdline`
and set `tokenStart` to that index (if `exefile` is found in the string).

However, this would only solve another special case that practically never
or extremely rarely occurs. Therefore, I have ignored these
type 3 paths ("path/to/executable") for now.

### Edge Cases

There is still a small chance that a program path could sneak into the
output due to unusual cases, but this is rare. It’s important to note that even
with this fix, some edge cases might still result in full path being shown.
Therefore, the goal here is to minimize errors, but we can't guarantee 100%
coverage for all possible edge cases.

But I think my patch results in the displayed paths being more useful to the
user in individual cases than the original code.
