### PR TITLE
cmdline: use strtoul() for safety check on overflow username arg

### DIFF
--- a/CommandLine.c
+++ b/CommandLine.c
@@ -225,7 +225,7 @@ static CommandLineStatus parseArguments(int argc, char** argv, CommandLineSettin
             if (!username) {
                flags->userId = geteuid();
             } else if (!Action_setUserOnly(username, &(flags->userId))) {
-               char* endptr;
+               const char* endptr;
                errno = 0;
                unsigned long val = strtoul(username, &endptr, 10);
                if (errno == ERANGE || *endptr != '\0' || username == endptr || val > UINT_MAX) {


### PR DESCRIPTION
References:
- https://stackoverflow.com/a/3792686