### PR TITLE
Fix CPU virtualization bar color and help text in non-detailed mode

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -744,8 +744,8 @@ static Htop_Reaction actionHelp(State* st) {
       addbartext(CRT_colors[CPU_IOWAIT], "/", "io-wait");
       addbartext(CRT_colors[BAR_SHADOW], " ", "used%");
    } else {
-      addbartext(CRT_colors[CPU_GUEST], "/", "guest");
-      addbartext(CRT_colors[BAR_SHADOW], "                            ", "used%");
+      addbartext(CRT_colors[CPU_GUEST], "/", "virt");
+      addbartext(CRT_colors[BAR_SHADOW], "                             ", "used%");
    }
    addattrstr(CRT_colors[BAR_BORDER], "]");
 

--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -36,6 +36,13 @@ static const int CPUMeter_attributes[] = {
    CPU_IOWAIT
 };
 
+static const int CPUMeter_attributes_summary[] = {
+   CPU_NICE,
+   CPU_NORMAL,
+   CPU_SYSTEM,
+   CPU_GUEST
+};
+
 typedef struct CPUMeterData_ {
    unsigned int cpus;
    Meter** meters;
@@ -68,6 +75,11 @@ static void CPUMeter_updateValues(Meter* this) {
 
    const Machine* host = this->host;
    const Settings* settings = host->settings;
+   if (settings->detailedCPUTime) {
+      this->curAttributes = CPUMeter_attributes;
+   } else {
+      this->curAttributes = CPUMeter_attributes_summary;
+   }
 
    unsigned int cpu = this->param;
    if (cpu > host->existingCPUs) {


### PR DESCRIPTION
The overlaying of CPU virt times (guest+steal) into the IRQ slot is problematic when displaying CPU time in bar mode. It results in the IRQ color being used for virt, which doesn't match up with the Help text for CPU util when in the non-detailed CPU time mode.  The text 'guest' displayed on the Help window is also misleading because the value is actually the sum of guest+steal time - use 'virt' instead, to indicate this is not guest time only.

Resolves #1920