### PR TITLE
Track oldFocus correctly in ScreensPanel

### DIFF
--- a/ScreensPanel.c
+++ b/ScreensPanel.c
@@ -224,7 +224,7 @@ static HandlerResult ScreensPanel_eventHandlerNormal(Panel* super, int ch) {
    ScreensPanel* const this = (ScreensPanel*) super;
 
    int selected = Panel_getSelectedIndex(super);
-   ScreenListItem* oldFocus = (ScreenListItem*) Panel_getSelected(super);
+   ScreenListItem* oldFocus = this->prevSelected;
    bool shouldRebuildArray = false;
    HandlerResult result = IGNORED;
 
@@ -339,6 +339,8 @@ static HandlerResult ScreensPanel_eventHandlerNormal(Panel* super, int ch) {
       result = HANDLED;
    }
 
+   this->prevSelected = newFocus;
+
    if (shouldRebuildArray)
       rebuildSettingsArray(super, selected);
    if (result == HANDLED)
@@ -385,6 +387,7 @@ ScreensPanel* ScreensPanel_new(Settings* settings) {
    this->renamingNewItem = false;
    super->cursorOn = false;
    this->cursor = 0;
+   this->prevSelected = NULL;
    Panel_setHeader(super, "Screens");
 
    for (unsigned int i = 0; i < settings->nScreens; i++) {
@@ -392,6 +395,7 @@ ScreensPanel* ScreensPanel_new(Settings* settings) {
       char* name = ss->heading;
       Panel_add(super, (Object*) ScreenListItem_new(name, ss));
    }
+   this->prevSelected = (ScreenListItem*) Panel_getSelected(super);
    return this;
 }
 

--- a/ScreensPanel.h
+++ b/ScreensPanel.h
@@ -36,6 +36,7 @@ typedef struct ScreensPanel_ {
    size_t cursor;
    ListItem* renamingItem;
    bool renamingNewItem;
+   struct ScreenListItem_* prevSelected;
 } ScreensPanel;
 
 typedef struct ScreenListItem_ {


### PR DESCRIPTION
Fixes: #1930

Track the previously selected ScreenListItem_ within ScreensPanel_ and use that for oldFocus so the event handler does not always come too late to the party.