### PR TITLE
Don't let '--no-color' affect htoprc

### DIFF
--- a/CRT.c
+++ b/CRT.c
@@ -1192,8 +1192,6 @@ void CRT_init(const Settings* settings, bool allowUnicode, bool retainScreenOnEx
    redirectStderr();
    noecho();
    CRT_settings = settings;
-   CRT_colors = CRT_colorSchemes[settings->colorScheme];
-   CRT_colorScheme = settings->colorScheme;
 
    for (int i = 0; i < LAST_COLORELEMENT; i++) {
       unsigned int color = CRT_colorSchemes[COLORSCHEME_DEFAULT][i];
@@ -1260,9 +1258,8 @@ IGNORE_WCASTQUAL_END
    CRT_installSignalHandlers();
 
    use_default_colors();
-   if (!has_colors())
-      CRT_colorScheme = COLORSCHEME_MONOCHROME;
-   CRT_setColors(CRT_colorScheme);
+
+   CRT_setColors(has_colors() ? settings->colorScheme : COLORSCHEME_MONOCHROME);
 
 #ifdef HAVE_LIBNCURSESW
    if (allowUnicode && String_eq(nl_langinfo(CODESET), "UTF-8")) {

--- a/ColorsPanel.c
+++ b/ColorsPanel.c
@@ -104,6 +104,6 @@ ColorsPanel* ColorsPanel_new(Settings* settings) {
    for (int i = 0; ColorSchemeNames[i] != NULL; i++) {
       Panel_add(super, (Object*) CheckItem_newByVal(ColorSchemeNames[i], false));
    }
-   CheckItem_set((CheckItem*)Panel_get(super, settings->colorScheme), true);
+   CheckItem_set((CheckItem*)Panel_get(super, (int)CRT_colorScheme), true);
    return this;
 }

--- a/CommandLine.c
+++ b/CommandLine.c
@@ -357,6 +357,8 @@ int CommandLine_run(int argc, char** argv) {
    Header* header = Header_new(host, 2);
    Header_populateFromSettings(header);
 
+   int colorSchemeFromConfig = settings->colorScheme;
+
    if (flags.delay != -1)
       settings->delay = flags.delay;
    if (!flags.useColors)
@@ -384,6 +386,12 @@ int CommandLine_run(int argc, char** argv) {
 
    host->iterationsRemaining = flags.iterationsRemaining;
    CRT_init(settings, flags.allowUnicode, flags.iterationsRemaining != -1);
+
+   // Do not save the color scheme override to 'htoprc'.
+   // 'settings' will keep the original color scheme until the user
+   // changes it in the Setup.
+   // ('CRT_colorScheme' holds the current, active color scheme.)
+   settings->colorScheme = colorSchemeFromConfig;
 
    MainPanel* panel = MainPanel_new();
    Machine_setTablesPanel(host, (Panel*) panel);


### PR DESCRIPTION
Delay the color scheme override by '--no-color' option to after the CRT_init call and don't make it change the 'settings' object.

Also included in this patch is a minor simplification of CRT_init() code.

(Related to #1876)