### PR TITLE
Use CPU_METER_STEAL for 'virtualized' CPU time in non-detailed mode

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -804,8 +804,8 @@ static Htop_Reaction actionHelp(State* st) {
       addbartext(CRT_colors[CPU_IOWAIT], "/", "io-wait");
       addbartext(CRT_colors[BAR_SHADOW], " ", "used%");
    } else {
-      addbartext(CRT_colors[CPU_GUEST], "/", "guest");
-      addbartext(CRT_colors[BAR_SHADOW], "                            ", "used%");
+      addbartext(CRT_colors[CPU_GUEST], "/", "virtualized");
+      addbartext(CRT_colors[BAR_SHADOW], "                      ", "used%");
    }
    addattrstr(CRT_colors[BAR_BORDER], "]");
 

--- a/Action.c
+++ b/Action.c
@@ -803,8 +803,11 @@ static Htop_Reaction actionHelp(State* st) {
       addbartext(CRT_colors[CPU_GUEST], "/", "guest");
       addbartext(CRT_colors[CPU_IOWAIT], "/", "io-wait");
       addbartext(CRT_colors[BAR_SHADOW], " ", "used%");
+   } else if (CRT_colorScheme == COLORSCHEME_MONOCHROME) {
+      addbartext(CRT_colors[CPU_STEAL], "/-/-/", "virtualized");
+      addbartext(CRT_colors[BAR_SHADOW], "                  ", "used%");
    } else {
-      addbartext(CRT_colors[CPU_GUEST], "/", "virtualized");
+      addbartext(CRT_colors[CPU_STEAL], "/", "virtualized");
       addbartext(CRT_colors[BAR_SHADOW], "                      ", "used%");
    }
    addattrstr(CRT_colors[BAR_BORDER], "]");

--- a/Action.c
+++ b/Action.c
@@ -804,8 +804,8 @@ static Htop_Reaction actionHelp(State* st) {
       addbartext(CRT_colors[CPU_IOWAIT], "/", "io-wait");
       addbartext(CRT_colors[BAR_SHADOW], " ", "used%");
    } else {
-      addbartext(CRT_colors[CPU_GUEST], "/", "virt");
-      addbartext(CRT_colors[BAR_SHADOW], "                             ", "used%");
+      addbartext(CRT_colors[CPU_GUEST], "/", "guest");
+      addbartext(CRT_colors[BAR_SHADOW], "                            ", "used%");
    }
    addattrstr(CRT_colors[BAR_BORDER], "]");
 

--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -36,13 +36,6 @@ static const int CPUMeter_attributes[] = {
    CPU_IOWAIT
 };
 
-static const int CPUMeter_attributes_summary[] = {
-   CPU_NICE,
-   CPU_NORMAL,
-   CPU_SYSTEM,
-   CPU_GUEST
-};
-
 typedef struct CPUMeterData_ {
    unsigned int cpus;
    Meter** meters;
@@ -89,11 +82,6 @@ static void CPUMeter_updateValues(Meter* this) {
 
    const Machine* host = this->host;
    const Settings* settings = host->settings;
-   if (settings->detailedCPUTime) {
-      this->curAttributes = CPUMeter_attributes;
-   } else {
-      this->curAttributes = CPUMeter_attributes_summary;
-   }
 
    unsigned int cpu = this->param;
    if (cpu > host->existingCPUs) {

--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -185,10 +185,10 @@ static void CPUMeter_display(const Object* cast, RichString* out) {
       len = xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_NICE]);
       RichString_appendAscii(out, CRT_colors[METER_TEXT], "low:");
       RichString_appendnAscii(out, CRT_colors[CPU_NICE_TEXT], buffer, len);
-      if (isNonnegative(this->values[CPU_METER_IRQ])) {
-         len = xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_IRQ]);
+      if (isNonnegative(this->values[CPU_METER_STEAL])) {
+         len = xSnprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_STEAL]);
          RichString_appendAscii(out, CRT_colors[METER_TEXT], "vir:");
-         RichString_appendnAscii(out, CRT_colors[CPU_GUEST], buffer, len);
+         RichString_appendnAscii(out, CRT_colors[CPU_STEAL], buffer, len);
       }
    }
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -370,8 +370,12 @@ double Platform_setCPUValues(Meter* this, unsigned int cpu) {
       v[CPU_METER_IOWAIT]  = cpuData->ioWaitPeriod / total * 100.0;
    } else {
       v[CPU_METER_KERNEL] = cpuData->systemAllPeriod / total * 100.0;
+      this->curItems = 3;
+
       v[CPU_METER_IRQ] = (cpuData->stealPeriod + cpuData->guestPeriod) / total * 100.0;
-      this->curItems = 4;
+      if (settings->accountGuestInCPUMeter) {
+         this->curItems = 4;
+      }
    }
 
    percent = sumPositiveValues(v, this->curItems);

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -372,9 +372,11 @@ double Platform_setCPUValues(Meter* this, unsigned int cpu) {
       v[CPU_METER_KERNEL] = cpuData->systemAllPeriod / total * 100.0;
       this->curItems = 3;
 
-      v[CPU_METER_IRQ] = (cpuData->stealPeriod + cpuData->guestPeriod) / total * 100.0;
+      v[CPU_METER_IRQ] = 0.0; // Accounted in 'kernel'
+      v[CPU_METER_SOFTIRQ] = 0.0; // Accounted in 'kernel'
+      v[CPU_METER_STEAL] = (cpuData->stealPeriod + cpuData->guestPeriod) / total * 100.0;
       if (settings->accountGuestInCPUMeter) {
-         this->curItems = 4;
+         this->curItems = 6;
       }
    }
 

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -267,17 +267,17 @@ double Platform_setCPUValues(Meter* this, int cpu) {
    if (host->settings->detailedCPUTime) {
       v[CPU_METER_KERNEL]  = cpuData->sysPeriod / total * 100.0;
       v[CPU_METER_IRQ]     = cpuData->intrPeriod / total * 100.0;
-      v[CPU_METER_SOFTIRQ] = 0.0;
-      v[CPU_METER_STEAL]   = 0.0;
-      v[CPU_METER_GUEST]   = 0.0;
-      v[CPU_METER_IOWAIT]  = 0.0;
-      v[CPU_METER_FREQUENCY] = NAN;
-      this->curItems = 8;
+      this->curItems = 4;
    } else {
       v[CPU_METER_KERNEL] = cpuData->sysAllPeriod / total * 100.0;
-      v[CPU_METER_IRQ] = 0.0; // No steal nor guest on NetBSD
-      this->curItems = 4;
+      v[CPU_METER_IRQ] = 0.0;
+      this->curItems = 3;
    }
+   v[CPU_METER_SOFTIRQ] = 0.0;
+   v[CPU_METER_STEAL]   = 0.0;
+   v[CPU_METER_GUEST]   = 0.0;
+   v[CPU_METER_IOWAIT]  = 0.0;
+
    totalPercent = v[CPU_METER_NICE] + v[CPU_METER_NORMAL] + v[CPU_METER_KERNEL] + v[CPU_METER_IRQ];
    totalPercent = CLAMP(totalPercent, 0.0, 100.0);
 

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -218,19 +218,18 @@ double Platform_setCPUValues(Meter* this, unsigned int cpu) {
    if (host->settings->detailedCPUTime) {
       v[CPU_METER_KERNEL]  = cpuData->sysPeriod / total * 100.0;
       v[CPU_METER_IRQ]     = cpuData->intrPeriod / total * 100.0;
-      v[CPU_METER_SOFTIRQ] = 0.0;
-      v[CPU_METER_STEAL]   = 0.0;
-      v[CPU_METER_GUEST]   = 0.0;
-      v[CPU_METER_IOWAIT]  = 0.0;
-      v[CPU_METER_FREQUENCY] = NAN;
-      this->curItems = 8;
+      this->curItems = 4;
    } else {
       v[CPU_METER_KERNEL] = cpuData->sysAllPeriod / total * 100.0;
-      v[CPU_METER_IRQ] = 0.0; // No steal nor guest on OpenBSD
-      this->curItems = 4;
+      v[CPU_METER_IRQ] = 0.0;
+      this->curItems = 3;
    }
-   totalPercent = v[CPU_METER_NICE] + v[CPU_METER_NORMAL] + v[CPU_METER_KERNEL] + v[CPU_METER_IRQ];
+   v[CPU_METER_SOFTIRQ] = 0.0;
+   v[CPU_METER_STEAL]   = 0.0;
+   v[CPU_METER_GUEST]   = 0.0;
+   v[CPU_METER_IOWAIT]  = 0.0;
 
+   totalPercent = v[CPU_METER_NICE] + v[CPU_METER_NORMAL] + v[CPU_METER_KERNEL] + v[CPU_METER_IRQ];
    totalPercent = CLAMP(totalPercent, 0.0, 100.0);
 
    v[CPU_METER_TEMPERATURE] = NAN;

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -576,10 +576,12 @@ static double Platform_setOneCPUValues(Meter* this, const Settings* settings, pm
       v[CPU_METER_KERNEL] = values[CPU_SYSTEM_ALL_PERIOD].ull / total * 100.0;
       this->curItems = 3;
 
+      v[CPU_METER_IRQ] = 0.0;
+      v[CPU_METER_SOFTIRQ] = 0.0;
       value = values[CPU_STEAL_PERIOD].ull + values[CPU_GUEST_PERIOD].ull;
-      v[CPU_METER_IRQ] = value / total * 100.0;
+      v[CPU_METER_STEAL] = value / total * 100.0;
       if (settings->accountGuestInCPUMeter) {
-         this->curItems = 4;
+         this->curItems = 6;
       }
    }
 

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -574,9 +574,13 @@ static double Platform_setOneCPUValues(Meter* this, const Settings* settings, pm
       v[CPU_METER_IOWAIT]  = values[CPU_IOWAIT_PERIOD].ull / total * 100.0;
    } else {
       v[CPU_METER_KERNEL] = values[CPU_SYSTEM_ALL_PERIOD].ull / total * 100.0;
+      this->curItems = 3;
+
       value = values[CPU_STEAL_PERIOD].ull + values[CPU_GUEST_PERIOD].ull;
       v[CPU_METER_IRQ] = value / total * 100.0;
-      this->curItems = 4;
+      if (settings->accountGuestInCPUMeter) {
+         this->curItems = 4;
+      }
    }
 
    percent = sumPositiveValues(v, this->curItems);


### PR DESCRIPTION
The virtualized CPU time will now write to the `CPU_METER_STEAL` item in the non-detailed CPU meter mode. Also fix the CPU meter text in the help screen.

This pull request also includes code cleanups such as unnecessary assignments of `v[CPU_METER_IRQ]` in NetBSD and OpenBSD platforms.

I think my approach is better than what's proposed in #1921.

Resolves #1920.