### PR TITLE
Add option for hyperthread visibility in CPU meter labels

### DIFF
--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -52,6 +52,13 @@ static void CPUMeter_init(Meter* this) {
          int coreID = Machine_getCPUPhysicalCoreID(host, cpu - 1);
          int threadIndex = Machine_getCPUThreadIndex(host, cpu - 1);
          char threadLetter = 'a' + (char)(threadIndex % 26);
+         // if we have more than 26 threads per core, then add the capital
+         // letters into the mix. If we have more than 52 threads per core, then
+         // some letters will still be repeated, but they'll be far apart from
+         // each other.
+         if ((threadIndex % 52) > 26) {
+             threadLetter -= ('a' - 'A');
+         }
          xSnprintf(caption, sizeof(caption), "%2d%c", coreID, threadLetter);
       } else {
          xSnprintf(caption, sizeof(caption), "%3u", Settings_cpuId(host->settings, cpu - 1));

--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -48,7 +48,14 @@ static void CPUMeter_init(Meter* this) {
       Meter_setCaption(this, "Avg");
    } else if (host->activeCPUs > 1) {
       char caption[10];
-      xSnprintf(caption, sizeof(caption), "%3u", Settings_cpuId(host->settings, cpu - 1));
+      if (host->settings->showCPUSMTLabels) {
+         int coreID = Machine_getCPUPhysicalCoreID(host, cpu - 1);
+         int threadIndex = Machine_getCPUThreadIndex(host, cpu - 1);
+         char threadLetter = 'a' + (char)(threadIndex % 26);
+         xSnprintf(caption, sizeof(caption), "%2d%c", coreID, threadLetter);
+      } else {
+         xSnprintf(caption, sizeof(caption), "%3u", Settings_cpuId(host->settings, cpu - 1));
+      }
       Meter_setCaption(this, caption);
    }
 }

--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -179,6 +179,7 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    Panel_add(super, (Object*) CheckItem_newByRef("Leave a margin around header", &(settings->headerMargin)));
    Panel_add(super, (Object*) CheckItem_newByRef("Detailed CPU time (System/IO-Wait/Hard-IRQ/Soft-IRQ/Steal/Guest)", &(settings->detailedCPUTime)));
    Panel_add(super, (Object*) CheckItem_newByRef("Count CPUs from 1 instead of 0", &(settings->countCPUsFromOne)));
+   Panel_add(super, (Object*) CheckItem_newByRef("Label CPUs based on SMT topology (e.g. 0a, 0b) instead of CPU index", &(settings->showCPUSMTLabels)));
    Panel_add(super, (Object*) CheckItem_newByRef("Update process names on every refresh", &(settings->updateProcessNames)));
    Panel_add(super, (Object*) CheckItem_newByRef("Add guest time in CPU meter percentage", &(settings->accountGuestInCPUMeter)));
    Panel_add(super, (Object*) CheckItem_newByRef("Also show CPU percentage numerically", &(settings->showCPUUsage)));

--- a/Machine.h
+++ b/Machine.h
@@ -83,6 +83,10 @@ void Machine_done(Machine* this);
 
 bool Machine_isCPUonline(const Machine* this, unsigned int id);
 
+int Machine_getCPUPhysicalCoreID(const Machine* this, unsigned int id);
+
+int Machine_getCPUThreadIndex(const Machine* this, unsigned int id);
+
 void Machine_populateTablesFromSettings(Machine* this, Settings* settings, Table* processTable);
 
 void Machine_setTablesPanel(Machine* this, Panel* panel);

--- a/Settings.c
+++ b/Settings.c
@@ -468,6 +468,8 @@ static bool Settings_read(Settings* this, const char* fileName, const Machine* h
       } else if (String_eq(option[0], "cpu_count_from_zero")) {
          // old (inverted) naming also supported for backwards compatibility
          this->countCPUsFromOne = !atoi(option[1]);
+      } else if (String_eq(option[0], "show_cpu_smt_labels")) {
+         this->showCPUSMTLabels = atoi(option[1]);
       } else if (String_eq(option[0], "show_cpu_usage")) {
          this->showCPUUsage = atoi(option[1]);
       } else if (String_eq(option[0], "show_cpu_frequency")) {
@@ -705,6 +707,7 @@ int Settings_write(const Settings* this, bool onCrash) {
    printSettingInteger("screen_tabs", this->screenTabs);
    printSettingInteger("detailed_cpu_time", this->detailedCPUTime);
    printSettingInteger("cpu_count_from_one", this->countCPUsFromOne);
+   printSettingInteger("show_cpu_smt_labels", this->showCPUSMTLabels);
    printSettingInteger("show_cpu_usage", this->showCPUUsage);
    printSettingInteger("show_cpu_frequency", this->showCPUFrequency);
    #ifdef BUILD_WITH_CPU_TEMP
@@ -810,6 +813,7 @@ Settings* Settings_new(const Machine* host, Hashtable* dynamicMeters, Hashtable*
    this->highlightMegabytes = true;
    this->detailedCPUTime = false;
    this->countCPUsFromOne = false;
+   this->showCPUSMTLabels = false;
    this->showCPUUsage = true;
    this->showCPUFrequency = false;
    #ifdef BUILD_WITH_CPU_TEMP

--- a/Settings.h
+++ b/Settings.h
@@ -77,6 +77,7 @@ typedef struct Settings_ {
    bool detailedCPUTime;
    bool showCPUUsage;
    bool showCPUFrequency;
+   bool showCPUSMTLabels;
    #ifdef BUILD_WITH_CPU_TEMP
    bool showCPUTemperature;
    bool degreeFahrenheit;

--- a/darwin/DarwinMachine.c
+++ b/darwin/DarwinMachine.c
@@ -137,3 +137,15 @@ bool Machine_isCPUonline(const Machine* host, unsigned int id) {
 
    return true;
 }
+
+int Machine_getCPUPhysicalCoreID(const Machine* host, unsigned int id) {
+   assert(id < host->existingCPUs);
+   (void) host;
+   return (int)id;
+}
+
+int Machine_getCPUThreadIndex(const Machine* host, unsigned int id) {
+   assert(id < host->existingCPUs);
+   (void) host; (void) id;
+   return 0;
+}

--- a/dragonflybsd/DragonFlyBSDMachine.c
+++ b/dragonflybsd/DragonFlyBSDMachine.c
@@ -373,3 +373,15 @@ bool Machine_isCPUonline(const Machine* host, unsigned int id) {
    // TODO: Support detecting online / offline CPUs.
    return true;
 }
+
+int Machine_getCPUPhysicalCoreID(const Machine* host, unsigned int id) {
+   assert(id < host->existingCPUs);
+   (void) host;
+   return (int)id;
+}
+
+int Machine_getCPUThreadIndex(const Machine* host, unsigned int id) {
+   assert(id < host->existingCPUs);
+   (void) host; (void) id;
+   return 0;
+}

--- a/freebsd/FreeBSDMachine.c
+++ b/freebsd/FreeBSDMachine.c
@@ -402,3 +402,15 @@ bool Machine_isCPUonline(const Machine* host, unsigned int id) {
 
    return true;
 }
+
+int Machine_getCPUPhysicalCoreID(const Machine* host, unsigned int id) {
+   assert(id < host->existingCPUs);
+   (void) host;
+   return (int)id;
+}
+
+int Machine_getCPUThreadIndex(const Machine* host, unsigned int id) {
+   assert(id < host->existingCPUs);
+   (void) host; (void) id;
+   return 0;
+}

--- a/linux/LinuxMachine.c
+++ b/linux/LinuxMachine.c
@@ -623,7 +623,6 @@ static void scanCPUFrequencyFromCPUinfo(LinuxMachine* this) {
    }
 }
 
-#ifdef HAVE_SENSORS_SENSORS_H
 static void LinuxMachine_fetchCPUTopologyFromCPUinfo(LinuxMachine* this) {
    const Machine* super = &this->super;
 
@@ -737,8 +736,6 @@ static void LinuxMachine_computeThreadIndices(LinuxMachine* this) {
    }
 }
 
-#endif
-
 static void LinuxMachine_scanCPUFrequency(LinuxMachine* this) {
    const Machine* super = &this->super;
 
@@ -816,13 +813,14 @@ Machine* Machine_new(UsersTable* usersTable, uid_t userId) {
    // Initialize CPU count
    LinuxMachine_updateCPUcount(this);
 
-   #ifdef HAVE_SENSORS_SENSORS_H
    // Fetch CPU topology
+   int ccds = 0;
    LinuxMachine_fetchCPUTopologyFromCPUinfo(this);
-   int ccds = LibSensors_countCCDs();
+   #ifdef HAVE_SENSORS_SENSORS_H
+   ccds = LibSensors_countCCDs();
+   #endif
    LinuxMachine_assignCCDs(this, ccds);
    LinuxMachine_computeThreadIndices(this);
-   #endif
 
    return super;
 }
@@ -852,29 +850,17 @@ bool Machine_isCPUonline(const Machine* super, unsigned int id) {
 }
 
 int Machine_getCPUPhysicalCoreID(const Machine* super, unsigned int id) {
-#ifdef HAVE_SENSORS_SENSORS_H
    const LinuxMachine* this = (const LinuxMachine*) super;
 
    assert(id < super->existingCPUs);
 
    const CPUData* cpu = &this->cpuData[id + 1];
    return cpu->physicalID * (this->maxCoreID + 1) + cpu->coreID;
-#else
-   (void) super;
-   /* Fall back to CPU id when topology unavailable */
-   return (int)id;
-#endif
 }
 
 int Machine_getCPUThreadIndex(const Machine* super, unsigned int id) {
-#ifdef HAVE_SENSORS_SENSORS_H
    const LinuxMachine* this = (const LinuxMachine*) super;
 
    assert(id < super->existingCPUs);
    return this->cpuData[id + 1].threadIndex;
-#else
-   (void) super;
-   (void) id;
-   return 0;
-#endif
 }

--- a/linux/LinuxMachine.h
+++ b/linux/LinuxMachine.h
@@ -53,6 +53,7 @@ typedef struct CPUData_ {
    int physicalID;      /* different for each CPU socket */
    int coreID;          /* same for hyperthreading */
    int ccdID;           /* same for each AMD chiplet */
+   int threadIndex;     /* SMT thread index: 0 for first thread, 1 for second, etc. */
    #endif
 
    bool online;

--- a/linux/LinuxMachine.h
+++ b/linux/LinuxMachine.h
@@ -49,12 +49,12 @@ typedef struct CPUData_ {
 
    #ifdef HAVE_SENSORS_SENSORS_H
    double temperature;
+   #endif
 
    int physicalID;      /* different for each CPU socket */
    int coreID;          /* same for hyperthreading */
    int ccdID;           /* same for each AMD chiplet */
    int threadIndex;     /* SMT thread index: 0 for first thread, 1 for second, etc. */
-   #endif
 
    bool online;
 } CPUData;
@@ -86,10 +86,8 @@ typedef struct LinuxMachine_ {
 
    CPUData* cpuData;
 
-   #ifdef HAVE_SENSORS_SENSORS_H
    int maxPhysicalID;
    int maxCoreID;
-   #endif
 
    memory_t totalHugePageMem;
    memory_t usedHugePageMem[HTOP_HUGEPAGE_COUNT];

--- a/netbsd/NetBSDMachine.c
+++ b/netbsd/NetBSDMachine.c
@@ -291,3 +291,15 @@ bool Machine_isCPUonline(const Machine* host, unsigned int id) {
    // TODO: Support detecting online / offline CPUs.
    return true;
 }
+
+int Machine_getCPUPhysicalCoreID(const Machine* host, unsigned int id) {
+   assert(id < host->existingCPUs);
+   (void) host;
+   return (int)id;
+}
+
+int Machine_getCPUThreadIndex(const Machine* host, unsigned int id) {
+   assert(id < host->existingCPUs);
+   (void) host; (void) id;
+   return 0;
+}

--- a/openbsd/OpenBSDMachine.c
+++ b/openbsd/OpenBSDMachine.c
@@ -292,3 +292,15 @@ bool Machine_isCPUonline(const Machine* super, unsigned int id) {
    const OpenBSDMachine* this = (const OpenBSDMachine*) super;
    return this->cpuData[id + 1].online;
 }
+
+int Machine_getCPUPhysicalCoreID(const Machine* host, unsigned int id) {
+   assert(id < host->existingCPUs);
+   (void) host;
+   return (int)id;
+}
+
+int Machine_getCPUThreadIndex(const Machine* host, unsigned int id) {
+   assert(id < host->existingCPUs);
+   (void) host; (void) id;
+   return 0;
+}

--- a/pcp/PCPMachine.c
+++ b/pcp/PCPMachine.c
@@ -404,3 +404,15 @@ bool Machine_isCPUonline(const Machine* host, unsigned int id) {
       return true;
    return false;
 }
+
+int Machine_getCPUPhysicalCoreID(const Machine* host, unsigned int id) {
+   assert(id < host->existingCPUs);
+   (void) host;
+   return (int)id;
+}
+
+int Machine_getCPUThreadIndex(const Machine* host, unsigned int id) {
+   assert(id < host->existingCPUs);
+   (void) host; (void) id;
+   return 0;
+}

--- a/solaris/SolarisMachine.c
+++ b/solaris/SolarisMachine.c
@@ -328,3 +328,15 @@ bool Machine_isCPUonline(const Machine* super, unsigned int id) {
 
    return (super->existingCPUs == 1) ? true : this->cpus[id + 1].online;
 }
+
+int Machine_getCPUPhysicalCoreID(const Machine* host, unsigned int id) {
+   assert(id < host->existingCPUs);
+   (void) host;
+   return (int)id;
+}
+
+int Machine_getCPUThreadIndex(const Machine* host, unsigned int id) {
+   assert(id < host->existingCPUs);
+   (void) host; (void) id;
+   return 0;
+}

--- a/unsupported/UnsupportedMachine.c
+++ b/unsupported/UnsupportedMachine.c
@@ -52,3 +52,15 @@ void Machine_scan(Machine* super) {
    this->usedMem = 0;
    this->cachedMem = 0;
 }
+
+int Machine_getCPUPhysicalCoreID(const Machine* host, unsigned int id) {
+   assert(id < host->existingCPUs);
+   (void) host;
+   return (int)id;
+}
+
+int Machine_getCPUThreadIndex(const Machine* host, unsigned int id) {
+   assert(id < host->existingCPUs);
+   (void) host; (void) id;
+   return 0;
+}


### PR DESCRIPTION
This PR adds a `show_smt_cpu_labels` setting which, when enabled, labels cpu meters with a `X{a,b,c,d}` convention where `X` is the physical core ID and `a/b/c/d` indicates which hyperthread on the core the labeled meter is watching. For example, 8 cores with SMT-2 renders as follows:

```
   0a[|              ]  4a[|              ]  0b[               ]  4b[               ]
   1a[               ]  5a[|              ]  1b[               ]  5b[|              ]
   2a[               ]  6a[               ]  2b[               ]  6b[||             ]
   3a[               ]  7a[||             ]  3b[               ]  7b[               ]
```

The setting is off by default and currently only implemented for Linux.