### PR TITLE
Make Cancel (F2, Esc) remove a newly added screen tab and not only abort the implicit rename

### DIFF
--- a/ScreensPanel.c
+++ b/ScreensPanel.c
@@ -1,7 +1,7 @@
 /*
 htop - ScreensPanel.c
 (C) 2004-2011 Hisham H. Muhammad
-(C) 2020-2023 htop dev team
+(C) 2020-2026 htop dev team
 Released under the GNU GPLv2+, see the COPYING file
 in the source distribution for its full text.
 */
@@ -50,6 +50,8 @@ static const char* const ScreensFunctions[] = {"      ", "Rename", "      ", "  
 static const char* const DynamicFunctions[] = {"      ", "Rename", "      ", "      ", "      ", "      ", "MoveUp", "MoveDn", "Remove", "Done  ", NULL};
 static const char* const ScreensRenamingFunctions[] = {"      ", "Cancel", "      ", "      ", "      ", "      ", "      ", "      ", "      ", "Done  ", NULL};
 static FunctionBar* Screens_renamingBar = NULL;
+
+static void rebuildSettingsArray(Panel* super, int selected);
 
 void ScreensPanel_cleanup(void) {
    if (Screens_renamingBar) {
@@ -106,6 +108,7 @@ static HandlerResult ScreensPanel_eventHandlerRenaming(Panel* super, int ch) {
          free(this->saved);
          item->value = xStrdup(this->buffer);
          this->renamingItem = NULL;
+         this->renamingNewItem = false;
          super->cursorOn = false;
          Panel_setSelectionColor(super, PANEL_SELECTION_FOCUS);
          Panel_setDefaultBar(super);
@@ -118,7 +121,20 @@ static HandlerResult ScreensPanel_eventHandlerRenaming(Panel* super, int ch) {
          if (!item)
             break;
          assert(item == this->renamingItem);
+
+         // Restore item->value to the heap-allocated saved string.
+         // This is safe for both cases: existing items keep their name,
+         // and new items need this before deletion to avoid freeing the stack buffer.
          item->value = this->saved;
+
+         if (this->renamingNewItem) {
+            // If canceling a newly created item, delete it
+            Panel_remove(super, Panel_getSelectedIndex(super));
+            // Rebuild with the updated selection after removal
+            rebuildSettingsArray(super, Panel_getSelectedIndex(super));
+         }
+
+         this->renamingNewItem = false;
          this->renamingItem = NULL;
          super->cursorOn = false;
          Panel_setSelectionColor(super, PANEL_SELECTION_FOCUS);
@@ -215,6 +231,7 @@ static HandlerResult ScreensPanel_eventHandlerNormal(Panel* super, int ch) {
          break;
       case KEY_F(2):
       case KEY_CTRL('R'):
+         this->renamingNewItem = false;
          startRenaming(super);
          result = HANDLED;
          break;
@@ -223,6 +240,7 @@ static HandlerResult ScreensPanel_eventHandlerNormal(Panel* super, int ch) {
          if (this->settings->dynamicScreens)
             break;
          addNewScreen(super);
+         this->renamingNewItem = true;
          startRenaming(super);
          shouldRebuildArray = true;
          result = HANDLED;
@@ -319,6 +337,7 @@ ScreensPanel* ScreensPanel_new(Settings* settings) {
    this->availableColumns = AvailableColumnsPanel_new((Panel*) this->columns, columns);
    this->moving = false;
    this->renamingItem = NULL;
+   this->renamingNewItem = false;
    super->cursorOn = false;
    this->cursor = 0;
    Panel_setHeader(super, "Screens");

--- a/ScreensPanel.h
+++ b/ScreensPanel.h
@@ -3,7 +3,7 @@
 /*
 htop - ScreensPanel.h
 (C) 2004-2011 Hisham H. Muhammad
-(C) 2020-2022 htop dev team
+(C) 2020-2026 htop dev team
 Released under the GNU GPLv2+, see the COPYING file
 in the source distribution for its full text.
 */
@@ -35,6 +35,7 @@ typedef struct ScreensPanel_ {
    char* saved;
    size_t cursor;
    ListItem* renamingItem;
+   bool renamingNewItem;
 } ScreensPanel;
 
 typedef struct ScreenListItem_ {


### PR DESCRIPTION
Canceling a new screen tab should ... cancel it and not just abort the implicit rename action