### PR TITLE
update mem info on every refresh on Solaris platform

### DIFF
--- a/solaris/SolarisMachine.c
+++ b/solaris/SolarisMachine.c
@@ -61,10 +61,9 @@ static void SolarisMachine_updateCPUcount(SolarisMachine* this) {
    }
 
    if (change) {
-      kstat_close(this->kd);
-      this->kd = kstat_open();
-      if (!this->kd)
-         CRT_fatalError("Cannot open kstat handle");
+      kid_t update_kid = kstat_chain_update(this->kd);
+      if (update_kid < 0)
+         CRT_fatalError("Cannot update kstat chain");
    }
 }
 
@@ -165,7 +164,7 @@ static void SolarisMachine_scanCPUTime(SolarisMachine* this) {
 
 static void SolarisMachine_scanMemoryInfo(SolarisMachine* this) {
    Machine*            super = &this->super;
-   static kstat_t*     meminfo = NULL;
+   kstat_t*            meminfo = NULL;
    struct swaptable*   sl = NULL;
    struct swapent*     swapdev = NULL;
    uint64_t            totalswap = 0;
@@ -176,8 +175,10 @@ static void SolarisMachine_scanMemoryInfo(SolarisMachine* this) {
    char*               spathbase = NULL;
 
    // Part 1 - physical memory
-   if (this->kd != NULL && meminfo == NULL) {
-      // Look up the kstat chain just once, it never changes
+   if (this->kd != NULL) {
+      // The ptr `meminfo` is invalidated when the kstat chain is updated by
+      // `kstat_chain_update` (in `SolarisMachine_updateCPUcount`). So it needs
+      // to be re-read on every memory update.
       meminfo = kstat_lookup_wrapper(this->kd, "unix", 0, "system_pages");
    }
    if (meminfo != NULL) {


### PR DESCRIPTION
# The bug
`htop` crashes on illumos when the cpu count changes.

Tested with latest main branch on an illumos system. I unfortunately don't have a Solaris machine to test on it, but according to the man pages the bug should be the same.
 
How to reproduce:

1. Open `htop` in a terminal
2. Disable CPU0:
```sh
# as root
psradm -f 0
# to re-enable CPU0
psradm -Fn 0
```

`htop` crashed in first terminal.

# Issue and Fix

The memory info was previously read only once and kept in a static variable. However, the pointer to the memory info is invalidated when the kstat chain is updated, such as when the cpu count changes.

From the Illumos `kstat_chain_update` man page:

```
[...] any kstat_t structures retrieved by the
kstat_lookup(3KSTAT) function or data pointers obtained through the
kstat_data_lookup(3KSTAT) function are invalidated by a call to
kstat_chain_update(). [...]
```

So, re-reading the struct `kstat_t` on every memory scan ensure that the pointer `meminfo` is always valid.

Note that I also replace the 2 calls to `kstat_open` and `kstat_close` by a single `kstat_chain_update`. 