### PR TITLE
Add Tctl temperature reading

### DIFF
--- a/linux/LibSensors.c
+++ b/linux/LibSensors.c
@@ -368,6 +368,17 @@ void LibSensors_getCPUTemperatures(CPUData* cpus, unsigned int existingCPUs, uns
                   }
                }
                ccdID++;
+            }
+
+            /* AMD k10temp with only one general Tctl */
+            else if (String_eq(label, "Tctl")) {
+               for (size_t i = 0; i <= existingCPUs; i++) {
+                  if (isNaN(data[i])) {
+                     data[i] = temp;
+                     if (i > 0)
+                        coreTempCount++;
+                  }
+               }
             } else {
                skip = false;
             }


### PR DESCRIPTION
For AMD k10temp, when Tccd is not present, we only have a Tctl value:

```
k10temp-pci-00c3
Adapter: PCI adapter
Tctl:         +39.1°C
```

I populate only `data[1]`, htop's existing fallback logic will copy this temperature to all individual cores.

Fixes #1776
