### PR TITLE
Extend events system, make mouse handling consistent

### DIFF
--- a/AvailableColumnsPanel.c
+++ b/AvailableColumnsPanel.c
@@ -51,6 +51,7 @@ static HandlerResult AvailableColumnsPanel_eventHandler(Panel* super, int ch) {
    switch (ch) {
       case 13:
       case KEY_ENTER:
+      case KEY_RECLICK:
       case KEY_F(5): {
          const ListItem* selected = (ListItem*) Panel_getSelected(super);
          if (!selected)

--- a/AvailableMetersPanel.c
+++ b/AvailableMetersPanel.c
@@ -40,7 +40,6 @@ static inline void AvailableMetersPanel_addMeter(Header* header, MetersPanel* pa
    const Meter* meter = Header_addMeterByClass(header, type, param, column);
    Panel_add((Panel*)panel, (Object*) Meter_toListItem(meter, false));
    Panel_setSelected((Panel*)panel, Panel_size((Panel*)panel) - 1);
-   MetersPanel_setMoving(panel, true);
 }
 
 static HandlerResult AvailableMetersPanel_eventHandler(Panel* super, int ch) {

--- a/ColumnsPanel.c
+++ b/ColumnsPanel.c
@@ -1,6 +1,7 @@
 /*
 htop - ColumnsPanel.c
 (C) 2004-2011 Hisham H. Muhammad
+(C) 2020-2026 htop dev team
 Released under the GNU GPLv2+, see the COPYING file
 in the source distribution for its full text.
 */
@@ -33,6 +34,17 @@ static void ColumnsPanel_delete(Object* object) {
    free(this);
 }
 
+static void ColumnsPanel_cancelMoving(ColumnsPanel* this) {
+   Panel* super = &this->super;
+   for (int i = 0; i < Panel_size(super); i++) {
+      ListItem* item = (ListItem*) Panel_get(super, i);
+      if (item)
+         item->moving = false;
+   }
+   this->moving = false;
+   Panel_setSelectionColor(super, PANEL_SELECTION_FOCUS);
+}
+
 static HandlerResult ColumnsPanel_eventHandler(Panel* super, int ch) {
    ColumnsPanel* const this = (ColumnsPanel*) super;
 
@@ -44,16 +56,27 @@ static HandlerResult ColumnsPanel_eventHandler(Panel* super, int ch) {
       case 0x0a:
       case 0x0d:
       case KEY_ENTER:
-      case KEY_MOUSE:
       case KEY_RECLICK:
          if (selected < size) {
-            this->moving = !(this->moving);
-            Panel_setSelectionColor(super, this->moving ? PANEL_SELECTION_FOLLOW : PANEL_SELECTION_FOCUS);
-            ListItem* selectedItem = (ListItem*) Panel_getSelected(super);
-            if (selectedItem)
-               selectedItem->moving = this->moving;
+            if (this->moving) {
+               ColumnsPanel_cancelMoving(this);
+            } else {
+               this->moving = true;
+               Panel_setSelectionColor(super, PANEL_SELECTION_FOLLOW);
+               ListItem* selectedItem = (ListItem*) Panel_getSelected(super);
+               if (selectedItem)
+                  selectedItem->moving = true;
+            }
             result = HANDLED;
          }
+         break;
+      case KEY_MOUSE:
+         if (this->moving) {
+            /* Single click while in move mode: cancel move mode */
+            ColumnsPanel_cancelMoving(this);
+            result = HANDLED;
+         }
+         /* else: just select the item, do not enter move mode */
          break;
       case KEY_UP:
          if (!this->moving)
@@ -82,6 +105,11 @@ static HandlerResult ColumnsPanel_eventHandler(Panel* super, int ch) {
       case KEY_DEL_MAC:
          if (size > 1 && selected < size)
             Panel_remove(super, selected);
+         result = HANDLED;
+         break;
+      case EVENT_PANEL_LOST_FOCUS:
+         if (this->moving)
+            ColumnsPanel_cancelMoving(this);
          result = HANDLED;
          break;
       default:

--- a/MetersPanel.c
+++ b/MetersPanel.c
@@ -1,6 +1,7 @@
 /*
 htop - MetersPanel.c
 (C) 2004-2011 Hisham H. Muhammad
+(C) 2020-2026 htop dev team
 Released under the GNU GPLv2+, see the COPYING file
 in the source distribution for its full text.
 */
@@ -51,17 +52,24 @@ static void MetersPanel_delete(Object* object) {
 void MetersPanel_setMoving(MetersPanel* this, bool moving) {
    Panel* super = &this->super;
    this->moving = moving;
-   ListItem* selected = (ListItem*)Panel_getSelected(super);
-   if (selected) {
-      selected->moving = moving;
-   }
    if (!moving) {
+      /* Reset all items' moving flags when canceling move mode */
+      for (int i = 0; i < Panel_size(super); i++) {
+         ListItem* item = (ListItem*) Panel_get(super, i);
+         if (item)
+            item->moving = false;
+      }
       Panel_setSelectionColor(super, PANEL_SELECTION_FOCUS);
       Panel_setDefaultBar(super);
    } else {
+      ListItem* selected = (ListItem*)Panel_getSelected(super);
+      if (selected) {
+         selected->moving = true;
+      }
       Panel_setSelectionColor(super, PANEL_SELECTION_FOLLOW);
       super->currentBar = Meters_movingBar;
    }
+   super->needsRedraw = true;
 }
 
 static inline bool moveToNeighbor(MetersPanel* this, MetersPanel* neighbor, int selected) {
@@ -96,10 +104,19 @@ static HandlerResult MetersPanel_eventHandler(Panel* super, int ch) {
       case 0x0a:
       case 0x0d:
       case KEY_ENTER:
+      case KEY_RECLICK:
          if (!Vector_size(this->meters))
             break;
          MetersPanel_setMoving(this, !(this->moving));
          result = HANDLED;
+         break;
+      case KEY_MOUSE:
+         if (this->moving) {
+            /* Single click while in move mode: cancel move mode */
+            MetersPanel_setMoving(this, false);
+            result = HANDLED;
+         }
+         /* else: just select the item, do not enter move mode */
          break;
       case ' ':
       case KEY_F(4):
@@ -160,6 +177,11 @@ static HandlerResult MetersPanel_eventHandler(Panel* super, int ch) {
             Panel_remove(super, selected);
          }
          MetersPanel_setMoving(this, false);
+         result = HANDLED;
+         break;
+      case EVENT_PANEL_LOST_FOCUS:
+         if (this->moving)
+            MetersPanel_setMoving(this, false);
          result = HANDLED;
          break;
    }

--- a/MetersPanel.c
+++ b/MetersPanel.c
@@ -23,17 +23,16 @@ in the source distribution for its full text.
 
 // Note: In code the meters are known to have bar/text/graph "Modes", but in UI
 // we call them "Styles".
-static const char* const MetersFunctions[] = {"Style ", "Move  ", "                                       ", "Delete", "Done  ", NULL};
-static const char* const MetersKeys[] = {"Space", "Enter", "  ", "Del", "F10"};
-static const int MetersEvents[] = {' ', 13, ERR, KEY_DC, KEY_F(10)};
+// Standard F-key layout matching the Screens panel:
+// F4=Style  F7=MoveUp  F8=MoveDn  F9=Delete  F10=Done
+static const char* const MetersFunctions[] = {"      ", "      ", "      ", "Style ", "      ", "      ", "MoveUp", "MoveDn", "Delete", "Done  ", NULL};
 
 // We avoid UTF-8 arrows ← → here as they might display full-width on Chinese
 // terminals, breaking our aligning.
 // In <http://unicode.org/reports/tr11/>, arrows (U+2019..U+2199) are
 // considered "Ambiguous characters".
-static const char* const MetersMovingFunctions[] = {"Style ", "Lock  ", "Up    ", "Down  ", "Left  ", "Right ", "       ", "Delete", "Done  ", NULL};
-static const char* const MetersMovingKeys[] = {"Space", "Enter", "Up", "Dn", "<-", "->", "  ", "Del", "F10"};
-static const int MetersMovingEvents[] = {' ', 13, KEY_UP, KEY_DOWN, KEY_LEFT, KEY_RIGHT, ERR, KEY_DC, KEY_F(10)};
+// Moving bar: F4=Style  F5=MoveLt  F6=MoveRt  F7=MoveUp  F8=MoveDn  F9=Delete  F10=Done
+static const char* const MetersMovingFunctions[] = {"      ", "      ", "      ", "Style ", "MoveLt", "MoveRt", "MoveUp", "MoveDn", "Delete", "Done  ", NULL};
 static FunctionBar* Meters_movingBar = NULL;
 
 void MetersPanel_cleanup(void) {
@@ -152,6 +151,7 @@ static HandlerResult MetersPanel_eventHandler(Panel* super, int ch) {
          Panel_moveSelectedDown(super);
          result = HANDLED;
          break;
+      case KEY_F(6):
       case KEY_RIGHT:
          sideMove = moveToNeighbor(this, this->rightNeighbor, selected);
          if (this->moving && !sideMove) {
@@ -161,6 +161,7 @@ static HandlerResult MetersPanel_eventHandler(Panel* super, int ch) {
          // if user is free, don't set HANDLED;
          // let ScreenManager handle focus.
          break;
+      case KEY_F(5):
       case KEY_LEFT:
          sideMove = moveToNeighbor(this, this->leftNeighbor, selected);
          if (this->moving && !sideMove) {
@@ -209,9 +210,9 @@ MetersPanel* MetersPanel_new(Settings* settings, const char* header, Vector* met
    MetersPanel* this = AllocThis(MetersPanel);
    Panel* super = &this->super;
 
-   FunctionBar* fuBar = FunctionBar_new(MetersFunctions, MetersKeys, MetersEvents);
+   FunctionBar* fuBar = FunctionBar_new(MetersFunctions, NULL, NULL);
    if (!Meters_movingBar) {
-      Meters_movingBar = FunctionBar_new(MetersMovingFunctions, MetersMovingKeys, MetersMovingEvents);
+      Meters_movingBar = FunctionBar_new(MetersMovingFunctions, NULL, NULL);
    }
    Panel_init(super, 1, 1, 1, 1, Class(ListItem), true, fuBar);
 

--- a/Panel.h
+++ b/Panel.h
@@ -32,6 +32,7 @@ typedef enum HandlerResult_ {
 } HandlerResult;
 
 #define EVENT_SET_SELECTED (-1)
+#define EVENT_PANEL_LOST_FOCUS (-2)
 
 #define EVENT_HEADER_CLICK(x_) (-10000 + (x_))
 #define EVENT_IS_HEADER_CLICK(ev_) ((ev_) >= -10000 && (ev_) <= -9000)

--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -299,6 +299,9 @@ void ScreenManager_run(ScreenManager* this, Panel** lastFocus, int* lastKey, con
                         } else if (mevent.y > panel->y && mevent.y <= panel->y + panel->h) {
                            ch = KEY_MOUSE;
                            if (panel == panelFocus || this->allowFocusChange) {
+                              if (i != focus && Panel_eventHandlerFn(panelFocus)) {
+                                 Panel_eventHandler(panelFocus, EVENT_PANEL_LOST_FOCUS);
+                              }
                               focus = i;
                               panelFocus = panel;
                               const Object* oldSelection = Panel_getSelected(panel);
@@ -393,6 +396,10 @@ void ScreenManager_run(ScreenManager* this, Panel** lastFocus, int* lastKey, con
             break;
          }
 
+         if (focus > 0 && Panel_eventHandlerFn(panelFocus)) {
+            Panel_eventHandler(panelFocus, EVENT_PANEL_LOST_FOCUS);
+         }
+
 tryLeft:
          if (focus > 0) {
             focus--;
@@ -412,6 +419,10 @@ tryLeft:
          }
          if (!this->allowFocusChange) {
             break;
+         }
+
+         if ((size_t)focus < this->panelCount - 1 && Panel_eventHandlerFn(panelFocus)) {
+            Panel_eventHandler(panelFocus, EVENT_PANEL_LOST_FOCUS);
          }
 
 tryRight:

--- a/ScreenTabsPanel.c
+++ b/ScreenTabsPanel.c
@@ -226,6 +226,14 @@ static HandlerResult ScreenNamesPanel_eventHandlerRenaming(Panel* super, int ch)
    }
 
    switch (ch) {
+      case EVENT_SET_SELECTED: {
+         ListItem* item = (ListItem*) Panel_getSelected(super);
+         if (item != this->renamingItem)
+            goto renameFinish;
+         break;
+      }
+      case EVENT_PANEL_LOST_FOCUS:
+         goto renameFinish;
       case 127:
       case KEY_BACKSPACE:
          if (this->cursor > 0) {
@@ -243,13 +251,16 @@ static HandlerResult ScreenNamesPanel_eventHandlerRenaming(Panel* super, int ch)
          if (!item)
             break;
          assert(item == this->renamingItem);
+renameFinish:
+         if (!this->renamingItem)
+            break;
          free(this->saved);
-         item->value = xStrdup(this->buffer);
-         this->renamingItem = NULL;
+         this->renamingItem->value = xStrdup(this->buffer);
          super->cursorOn = false;
          Panel_setSelectionColor(super, PANEL_SELECTION_FOCUS);
          Panel_setDefaultBar(super);
-         renameScreenSettings(this, item);
+         renameScreenSettings(this, (ListItem*) this->renamingItem);
+         this->renamingItem = NULL;
          break;
       }
       case 27: // Esc

--- a/ScreensPanel.c
+++ b/ScreensPanel.c
@@ -60,6 +60,17 @@ void ScreensPanel_cleanup(void) {
    }
 }
 
+static void ScreensPanel_cancelMoving(ScreensPanel* this) {
+   Panel* super = &this->super;
+   for (int i = 0; i < Panel_size(super); i++) {
+      ListItem* item = (ListItem*) Panel_get(super, i);
+      if (item)
+         item->moving = false;
+   }
+   this->moving = false;
+   Panel_setSelectionColor(super, PANEL_SELECTION_FOCUS);
+}
+
 static void ScreensPanel_delete(Object* object) {
    Panel* super = (Panel*) object;
 
@@ -88,6 +99,14 @@ static HandlerResult ScreensPanel_eventHandlerRenaming(Panel* super, int ch) {
    }
 
    switch (ch) {
+      case EVENT_SET_SELECTED: {
+         ListItem* item = (ListItem*) Panel_getSelected(super);
+         if (item != this->renamingItem)
+            goto renameFinish;
+         break;
+      }
+      case EVENT_PANEL_LOST_FOCUS:
+         goto renameFinish;
       case 127:
       case KEY_BACKSPACE:
          if (this->cursor > 0) {
@@ -105,8 +124,11 @@ static HandlerResult ScreensPanel_eventHandlerRenaming(Panel* super, int ch) {
          if (!item)
             break;
          assert(item == this->renamingItem);
+renameFinish:
+         if (!this->renamingItem)
+            break;
          free(this->saved);
-         item->value = xStrdup(this->buffer);
+         this->renamingItem->value = xStrdup(this->buffer);
          this->renamingItem = NULL;
          this->renamingNewItem = false;
          super->cursorOn = false;
@@ -210,17 +232,39 @@ static HandlerResult ScreensPanel_eventHandlerNormal(Panel* super, int ch) {
       case '\n':
       case '\r':
       case KEY_ENTER:
-      case KEY_MOUSE:
-      case KEY_RECLICK: {
-         this->moving = !this->moving;
-         Panel_setSelectionColor(super, this->moving ? PANEL_SELECTION_FOLLOW : PANEL_SELECTION_FOCUS);
-         ListItem* item = (ListItem*) Panel_getSelected(super);
-         if (item)
-            item->moving = this->moving;
+         if (this->moving) {
+            ScreensPanel_cancelMoving(this);
+         } else {
+            this->moving = true;
+            Panel_setSelectionColor(super, PANEL_SELECTION_FOLLOW);
+            ListItem* item = (ListItem*) Panel_getSelected(super);
+            if (item)
+               item->moving = true;
+         }
          result = HANDLED;
          break;
-      }
+      case KEY_MOUSE:
+         if (this->moving) {
+            /* Single click while in move mode: cancel move mode */
+            ScreensPanel_cancelMoving(this);
+            result = HANDLED;
+         }
+         /* else: just select the item, do not enter move mode */
+         break;
+      case KEY_RECLICK:
+         /* Double click: start renaming */
+         this->renamingNewItem = false;
+         startRenaming(super);
+         result = HANDLED;
+         break;
       case EVENT_SET_SELECTED:
+         if (this->moving)
+            ScreensPanel_cancelMoving(this);
+         result = HANDLED;
+         break;
+      case EVENT_PANEL_LOST_FOCUS:
+         if (this->moving)
+            ScreensPanel_cancelMoving(this);
          result = HANDLED;
          break;
       case KEY_NPAGE:
@@ -272,7 +316,8 @@ static HandlerResult ScreensPanel_eventHandlerNormal(Panel* super, int ch) {
          result = HANDLED;
          break;
       case KEY_F(9):
-      //case KEY_DC:
+      case KEY_DC:
+      case KEY_DEL_MAC:
          if (Panel_size(super) > 1)
             Panel_remove(super, selected);
          shouldRebuildArray = true;


### PR DESCRIPTION
Fixes: #1760
Improves over: #1783

Extends the events with a lost focus one and makes the screens, meters and columns editing handle that properly.
Since we have that consistent then, I spliced out the second commit to also make the function bar consistent between the meters and the screens setup. The meters one was a bit out-of-the-usual. The shortcuts (space to change meter mode ("style"), enter to accept, cursor keys to move) all still work.

When playing around in Setup for hours the UI inconsistency ... hurts ... so I fixed that quite early but I want to give you all the bikeshedding options :smile:. Commit #1 builds fine separately.

Assisted-by: Microsoft Copilot/Claude Sonnet 4.6
