### PR TITLE
improve htop bootup time by caching all getpwuid result

### DIFF
--- a/UsersTable.c
+++ b/UsersTable.c
@@ -35,8 +35,13 @@ char* UsersTable_getRef(UsersTable* this, unsigned int uid) {
       const struct passwd* userData = getpwuid(uid);
       if (userData != NULL) {
          name = xStrdup(userData->pw_name);
-         Hashtable_put(this->users, uid, name);
+      } else {
+         name = xStrdup("");
       }
+      Hashtable_put(this->users, uid, name);
+   }
+   if (!name || !*name) {
+      return NULL;
    }
    return name;
 }


### PR DESCRIPTION
This PR aims to reduce htop bootup time that I encountered while using htop in GCP with oslogin enabled

<details><summary>Details about how I encountered black screen when using htop</summary>
<p>

When running htop in debian 12 in my GCP oslogin enabled instance, it would just black screen and does nothing
Here's the package versions that's installed on my debian 12:

| APT Package Name | APT Package Version |
|--------|--------|
| `google-compute-engine-oslogin` | `1:20240415.00-g1+deb12` |
| `htop` | `3.2.2-2` |

After some debugging I have found that the old oslogin software that's installed would retry 3 times with 1 second interval on 400 status code
I am able to verify that running `time getent passwd 999` also returns after 3 seconds too
Upgrading `google-compute-engine-oslogin` to `1:20240701.00-g1+deb12` fixes the issue where it would wait and retry 3 times
The fixes is introduced by this PR: https://github.com/GoogleCloudPlatform/guest-oslogin/pull/137

Even with the fixed oslogin software, htop still takes some considerable amount of time to open in version `3.2.2`
After some debugging I have found that htop is calling `getpwuid` 442 times, and on each NSS lookup oslogin would make an http request to resolve the username
Here's the time it took to render around 1 frame (`3.2.2` does not have the -n1 options):
```
real    0m5.317s
user    0m0.138s
sys     0m0.178s
```

At some point I tried to use the latest commit of htop to test and found out that the `getpwuid` call reduced from 442 times to 2 times
Here's the time it took to render 1 frame on version `htop 3.5.0-dev-3.4.1-265-g70f873e`:
```
real    0m0.096s
user    0m0.019s
sys     0m0.059s
```

While it's significantly faster due to I presume calling `getpwuid` on each process instead of each threads, it still does redundant calls based on the `strace` that I have:
```
02:44:54.591145 sendto(7, "GET /computeMetadata/v1/oslogin/users?uid=999 HTTP/1.1\r\nHost: 169.254.169.254\r\nAccept: */*\r\nMetadata-Flavor: Google\r\n\r\n", 119, MSG_NOSIGNAL, NULL, 0) = 119
02:44:54.610795 recvfrom(7, "HTTP/1.1 400 Bad Request\r\nMetadata-Flavor: Google\r\nDate: Fri, 23 Jan 2026 02:44:54 GMT\r\nContent-Type: text/html\r\nServer: Metadata Server for VM\r\nContent-Length: 198\r\nX-XSS-Protection: 0\r\nX-Frame-Options: SAMEORIGIN\r\n\r\ncom.google.cloud.oslogin.exceptions.OsLoginRpcException: <eye3 title='INVALID_ARGUMENT'/> generic::INVALID_ARGUMENT: [ReqId=6490524661870.53CC292.D700D9D6] Error Details: UID is not POSIX compliant.", 16384, 0, NULL, NULL) = 416
02:44:55.012879 sendto(7, "GET /computeMetadata/v1/oslogin/users?uid=999 HTTP/1.1\r\nHost: 169.254.169.254\r\nAccept: */*\r\nMetadata-Flavor: Google\r\n\r\n", 119, MSG_NOSIGNAL, NULL, 0) = 119
02:44:55.019667 recvfrom(7, "HTTP/1.1 400 Bad Request\r\nMetadata-Flavor: Google\r\nDate: Fri, 23 Jan 2026 02:44:55 GMT\r\nContent-Type: text/html\r\nServer: Metadata Server for VM\r\nContent-Length: 198\r\nX-XSS-Protection: 0\r\nX-Frame-Options: SAMEORIGIN\r\n\r\ncom.google.cloud.oslogin.exceptions.OsLoginRpcException: <eye3 title='INVALID_ARGUMENT'/> generic::INVALID_ARGUMENT: [ReqId=64905246C7685.8E94314.372A4AF5] Error Details: UID is not POSIX compliant.", 16384, 0, NULL, NULL) = 416
```
As you can see, `getpwuid` is being called with the same uid, and the reason it's being called 2 times is because I have 2 mongo docker that's running with `999` uid
</p>
</details>

In a specific scenario where a lot of processes with uid that's doesn't resolve to a name can cause long startup time when using htop
The following steps can validate that statement:
1. Create a debian 12 instance in GCP with oslogin enabled (oslogin should be on latest version already)
2. Install docker, custom htop built from main, and strace
3. Run `sudo docker run --rm -it --user 999 ubuntu`
4. Inside docker, run `for i in {1..1000}; do sleep 60 & done`
5. In another terminal run `sudo strace -tt -o htop.txt -s 4096 ./htop -n1`
6. Run `cat htop.txt | grep 'GET /' -c` in order to get the amount of http call being used for NSS lookup by oslogin:
```
1003
```
7. Run `time ./htop -n1` in order to measure the time taken to render 1 frame:
```
real    0m10.180s
user    0m0.259s
sys     0m0.342s
```

As you can see, `getpwuid` is being called 1003 times and each time NSS lookup is being done which took 10 seconds to render 1 frame

Here's my proposed changes:
- Saves any NULL pointer as empty string
- If the returning string is empty, return NULL pointer

Here's the same test being run on the patched htop:
- `sudo strace -tt -o htop.txt -s 4096 ./htop-patched -n1 ; cat htop.txt | grep 'GET /' -c`
```
1
```
- `time ./htop-patched -n1`
```
real    0m0.204s
user    0m0.071s
sys     0m0.127s
```
This patch also somewhat mitigate bad NSS lookup implementation too since it reduces the amount of calls to `getpwuid` which might take awhile to return on unexpected input