### PR TITLE
pcp/*/*: add defined(x) guards for derived metrics from optional PMDAs

### DIFF
--- a/pcp/columns/tcp
+++ b/pcp/columns/tcp
@@ -6,26 +6,26 @@
 heading = TCPS
 caption = TCP_SEND
 width = 6
-metric = bpf.proc.net.tcp.send.packets
+metric = defined(bpf.proc.net.tcp.send.packets) ? bpf.proc.net.tcp.send.packets : novalue()
 description = Count of TCP packets sent
 
 [tcp_send_bytes]
 heading = TCPSB
 caption = TCP_SEND_BYTES
 width = 6
-metric = bpf.proc.net.tcp.send.bytes
+metric = defined(bpf.proc.net.tcp.send.bytes) ? bpf.proc.net.tcp.send.bytes : novalue()
 description = Cumulative bytes sent via TCP
 
 [tcp_recv_packets]
 heading = TCPR
 caption = TCP_RECV
 width = 6
-metric = bpf.proc.net.tcp.recv.packets
+metric = defined(bpf.proc.net.tcp.recv.packets) ? bpf.proc.net.tcp.recv.packets : novalue()
 description = Count of TCP packets received
 
 [tcp_recv_bytes]
 heading = TCPRB
 caption = TCP_RECV_BYTES
 width = 6
-metric = bpf.proc.net.tcp.recv.bytes
+metric = defined(bpf.proc.net.tcp.recv.bytes) ? bpf.proc.net.tcp.recv.bytes : novalue()
 description = Cumulative bytes received via TCP

--- a/pcp/columns/udp
+++ b/pcp/columns/udp
@@ -6,26 +6,26 @@
 heading = UDPS
 caption = UDP_SEND
 width = 6
-metric = bpf.proc.net.udp.send.packets
+metric = defined(bpf.proc.net.udp.send.packets) ? bpf.proc.net.udp.send.packets : novalue()
 description = Count of UDP packets sent
 
 [udp_send_bytes]
 heading = UDPSB
 caption = UDP_SEND_BYTES
 width = 6
-metric = bpf.proc.net.udp.send.bytes
+metric = defined(bpf.proc.net.udp.send.bytes) ? bpf.proc.net.udp.send.bytes : novalue()
 description = Cumulative bytes sent via UDP
 
 [udp_recv_packets]
 heading = UDPR
 caption = UDP_RECV
 width = 6
-metric = bpf.proc.net.udp.recv.packets
+metric = defined(bpf.proc.net.udp.recv.packets) ? bpf.proc.net.udp.recv.packets : novalue()
 description = Count of UDP packets received
 
 [udp_recv_bytes]
 heading = UDPRB
 caption = UDP_RECV_BYTES
 width = 6
-metric = bpf.proc.net.udp.recv.bytes
+metric = defined(bpf.proc.net.udp.recv.bytes) ? bpf.proc.net.udp.recv.bytes : novalue()
 description = Cumulative bytes received via UDP

--- a/pcp/meters/gpu
+++ b/pcp/meters/gpu
@@ -5,38 +5,38 @@
 [amd_gpu_load]
 caption = AMD GPU load
 description = AMD GPU load
-load.metric = amdgpu.gpu.load
+load.metric = defined(amdgpu.gpu.load) ? amdgpu.gpu.load : novalue()
 load.suffix = %
 
 [amd_gpu_average_power]
 caption = AMD GPU average power
 description = AMD GPU average power in Watts
-average_power.metric = amdgpu.gpu.average_power
+average_power.metric = defined(amdgpu.gpu.average_power) ? amdgpu.gpu.average_power : novalue()
 average_power.suffix = W
 
 [amd_gpu_memory]
 type = bar
 caption = AMD GPU memory
 description = Allocated frame buffer memory
-used.metric = amdgpu.memory.used
+used.metric = defined(amdgpu.memory.used) ? amdgpu.memory.used : novalue()
 used.color = red
-total.metric = amdgpu.memory.total
+total.metric = defined(amdgpu.memory.total) ? amdgpu.memory.total : novalue()
 total.color: blue
 
 [amd_gpu_clock]
 caption = AMD GPU clock
 description = The GPU clock speed in MHz
-clock.metric = amdgpu.gpu.clock
+clock.metric = defined(amdgpu.gpu.clock) ? amdgpu.gpu.clock : novalue()
 clock.label = MHz
 
 [amd_gpu_memory_clock]
 caption = AMD GPU memory clock
 description = The GDDRx memory clock speed in MHz
-clock.metric = amdgpu.memory.clock
+clock.metric = defined(amdgpu.memory.clock) ? amdgpu.memory.clock : novalue()
 clock.label = MHz
 
 [amd_gpu_temp]
 caption = AMD GPU temperature
 description = The GPU temperature in degrees Celsius
-temp.metric = amdgpu.gpu.temperature / 1000
+temp.metric = defined(amdgpu.gpu.temperature) ? amdgpu.gpu.temperature / 1000  : novalue()
 temp.label = °C

--- a/pcp/meters/memcache
+++ b/pcp/meters/memcache
@@ -5,7 +5,7 @@
 [memcache]
 caption = Memcache
 description = Memcache Hits
-hit.metric = sum(memcache.hits)
+hit.metric = defined(memcache.hits) ? sum(memcache.hits) : novalue()
 hit.color = green
-miss.metric = sum(memcache.misses)
+miss.metric = defined(memcache.misses) ? sum(memcache.misses) : novalue()
 miss.color = blue

--- a/pcp/meters/mysql
+++ b/pcp/meters/mysql
@@ -5,68 +5,68 @@
 [mysql_io]
 caption = MySQL I/O
 description = MySQL throughput
-recv.metric = mysql.status.bytes_received
+recv.metric = defined(mysql.status.bytes_received) ? mysql.status.bytes_received : novalue()
 recv.color = green
-sent.metric = mysql.status.bytes_sent
+sent.metric = defined(mysql.status.bytes_sent) ? mysql.status.bytes_sent : novalue()
 sent.color = blue
 
 [mysql_keys]
 caption = MySQL keys
 description = MySQL key status
-key_blocks_used.metric = mysql.status.key_blocks_used
+key_blocks_used.metric = defined(mysql.status.key_blocks_used) ? mysql.status.key_blocks_used : novalue()
 key_blocks_used.color = yellow
 key_blocks_used.label = used
-key_reads.metric = mysql.status.key_reads
+key_reads.metric = defined(mysql.status.key_reads) ? mysql.status.key_reads : novalue()
 key_reads.label = read
 key_reads.color = green
-key_writes.metric = mysql.status.key_writes
+key_writes.metric = defined(mysql.status.key_writes) ? mysql.status.key_writes : novalue()
 key_writes.label = writ
 key_writes.color = blue
-key_read_requests.metric = mysql.status.key_read_requests
+key_read_requests.metric = defined(mysql.status.key_read_requests) ? mysql.status.key_read_requests : novalue()
 key_read_requests.label = rreq
 key_read_requests.color = green
-key_write_requests.metric = mysql.status.key_write_requests
+key_write_requests.metric = defined(mysql.status.key_write_requests) ? mysql.status.key_write_requests : novalue()
 key_write_requests.label = wreq
 key_write_requests.color = blue
 
 [innodb_buffer]
 caption = InnoDB pool
 description = InnoDB buffer pool
-created.metric = mysql.status.innodb_pages_created
+created.metric = defined(mysql.status.innodb_pages_created) ? mysql.status.innodb_pages_created : novalue()
 created.label = cr
 created.color = yellow
-read.metric = mysql.status.innodb_pages_read
+read.metric = defined(mysql.status.innodb_pages_read) ? mysql.status.innodb_pages_read : novalue()
 read.label = rd
 read.color = green
-written.metric = mysql.status.innodb_pages_written
+written.metric = defined(mysql.status.innodb_pages_written) ? mysql.status.innodb_pages_written : novalue()
 written.label = wr
 written.color = red
 
 [innodb_io]
 caption = InnoDB I/O
 description = InnoDB I/O operations
-read.metric = mysql.status.innodb_data_read
+read.metric = defined(mysql.status.innodb_data_read) ? mysql.status.innodb_data_read : novalue()
 read.label = rd
 read.color = green
-written.metric = mysql.status.innodb_data.writes
+written.metric = defined(mysql.status.innodb_data.writes) ? mysql.status.innodb_data.writes : novalue()
 written.label = wr
 written.color = blue
-sync.metric = mysql.status.innodb_data_fsyncs
+sync.metric = defined(mysql.status.innodb_data_fsyncs) ? mysql.status.innodb_data_fsyncs : novalue()
 sync.label = sync
 sync.color = cyan
 
 [innodb_ops]
 caption = InnoDB ops
 description = InnoDB operations
-inserted.metric = mysql.status.innodb_rows_inserted
+inserted.metric = defined(mysql.status.innodb_rows_inserted) ? mysql.status.innodb_rows_inserted : novalue()
 inserted.label = ins
 inserted.color = blue
-updated.metric = mysql.status.innodb_rows_updated
+updated.metric = defined(mysql.status.innodb_rows_updated) ? mysql.status.innodb_rows_updated : novalue()
 updated.label = upd
 updated.color = cyan
-deleted.metric = mysql.status.innodb_rows_deleted
+deleted.metric = defined(mysql.status.innodb_rows_deleted) ? mysql.status.innodb_rows_deleted : novalue()
 deleted.label = del
 deleted.color = red
-read.metric = mysql.status.innodb_rows_read
+read.metric = defined(mysql.status.innodb_rows_read) ? mysql.status.innodb_rows_read : novalue()
 read.label = rd
 read.color = green

--- a/pcp/meters/postfix
+++ b/pcp/meters/postfix
@@ -4,17 +4,17 @@
 
 [postfix]
 caption = Postfix
-incoming.metric = sum(postfix.queues.incoming)
+incoming.metric = defined(postfix.queues.incoming) ? sum(postfix.queues.incoming) : novalue()
 incoming.color = green
 incoming.label = in
-active.metric = sum(postfix.queues.active)
+active.metric = defined(postfix.queues.active) ? sum(postfix.queues.active) : novalue()
 active.color = blue
 active.label = act
-deferred.metric = sum(postfix.queues.deferred)
+deferred.metric = defined(postfix.queues.deferred) ? sum(postfix.queues.deferred) : novalue()
 deferred.color = cyan
 deferred.label = dfr
-bounce.metric = sum(postfix.queues.maildrop)
+bounce.metric = defined(postfix.queues.maildrop) ? sum(postfix.queues.maildrop) : novalue()
 bounce.color = red
 bounce.label = bnc
-hold.metric = sum(postfix.queues.hold)
+hold.metric = defined(postfix.queues.hold) ? sum(postfix.queues.hold) : novalue()
 hold.color = yellow

--- a/pcp/meters/redis
+++ b/pcp/meters/redis
@@ -5,25 +5,25 @@
 [redisxact]
 caption = Redis xact
 description = Redis transactions
-tps.metric = redis.instantaneous_ops_per_sec
+tps.metric = defined(redis.instantaneous_ops_per_sec) ? redis.instantaneous_ops_per_sec : novalue()
 tps.color = green
 
 [redismem]
 caption = Redis mem
 description = Redis memory
-lua.metric = redis.used_memory_lua
+lua.metric = defined(redis.used_memory_lua) ? redis.used_memory_lua : novalue()
 lua.color = magenta
-used.metric = redis.used_memory
+used.metric = defined(redis.used_memory) ? redis.used_memory : novalue()
 used.color = blue
 
 [redisclient]
 caption = Redis clients
 description = Redis clients
 type = bar
-blocked.metric = redis.blocked_clients
+blocked.metric = defined(redis.blocked_clients) ? redis.blocked_clients : novalue()
 blocked.color = blue
 blocked.label = blk
-clients.metric = redis.connected_clients
+clients.metric = defined(redis.connected_clients) ? redis.connected_clients : novalue()
 clients.color = green
 clients.label = conn
 
@@ -31,9 +31,9 @@ clients.label = conn
 caption = Redis conn
 description = Redis connections
 type = bar
-reject.metric = redis.rejected_connections
+reject.metric = defined(redis.rejected_connections) ? redis.rejected_connections : novalue()
 reject.color = magenta
 reject.label = fail/s
-total.metric = redis.total_connections_received
+total.metric = defined(redis.total_connections_received) ? redis.total_connections_received : novalue()
 total.color = blue
 total.label = conn/s

--- a/pcp/screens/biosnoop
+++ b/pcp/screens/biosnoop
@@ -9,33 +9,33 @@ default = false
 
 pid.heading = PID
 pid.caption = Process identifier
-pid.metric = bpf.biosnoop.pid
+pid.metric = defined(bpf.biosnoop.pid) ? bpf.biosnoop.pid : novalue()
 pid.format = process
 
 disk.heading = DISK
 disk.caption = Device name
 disk.width = -7
-disk.metric = bpf.biosnoop.disk
+disk.metric = defined(bpf.biosnoop.disk) ? bpf.biosnoop.disk : novalue()
 
 rwbs.heading = TYPE
 rwbs.caption = I/O type string
 rwbs.width = -4
-rwbs.metric = bpf.biosnoop.rwbs
+rwbs.metric = defined(bpf.biosnoop.rwbs) ? bpf.biosnoop.rwbs : novalue()
 
 bytes.heading = BYTES
 bytes.caption = I/O size in bytes
-bytes.metric = bpf.biosnoop.bytes
+bytes.metric = defined(bpf.biosnoop.bytes) ? bpf.biosnoop.bytes : novalue()
 
 lat.heading = LAT
 lat.caption = I/O latency
-lat.metric = bpf.biosnoop.lat
+lat.metric = defined(bpf.biosnoop.lat) ? bpf.biosnoop.lat : novalue()
 
 sector.heading = SECTOR
 sector.caption = Device sector
-sector.metric = bpf.biosnoop.sector
+sector.metric = defined(bpf.biosnoop.sector) ? bpf.biosnoop.sector : novalue()
 
 comm.heading = Command
 comm.caption = Process command name
 comm.width = -16
-comm.metric = bpf.biosnoop.comm
+comm.metric = defined(bpf.biosnoop.comm) ? bpf.biosnoop.comm : novalue()
 comm.format = process

--- a/pcp/screens/cgroupsmem
+++ b/pcp/screens/cgroupsmem
@@ -38,7 +38,7 @@ swap.heading = SWAP
 swap.metric = cgroup.memory.stat.swap
 
 pgfault.heading = FAULTS
-pgfault.metric = cgroup.memory.stat.pgfaults
+pgfault.metric = cgroup.memory.stat.pgfault
 
 name.heading = Control group
 name.caption = Control group name

--- a/pcp/screens/execsnoop
+++ b/pcp/screens/execsnoop
@@ -9,29 +9,29 @@ default = false
 
 pid.heading = PID
 pid.caption = Process Identifier
-pid.metric = bpf.execsnoop.pid
+pid.metric = defined(bpf.execsnoop.pid) ? bpf.execsnoop.pid : novalue()
 pid.format = process
 
 ppid.heading = PPID
 ppid.caption = Parent Process
-ppid.metric = bpf.execsnoop.ppid
+ppid.metric = defined(bpf.execsnoop.ppid) ? bpf.execsnoop.ppid : novalue()
 ppid.format = process
 
 uid.heading = UID
 uid.caption = User Identifier
-uid.metric = bpf.execsnoop.uid
+uid.metric = defined(bpf.execsnoop.uid) ? bpf.execsnoop.uid : novalue()
 
 comm.heading = COMM
 comm.caption = Command
 comm.width = -16
-comm.metric = bpf.execsnoop.comm
+comm.metric = defined(bpf.execsnoop.comm) ? bpf.execsnoop.comm : novalue()
 comm.format = command
 
 ret.heading = RET
 ret.caption = Return Code
-ret.metric = bpf.execsnoop.ret
+ret.metric = defined(bpf.execsnoop.ret) ? bpf.execsnoop.ret : novalue()
 
 path.heading = Arguments
 path.caption = Arguments
 path.width = -12
-path.metric = bpf.execsnoop.args
+path.metric = defined(bpf.execsnoop.args) ? bpf.execsnoop.args : novalue()

--- a/pcp/screens/exitsnoop
+++ b/pcp/screens/exitsnoop
@@ -9,40 +9,40 @@ default = false
 
 pid.heading = PID
 pid.caption = Process Identifier
-pid.metric = bpf.exitsnoop.pid
+pid.metric = defined(bpf.exitsnoop.pid) ? bpf.exitsnoop.pid : novalue()
 pid.format = process
 
 ppid.heading = PPID
 ppid.caption = Parent Process
-ppid.metric = bpf.exitsnoop.ppid
+ppid.metric = defined(bpf.exitsnoop.ppid) ? bpf.exitsnoop.ppid : novalue()
 ppid.format = process
 
 tid.heading = TID
 tid.caption = Task Identifier
-tid.metric = bpf.exitsnoop.tid
+tid.metric = defined(bpf.exitsnoop.tid) ? bpf.exitsnoop.tid : novalue()
 tid.format = process
 tid.default = false
 
 signal.heading = SIG
 signal.caption = Signal number
-signal.metric = bpf.exitsnoop.sig
+signal.metric = defined(bpf.exitsnoop.sig) ? bpf.exitsnoop.sig : novalue()
 
 exit.heading = EXIT
 exit.caption = Exit Code
-exit.metric = bpf.exitsnoop.exit_code
+exit.metric = defined(bpf.exitsnoop.exit_code) ? bpf.exitsnoop.exit_code : novalue()
 
 core.heading = CORE
 core.caption = Dumped core
-core.metric = bpf.exitsnoop.coredump
+core.metric = defined(bpf.exitsnoop.coredump) ? bpf.exitsnoop.coredump : novalue()
 core.default = false
 
 age.heading = AGE
 age.caption = Process age
-age.metric = bpf.exitsnoop.age
+age.metric = defined(bpf.exitsnoop.age) ? bpf.exitsnoop.age : novalue()
 age.default = false
 
 comm.heading = Command
 comm.caption = COMM
 comm.width = -16
-comm.metric = bpf.exitsnoop.comm
+comm.metric = defined(bpf.exitsnoop.comm) ? bpf.exitsnoop.comm : novalue()
 comm.format = command

--- a/pcp/screens/opensnoop
+++ b/pcp/screens/opensnoop
@@ -8,20 +8,20 @@ caption = BPF open(2) syscall snoop
 default = false
 
 pid.heading = PID
-pid.metric = bpf.opensnoop.pid
+pid.metric = defined(bpf.opensnoop.pid) ? bpf.opensnoop.pid : novalue()
 pid.format = process
 
 comm.heading = COMM
-comm.metric = bpf.opensnoop.comm
+comm.metric = defined(bpf.opensnoop.comm) ? bpf.opensnoop.comm : novalue()
 comm.format = command
 
 fd.heading = FD
-fd.metric = bpf.opensnoop.fd
+fd.metric = defined(bpf.opensnoop.fd) ? bpf.opensnoop.fd : novalue()
 
 err.heading = ERR
-err.metric = bpf.opensnoop.err
+err.metric = defined(bpf.opensnoop.err) ? bpf.opensnoop.err : novalue()
 
 file.heading = File name
 file.width = -32
-file.metric = bpf.opensnoop.fname
+file.metric = defined(bpf.opensnoop.fname) ? bpf.opensnoop.fname : novalue()
 file.format = path


### PR DESCRIPTION
A recent change to libpcp has meant that derived expressions involving metrics that are not known are now generating warning error messages.

The use of expressions of the form: defined(x) ? x : novalue() both avoids the warning message and ensures the resulting derived metric returns "No value(s) available" when fetched.

This commit adds defined(x) guards for all derived metrics from the optional PMDAs that may not be installed, i.e. bpf, memcache, postfix, amdgpu, mysql and redis.

Also correct a spelling error in the name of one PCP metric in the pcp/screens/cgroupsmem file that was exposed by the libpcp change.