### PR TITLE
pcp/PCPDynamicMeter.c: guard against underflow of buffer[] index

### DIFF
--- a/pcp/PCPDynamicMeter.c
+++ b/pcp/PCPDynamicMeter.c
@@ -330,7 +330,8 @@ void PCPDynamicMeter_updateValues(PCPDynamicMeter* this, Meter* meter) {
       pmAtomValue atom, raw;
 
       if (!Metric_values(base, &raw, 1, desc->type)) {
-         bytes--; /* clear the separator */
+	 if (bytes > 0)
+	     bytes--; /* clear the separator */
          continue;
       }
 
@@ -342,7 +343,8 @@ void PCPDynamicMeter_updateValues(PCPDynamicMeter* this, Meter* meter) {
       if (desc->type == PM_TYPE_STRING)
          atom = raw;
       else if (pmConvScale(desc->type, &raw, &desc->units, &atom, &conv) < 0) {
-         bytes--; /* clear the separator */
+	 if (bytes > 0)
+	     bytes--; /* clear the separator */
          continue;
       }
 


### PR DESCRIPTION
On the error paths, the index (bytes) was unconditionally decremented but it may be 0 (for failure on the first metric), leading to underflow and a huge value (bytes is size_t and hence unsigned).

Fixes Coverity CID 426719 over at
https://scan4.scan.coverity.com/#/project-view/38378/14885?selectedIssue=426719