### PR TITLE
Refactor FUNCTIONBAR_MAXEVENTS and use sentinels in loops

### DIFF
--- a/FunctionBar.h
+++ b/FunctionBar.h
@@ -18,7 +18,6 @@ typedef struct FunctionBar_ {
       const char* const* constKeys;
    } keys;
    int* events;
-   uint32_t size;
    bool staticData;
 } FunctionBar;
 


### PR DESCRIPTION
Set FUNCTIONBAR_MAXEVENTS to the actual limit (11) and adjust the loops which use it to solely rely on sentinel NULL, removing checks for a situation which cannot occur.

Fixes covscan issue #644308