### PR TITLE
Fix regression on inappropriately truncated command name

### DIFF
--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -1336,11 +1336,6 @@ static bool LinuxProcessTable_readCmdlineFile(Process* process, openat_arg_t pro
    bool argSepSpace = false;
 
    for (size_t i = 0; i < (size_t)amtRead; i++) {
-      // If this is true, there's a NUL byte in the middle of command
-      if (tokenEnd != (size_t)-1) {
-         argSepNUL = true;
-      }
-
       const char argChar = command[i];
 
       /* newline used as delimiter - when forming the mergedCommand, newline is
@@ -1360,6 +1355,11 @@ static bool LinuxProcessTable_readCmdlineFile(Process* process, openat_arg_t pro
          }
 
          continue;
+      }
+
+      // If this is true, there's a NUL byte in the middle of command
+      if (tokenEnd != (size_t)-1) {
+         argSepNUL = true;
       }
 
       /* Record some information for the argument parsing heuristic below. */


### PR DESCRIPTION
As mentioned in #1817, in `LinuxProcessTable_readCmdlineFile()`, `argSepNUL` is being set if **any** character is found after the first NUL, which is incorrect.

This pull request changes the behavior to only set the flag when a non-NUL character is found after the first NUL.

Tested on Debian trixie. Both problematic processes mentioned in the issue are now displayed correctly.

Fixes: #1817