### PR TITLE
Add total seconds to uptime meter

### DIFF
--- a/UptimeMeter.c
+++ b/UptimeMeter.c
@@ -25,6 +25,7 @@ static void UptimeMeter_updateValues(Meter* this) {
       xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "(unknown)");
       return;
    }
+
    int seconds = totalseconds % 60;
    int minutes = (totalseconds / 60) % 60;
    int hours = (totalseconds / 3600) % 24;
@@ -56,5 +57,31 @@ const MeterClass UptimeMeter_class = {
    .attributes = UptimeMeter_attributes,
    .name = "Uptime",
    .uiName = "Uptime",
+   .caption = "Uptime: "
+};
+
+
+static void SecondsUptimeMeter_updateValues(Meter* this) {
+   int totalseconds = Platform_getUptime();
+   if (totalseconds <= 0) {
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "(unknown)");
+      return;
+   }
+   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%d s", totalseconds);
+}
+
+const MeterClass SecondsUptimeMeter_class = {
+   .super = {
+      .extends = Class(Meter),
+      .delete = Meter_delete
+   },
+   .updateValues = SecondsUptimeMeter_updateValues,
+   .defaultMode = TEXT_METERMODE,
+   .supportedModes = (1 << TEXT_METERMODE) | (1 << LED_METERMODE),
+   .maxItems = 0,
+   .total = 0.0,
+   .attributes = UptimeMeter_attributes,
+   .name = "SecondsUptime",
+   .uiName = "Uptime (seconds)",
    .caption = "Uptime: "
 };

--- a/UptimeMeter.h
+++ b/UptimeMeter.h
@@ -11,5 +11,7 @@ in the source distribution for its full text.
 
 
 extern const MeterClass UptimeMeter_class;
+extern const MeterClass SecondsUptimeMeter_class;
+
 
 #endif

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -129,6 +129,7 @@ const MeterClass* const Platform_meterTypes[] = {
    &HostnameMeter_class,
    &SysArchMeter_class,
    &UptimeMeter_class,
+   &SecondsUptimeMeter_class,
    &AllCPUsMeter_class,
    &AllCPUs2Meter_class,
    &AllCPUs4Meter_class,

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -105,6 +105,7 @@ const MeterClass* const Platform_meterTypes[] = {
    &SwapMeter_class,
    &TasksMeter_class,
    &UptimeMeter_class,
+   &SecondsUptimeMeter_class,
    &BatteryMeter_class,
    &HostnameMeter_class,
    &SysArchMeter_class,

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -112,6 +112,7 @@ const MeterClass* const Platform_meterTypes[] = {
    &MemorySwapMeter_class,
    &TasksMeter_class,
    &UptimeMeter_class,
+   &SecondsUptimeMeter_class,
    &BatteryMeter_class,
    &HostnameMeter_class,
    &SysArchMeter_class,

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -222,6 +222,7 @@ const MeterClass* const Platform_meterTypes[] = {
    &HugePageMeter_class,
    &TasksMeter_class,
    &UptimeMeter_class,
+   &SecondsUptimeMeter_class,
    &BatteryMeter_class,
    &HostnameMeter_class,
    &AllCPUsMeter_class,

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -164,6 +164,7 @@ const MeterClass* const Platform_meterTypes[] = {
    &MemorySwapMeter_class,
    &TasksMeter_class,
    &UptimeMeter_class,
+   &SecondsUptimeMeter_class,
    &BatteryMeter_class,
    &HostnameMeter_class,
    &SysArchMeter_class,

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -112,6 +112,7 @@ const MeterClass* const Platform_meterTypes[] = {
    &MemorySwapMeter_class,
    &TasksMeter_class,
    &UptimeMeter_class,
+   &SecondsUptimeMeter_class,
    &BatteryMeter_class,
    &HostnameMeter_class,
    &SysArchMeter_class,

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -91,6 +91,7 @@ const MeterClass* const Platform_meterTypes[] = {
    &MemorySwapMeter_class,
    &TasksMeter_class,
    &UptimeMeter_class,
+   &SecondsUptimeMeter_class,
    &BatteryMeter_class,
    &HostnameMeter_class,
    &AllCPUsMeter_class,

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -116,6 +116,7 @@ const MeterClass* const Platform_meterTypes[] = {
    &HostnameMeter_class,
    &SysArchMeter_class,
    &UptimeMeter_class,
+   &SecondsUptimeMeter_class,
    &AllCPUsMeter_class,
    &AllCPUs2Meter_class,
    &AllCPUs4Meter_class,

--- a/unsupported/Platform.c
+++ b/unsupported/Platform.c
@@ -59,6 +59,7 @@ const MeterClass* const Platform_meterTypes[] = {
    &HostnameMeter_class,
    &SysArchMeter_class,
    &UptimeMeter_class,
+   &SecondsUptimeMeter_class,
    &AllCPUsMeter_class,
    &AllCPUs2Meter_class,
    &AllCPUs4Meter_class,


### PR DESCRIPTION
This will add a total seconds count appended to the uptime counter. This would help me (and others) for viewing the live system uptime in seconds, as it is used for the kernel logs and other internal counters. Thank you for your time and consideration.

Preview below:
<img width="217" height="29" alt="image" src="https://github.com/user-attachments/assets/d82ffaed-850c-41f9-a978-8330f7f2b342" />
