### PR TITLE
Fix formatting of AI-Assisted Contributions Policy

### DIFF
--- a/docs/ai-contributions-policy.md
+++ b/docs/ai-contributions-policy.md
@@ -5,21 +5,21 @@ v1.0, 2026-02-18
 
 2.  **Accountability**:
 
-        You *MUST* take the responsibility for your contribution.
+    You **MUST** take the responsibility for your contribution.
 
-        Contributing to htop means vouching for the quality, license compliance, and utility of your submission.
+    Contributing to htop means vouching for the quality, license compliance, and utility of your submission.
 
-        All contributions, whether from a human author or assisted by large language models (LLMs) or other generative AI tools, must meet the project’s standards for inclusion.
+    All contributions, whether from a human author or assisted by large language models (LLMs) or other generative AI tools, must meet the project’s standards for inclusion.
 
-        The contributor is always the author and is fully accountable for the entirety of these contributions.
+    The contributor is always the author and is fully accountable for the entirety of these contributions.
 
 3.  **Transparency**:
 
-        You *MUST* disclose the use of AI tools when the significant part of the contribution is taken from a tool without changes.
+    You **MUST** disclose the use of AI tools when the significant part of the contribution is taken from a tool without changes.
 
-        You *SHOULD* disclose the other uses of AI tools, where it might be useful.
+    You **SHOULD** disclose the other uses of AI tools, where it might be useful.
 
-        Routine use of assistive tools for correcting grammar and spelling, or for clarifying language, does not require disclosure.
+    Routine use of assistive tools for correcting grammar and spelling, or for clarifying language, does not require disclosure.
 
     -   Disclosures are made where authorship is normally indicated. For contributions tracked in git, the recommended method is an `Assisted-by:` commit message trailer.
 
@@ -29,17 +29,17 @@ v1.0, 2026-02-18
 
         -   `Assisted-by: ChatGPTv5`
 
-        For contributions outside git commits, disclosure may include document preambles, design file metadata or `Assisted-by:` lines on issues.
+    For contributions outside git commits, disclosure may include document preambles, design file metadata or `Assisted-by:` lines on issues.
 
 4.  **Contribution Evaluation**:
 
-        AI tools may be used to assist human reviewers by providing analysis and suggestions.
+    AI tools may be used to assist human reviewers by providing analysis and suggestions.
 
-        You *MUST NOT* use AI as the sole or final arbiter in making a substantive or subjective judgment on a contribution.
+    You **MUST NOT** use AI as the sole or final arbiter in making a substantive or subjective judgment on a contribution.
 
-        This does not prohibit the use of automated tooling for objective technical validation, such as CI/CD pipelines, automated testing, or spam filtering.
+    This does not prohibit the use of automated tooling for objective technical validation, such as CI/CD pipelines, automated testing, or spam filtering.
 
-        The final accountability for accepting a contribution, even if implemented by an automated system, always rests with the human contributor who authorizes the action.
+    The final accountability for accepting a contribution, even if implemented by an automated system, always rests with the human contributor who authorizes the action.
 
 This policy has been adapted for htop use from the Fedora policy v1.0 published at <https://docs.fedoraproject.org/en-US/council/policy/ai-contribution-policy/>.
 


### PR DESCRIPTION
In the new [AI-Assisted Contributions Policy][1], most paragraphs are incorrectly rendered as code blocks. Furthermore, italicized text was presumably meant to be bold (it is bold in the original Fedora version). This pull request fixes both formatting issues.

See here the [rendered version][2].

[1]: /htop-dev/htop/blob/main/docs/ai-contributions-policy.md
[2]: /edgar-bonet/htop/blob/format/docs/ai-contributions-policy.md