### PR TITLE
panel: reuse single rich str instead two alloc rich str

### DIFF
--- a/Panel.c
+++ b/Panel.c
@@ -277,11 +277,13 @@ void Panel_draw(Panel* this, bool force_redraw, bool focus, bool highlightSelect
       ? CRT_colors[this->selectionColorId]
       : CRT_colors[PANEL_SELECTION_UNFOCUS];
 
+   RichString_begin(item);
    if (this->needsRedraw || force_redraw) {
       int line = 0;
       for (int i = first; line < h && i < upTo; i++) {
          const Object* itemObj = Vector_get(this->items, i);
-         RichString_begin(item);
+         RichString_rewind(&item, RichString_size(&item));
+         item.highlightAttr = 0;
          Object_display(itemObj, &item);
          int itemLen = RichString_sizeVal(item);
          int amt = MINIMUM(itemLen - scrollH, this->w);
@@ -298,7 +300,6 @@ void Panel_draw(Panel* this, bool force_redraw, bool focus, bool highlightSelect
             RichString_printoffnVal(item, y + line, x, scrollH, amt);
          if (item.highlightAttr)
             attrset(CRT_colors[RESET_COLOR]);
-         RichString_delete(&item);
          line++;
       }
       while (line < h) {
@@ -308,28 +309,29 @@ void Panel_draw(Panel* this, bool force_redraw, bool focus, bool highlightSelect
 
    } else {
       const Object* oldObj = Vector_get(this->items, this->oldSelected);
-      RichString_begin(old);
-      Object_display(oldObj, &old);
-      int oldLen = RichString_sizeVal(old);
-      const Object* newObj = Vector_get(this->items, this->selected);
-      RichString_begin(new);
-      Object_display(newObj, &new);
-      int newLen = RichString_sizeVal(new);
-      this->selectedLen = newLen;
+      RichString_rewind(&item, RichString_size(&item));
+      Object_display(oldObj, &item);
+      int oldLen = RichString_sizeVal(item);
       mvhline(y + this->oldSelected - first, x + 0, ' ', this->w);
       if (scrollH < oldLen)
-         RichString_printoffnVal(old, y + this->oldSelected - first, x,
+         RichString_printoffnVal(item, y + this->oldSelected - first, x,
             scrollH, MINIMUM(oldLen - scrollH, this->w));
+
+      const Object* newObj = Vector_get(this->items, this->selected);
+      RichString_rewind(&item, RichString_size(&item));
+      item.highlightAttr = 0;
+      Object_display(newObj, &item);
+      int newLen = RichString_sizeVal(item);
+      this->selectedLen = newLen;
       attrset(selectionColor);
       mvhline(y + this->selected - first, x + 0, ' ', this->w);
-      RichString_setAttr(&new, selectionColor);
+      RichString_setAttr(&item, selectionColor);
       if (scrollH < newLen)
-         RichString_printoffnVal(new, y + this->selected - first, x,
+         RichString_printoffnVal(item, y + this->selected - first, x,
             scrollH, MINIMUM(newLen - scrollH, this->w));
       attrset(CRT_colors[RESET_COLOR]);
-      RichString_delete(&new);
-      RichString_delete(&old);
    }
+   RichString_delete(&item);
 
    if (focus && (this->needsRedraw || force_redraw || !this->wasFocus)) {
       if (Panel_drawFunctionBarFn(this))


### PR DESCRIPTION
Reallocation rich string inside body for loop may be impractical with freeing inside, same applies to new and old rich strings, it would be more logical to use one object and reuse it to save memory