### PR TITLE
Fix function bar labels in Screens panel rename mode

### DIFF
--- a/CommandLine.c
+++ b/CommandLine.c
@@ -37,6 +37,8 @@ in the source distribution for its full text.
 #include "Process.h"
 #include "ProcessTable.h"
 #include "ScreenManager.h"
+#include "ScreensPanel.h"
+#include "ScreenTabsPanel.h"
 #include "Settings.h"
 #include "Table.h"
 #include "UsersTable.h"
@@ -450,6 +452,8 @@ int CommandLine_run(int argc, char** argv) {
 
    ScreenManager_delete(scr);
    MetersPanel_cleanup();
+   ScreensPanel_cleanup();
+   ScreenTabsPanel_cleanup();
 
    UsersTable_delete(ut);
 

--- a/ScreenTabsPanel.c
+++ b/ScreenTabsPanel.c
@@ -171,6 +171,15 @@ ScreenNameListItem* ScreenNameListItem_new(const char* value, ScreenSettings* ss
 }
 
 static const char* const ScreenNamesFunctions[] = {"      ", "      ", "      ", "      ", "New   ", "      ", "      ", "      ", "      ", "Done  ", NULL};
+static const char* const ScreenNamesRenamingFunctions[] = {"Cancel", "Done  ", "      ", "      ", "      ", "      ", "      ", "      ", "      ", "      ", NULL};
+static FunctionBar* ScreenNames_renamingBar = NULL;
+
+void ScreenTabsPanel_cleanup(void) {
+   if (ScreenNames_renamingBar) {
+      FunctionBar_delete(ScreenNames_renamingBar);
+      ScreenNames_renamingBar = NULL;
+   }
+}
 
 static void ScreenNamesPanel_delete(Object* object) {
    ScreenNamesPanel* this = (ScreenNamesPanel*) object;
@@ -228,7 +237,8 @@ static HandlerResult ScreenNamesPanel_eventHandlerRenaming(Panel* super, int ch)
          break;
       case '\n':
       case '\r':
-      case KEY_ENTER: {
+      case KEY_ENTER:
+      case KEY_F(2): {
          ListItem* item = (ListItem*) Panel_getSelected(super);
          if (!item)
             break;
@@ -238,10 +248,12 @@ static HandlerResult ScreenNamesPanel_eventHandlerRenaming(Panel* super, int ch)
          this->renamingItem = NULL;
          super->cursorOn = false;
          Panel_setSelectionColor(super, PANEL_SELECTION_FOCUS);
+         Panel_setDefaultBar(super);
          renameScreenSettings(this, item);
          break;
       }
-      case 27: { // Esc
+      case 27: // Esc
+      case KEY_F(1): {
          ListItem* item = (ListItem*) Panel_getSelected(super);
          if (!item)
             break;
@@ -250,6 +262,7 @@ static HandlerResult ScreenNamesPanel_eventHandlerRenaming(Panel* super, int ch)
          this->renamingItem = NULL;
          super->cursorOn = false;
          Panel_setSelectionColor(super, PANEL_SELECTION_FOCUS);
+         Panel_setDefaultBar(super);
          break;
       }
    }
@@ -275,6 +288,7 @@ static void startRenaming(Panel* super) {
    Panel_setSelectionColor(super, PANEL_EDIT);
    super->selectedLen = strlen(this->buffer);
    Panel_setCursorToSelection(super);
+   super->currentBar = ScreenNames_renamingBar;
 }
 
 static void addNewScreen(Panel* super, DynamicScreen* ds) {
@@ -352,6 +366,9 @@ ScreenNamesPanel* ScreenNamesPanel_new(Settings* settings) {
    Panel* super = &this->super;
 
    FunctionBar* fuBar = FunctionBar_new(ScreenNamesFunctions, NULL, NULL);
+   if (!ScreenNames_renamingBar) {
+      ScreenNames_renamingBar = FunctionBar_new(ScreenNamesRenamingFunctions, NULL, NULL);
+   }
    Panel_init(super, 1, 1, 1, 1, Class(ListItem), true, fuBar);
 
    this->settings = settings;

--- a/ScreenTabsPanel.h
+++ b/ScreenTabsPanel.h
@@ -58,4 +58,6 @@ extern PanelClass ScreenNamesPanel_class;
 
 ScreenNamesPanel* ScreenNamesPanel_new(Settings* settings);
 
+void ScreenTabsPanel_cleanup(void);
+
 #endif

--- a/ScreensPanel.h
+++ b/ScreensPanel.h
@@ -52,4 +52,6 @@ ScreensPanel* ScreensPanel_new(Settings* settings);
 
 void ScreensPanel_update(Panel* super);
 
+void ScreensPanel_cleanup(void);
+
 #endif


### PR DESCRIPTION
When entering rename mode in the Screens setup (F2 Setup > Screens), the function bar now displays appropriate labels:
- F1: Cancel (cancels rename, restores original name)
- F2: Done (confirms rename)
- F3-F10: blank

Previously, the function bar showed stale labels from normal mode (New, MoveUp, MoveDn, Remove, Done) which were non-functional and confusing during rename.

Visual summary

```
Normal mode:
F1       F2       F3       F4       F5       F6       F7       F8      F9       F10
          Rename	           New               MvUp  MvDn  Rm     Done
Rename mode:
F1       F2       F3       F4       F5       F6       F7       F8       F9       F10
Cancel   Done
```

Fixes #1882