### PR TITLE
Implement line editor for Search, Filter and (re)naming Screens

### DIFF
--- a/CRT.c
+++ b/CRT.c
@@ -1239,6 +1239,11 @@ IGNORE_WCASTQUAL_BEGIN
       define_key("\033[14;2~", KEY_F(15));
       define_key("\033[17;2~", KEY_F(18));
       define_key("\033[Z", KEY_SHIFT_TAB);
+
+      /* These are a bit of a gamble: */
+      define_key("\033[1;5D", KEY_CTRL_LEFT);
+      define_key("\033[1;5C", KEY_CTRL_RIGHT);
+
       char sequence[3] = "\033a";
       for (char c = 'a'; c <= 'z'; c++) {
          sequence[1] = c;

--- a/CRT.h
+++ b/CRT.h
@@ -181,12 +181,15 @@ void CRT_handleSIGSEGV(int signal) ATTR_NORETURN;
 #define KEY_FOCUS_IN   (KEY_MAX + 'I')
 #define KEY_FOCUS_OUT  (KEY_MAX + 'O')
 #define KEY_DEL_MAC    127
+#define KEY_CTRL_LEFT  KEY_SLEFT   // we treat them the same
+#define KEY_CTRL_RIGHT KEY_SRIGHT  // we treat them, yup, the same
+
 #ifndef PADPLUS
-# define KEY_PADPLUS    583
-# define KEY_PADMINUS   588
+# define KEY_PADPLUS   583
+# define KEY_PADMINUS  588
 #else
-# define KEY_PADPLUS    PADPLUS
-# define KEY_PADMINUS   PADMINUS
+# define KEY_PADPLUS   PADPLUS
+# define KEY_PADMINUS  PADMINUS
 #endif
 
 extern char CRT_degreeSign[];

--- a/CommandLine.c
+++ b/CommandLine.c
@@ -425,6 +425,20 @@ int CommandLine_run(int argc, char** argv) {
    if (flags.commFilter)
       setCommFilter(&state, &(flags.commFilter));
 
+   /* Set up shared search/filter history, stored next to the config file */
+   const char* rcPath = settings->filename;
+   const char* lastSlash = strrchr(rcPath, '/');
+   char historyPath[PATH_MAX];
+   if (lastSlash) {
+      int dirLen = (int)(lastSlash - rcPath + 1);
+      xSnprintf(historyPath, sizeof(historyPath), "%.*s" "htop_history", dirLen, rcPath);
+   } else {
+   /* no history file saved unless we have a sane rcPath */
+      historyPath[0] = '\0';
+   }
+
+   IncSet_setHistoryFile(panel->inc, historyPath);
+
    ScreenManager* scr = ScreenManager_new(header, host, &state, true);
    ScreenManager_add(scr, (Panel*) panel, -1);
 

--- a/FunctionBar.c
+++ b/FunctionBar.c
@@ -96,7 +96,6 @@ int FunctionBar_draw(const FunctionBar* this) {
 }
 
 int FunctionBar_drawExtra(const FunctionBar* this, const char* buffer, int attr, bool setCursor) {
-   int cursorX = 0;
    attrset(CRT_colors[FUNCTION_BAR]);
    mvhline(LINES - 1, 0, ' ', COLS);
    int x = 0;
@@ -109,6 +108,9 @@ int FunctionBar_drawExtra(const FunctionBar* this, const char* buffer, int attr,
       mvaddstr(LINES - 1, x, this->functions[i]);
       x += strlen(this->functions[i]);
    }
+
+   /* cursorX: position after function keys (= start of input field) */
+   int cursorX = x;
 
    if (buffer) {
       if (attr == -1) {
@@ -144,6 +146,16 @@ void FunctionBar_append(const char* buffer, int attr) {
    attrset(CRT_colors[RESET_COLOR]);
 
    currentLen += strlen(buffer) + 1;
+}
+
+int FunctionBar_getWidth(const FunctionBar* this) {
+   int x = 0;
+   for (size_t i = 0; this->functions[i]; i++) {
+      assert(i < FUNCTIONBAR_MAXEVENTS);
+      x += strlen(this->keys.constKeys[i]);
+      x += strlen(this->functions[i]);
+   }
+   return x;
 }
 
 int FunctionBar_synthesizeEvent(const FunctionBar* this, int pos) {

--- a/FunctionBar.h
+++ b/FunctionBar.h
@@ -35,6 +35,8 @@ int FunctionBar_drawExtra(const FunctionBar* this, const char* buffer, int attr,
 
 void FunctionBar_append(const char* buffer, int attr);
 
+int FunctionBar_getWidth(const FunctionBar* this);
+
 int FunctionBar_synthesizeEvent(const FunctionBar* this, int pos);
 
 #endif

--- a/History.c
+++ b/History.c
@@ -1,0 +1,152 @@
+/*
+htop - History.c
+(C) 2004-2026 htop dev team
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include "config.h" // IWYU pragma: keep
+
+#include "History.h"
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "Macros.h"
+#include "XUtils.h"
+
+
+static void History_load(History* this) {
+   if (!this->filename)
+      return;
+   FILE* fp = fopen(this->filename, "r");
+   if (!fp)
+      return;
+
+   char line[LINEEDITOR_MAX + 2];
+   while (fgets(line, sizeof(line), fp)) {
+      size_t len = strlen(line);
+      /* strip trailing newline */
+      while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r'))
+         line[--len] = '\0';
+      if (len == 0)
+         continue;
+
+      History_add(this, line);
+   }
+   fclose(fp);
+}
+
+History* History_new(const char* filename) {
+   History* this = xCalloc(1, sizeof(History));
+   this->capacity = 64;
+   this->entries = xCalloc(this->capacity, sizeof(char*));
+   this->count = 0;
+   this->position = 0;
+   this->saved[0] = '\0';
+   this->filename = filename ? xStrdup(filename) : NULL;
+
+   if (this->filename)
+      History_load(this);
+
+   this->position = this->count;
+
+   return this;
+}
+
+void History_delete(History* this) {
+   for (size_t i = 0; i < this->count; i++)
+      free(this->entries[i]);
+   free(this->entries);
+   free(this->filename);
+   free(this);
+}
+
+void History_save(const History* this) {
+   if (!this->filename)
+      return;
+   /* Settings_write writes things via a temp file & rename, we do it less robust but faster here: */
+   int fd = open(this->filename, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+   if (fd == -1)
+      return;
+   FILE* fp = fdopen(fd, "w");
+   if (!fp) {
+      close(fd); // fd not consumed on failure, so close it
+      return;
+   }
+   size_t start = (this->count > HISTORY_MAX_ENTRIES) ? this->count - HISTORY_MAX_ENTRIES : 0;
+   for (size_t i = start; i < this->count; i++)
+      fprintf(fp, "%s\n", this->entries[i]);
+   fclose(fp);
+}
+
+void History_add(History* this, const char* entry) {
+   if (!entry || entry[0] == '\0')
+      return;
+
+   /* Deduplicate: remove previous identical entry if present */
+   for (size_t i = 0; i < this->count; i++) {
+      if (String_eq(this->entries[i], entry)) {
+         free(this->entries[i]);
+         memmove(this->entries + i, this->entries + i + 1, (this->count - i - 1) * sizeof(char*));
+         this->count--;
+         break;
+      }
+   }
+
+   /* Grow array if needed */
+   if (this->count >= this->capacity) {
+      if (this->capacity < HISTORY_MAX_ENTRIES) {
+         this->capacity = MINIMUM(this->capacity * 2, (size_t)HISTORY_MAX_ENTRIES);
+         this->entries = xReallocArray(this->entries, this->capacity, sizeof(char*));
+      } else {
+         /* Drop oldest entry */
+         free(this->entries[0]);
+         memmove(this->entries, this->entries + 1, (this->count - 1) * sizeof(char*));
+         this->count--;
+      }
+   }
+
+   this->entries[this->count++] = xStrdup(entry);
+
+   /* Reset position to "at new input" */
+   this->position = this->count;
+   this->saved[0] = '\0';
+}
+
+const char* History_navigate(History* this, LineEditor* editor, bool back) {
+   if (this->count == 0)
+      return NULL;
+
+   if (back) {
+      /* Going back (up arrow) */
+      if (this->position == this->count) {
+         /* Save current editor content before entering history */
+         strncpy(this->saved, LineEditor_getText(editor), LINEEDITOR_MAX);
+         this->saved[LINEEDITOR_MAX] = '\0';
+      }
+      if (this->position > 0) {
+         this->position--;
+         return this->entries[this->position];
+      }
+      return NULL; /* Already at oldest entry */
+   } else {
+      /* Going forward (down arrow) */
+      if (this->position >= this->count)
+         return NULL; /* Already at newest */
+      this->position++;
+      if (this->position == this->count) {
+         /* Restore saved input */
+         return this->saved;
+      }
+      return this->entries[this->position];
+   }
+}
+
+void History_resetPosition(History* this) {
+   this->position = this->count;
+   this->saved[0] = '\0';
+}

--- a/History.h
+++ b/History.h
@@ -1,0 +1,48 @@
+#ifndef HEADER_History
+#define HEADER_History
+/*
+htop - History.h
+(C) 2004-2026 htop dev team
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "LineEditor.h"
+
+
+#define HISTORY_MAX_ENTRIES 512
+
+typedef struct History_ {
+   char** entries;    /* array of history strings, oldest first */
+   size_t count;      /* current number of entries */
+   size_t capacity;   /* allocated capacity */
+   size_t position;      /* current browse position: count = "at new input" */
+   char saved[LINEEDITOR_MAX + 1]; /* saved current input while browsing */
+   char* filename;    /* path to history file (may be NULL = no read / write) */
+} History;
+
+/* Create a new History, loading from the given file (may be NULL = init new history) */
+History* History_new(const char* filename);
+
+/* Free all resources */
+void History_delete(History* this);
+
+/* Add an entry to the history (deduplicates identical entries).
+   Resets the browse position to "at new input". */
+void History_add(History* this, const char* entry);
+
+/* Save history to file (noop if filename is NULL) */
+void History_save(const History* this);
+
+/* Navigate history: back=true goes to older entries, back=false goes to newer.
+   Saves/restores the current editor content as needed.
+   Returns the string to put in the editor, or NULL if already at the limit. */
+const char* History_navigate(History* this, LineEditor* editor, bool back);
+
+/* Reset browse position to "at new input" (discards saved input state) */
+void History_resetPosition(History* this);
+
+#endif

--- a/IncSet.c
+++ b/IncSet.c
@@ -9,11 +9,12 @@ in the source distribution for its full text.
 
 #include "IncSet.h"
 
-#include <ctype.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "CRT.h"
+#include "History.h"
+#include "LineEditor.h"
 #include "ListItem.h"
 #include "Object.h"
 #include "ProvideCurses.h"
@@ -21,8 +22,7 @@ in the source distribution for its full text.
 
 
 static void IncMode_reset(IncMode* mode) {
-   mode->index = 0;
-   mode->buffer[0] = 0;
+   LineEditor_reset(&mode->editor);
 }
 
 void IncSet_reset(IncSet* this, IncType type) {
@@ -31,9 +31,8 @@ void IncSet_reset(IncSet* this, IncType type) {
 
 void IncSet_setFilter(IncSet* this, const char* filter) {
    IncMode* mode = &this->modes[INC_FILTER];
-   size_t len = String_safeStrncpy(mode->buffer, filter, sizeof(mode->buffer));
-   mode->index = len;
-   this->filtering = true;
+   LineEditor_setText(&mode->editor, filter);
+   this->filtering = (filter && filter[0] != '\0');
 }
 
 static const char* const searchFunctions[] = {"Next  ", "Prev   ", "Cancel ", " Search: ", NULL};
@@ -44,6 +43,7 @@ static inline void IncMode_initSearch(IncMode* search) {
    memset(search, 0, sizeof(IncMode));
    search->bar = FunctionBar_new(searchFunctions, searchKeys, searchEvents);
    search->isFilter = false;
+   LineEditor_init(&search->editor);
 }
 
 static const char* const filterFunctions[] = {"Done  ", "Clear ", " Filter: ", NULL};
@@ -54,6 +54,7 @@ static inline void IncMode_initFilter(IncMode* filter) {
    memset(filter, 0, sizeof(IncMode));
    filter->bar = FunctionBar_new(filterFunctions, filterKeys, filterEvents);
    filter->isFilter = true;
+   LineEditor_init(&filter->editor);
 }
 
 static inline void IncMode_done(IncMode* mode) {
@@ -68,21 +69,35 @@ IncSet* IncSet_new(FunctionBar* bar) {
    this->defaultBar = bar;
    this->filtering = false;
    this->found = false;
+   this->history = NULL;
    return this;
 }
 
 void IncSet_delete(IncSet* this) {
    IncMode_done(&(this->modes[0]));
    IncMode_done(&(this->modes[1]));
+   if (this->history)
+      History_delete(this->history);
    free(this);
 }
 
-static void updateWeakPanel(const IncSet* this, Panel* panel, Vector* lines) {
+void IncSet_setHistoryFile(IncSet* this, const char* filename) {
+   if (this->history)
+      History_delete(this->history);
+   this->history = History_new(filename);
+}
+
+void IncSet_saveHistory(const IncSet* this) {
+   if (this->history)
+      History_save(this->history);
+}
+
+static void updateWeakPanel(IncSet* this, Panel* panel, Vector* lines) {
    const Object* selected = Panel_getSelected(panel);
    Panel_prune(panel);
    if (this->filtering) {
       int n = 0;
-      const char* incFilter = this->modes[INC_FILTER].buffer;
+      const char* incFilter = LineEditor_getText(&this->modes[INC_FILTER].editor);
       for (int i = 0; i < Vector_size(lines); i++) {
          ListItem* line = (ListItem*)Vector_get(lines, i);
          if (String_contains_i(line->value, incFilter, true)) {
@@ -105,10 +120,10 @@ static void updateWeakPanel(const IncSet* this, Panel* panel, Vector* lines) {
    }
 }
 
-static bool search(const IncSet* this, Panel* panel, IncMode_GetPanelValue getPanelValue) {
+static bool search(IncSet* this, Panel* panel, IncMode_GetPanelValue getPanelValue) {
    int size = Panel_size(panel);
    for (int i = 0; i < size; i++) {
-      if (String_contains_i(getPanelValue(panel, i), this->active->buffer, true)) {
+      if (String_contains_i(getPanelValue(panel, i), LineEditor_getText(&this->active->editor), true)) {
          Panel_setSelected(panel, i);
          return true;
       }
@@ -122,6 +137,9 @@ void IncSet_activate(IncSet* this, IncType type, Panel* panel) {
    panel->currentBar = this->active->bar;
    panel->cursorOn = true;
    this->panel = panel;
+   /* Reset history browse position when starting a new search/filter */
+   if (this->history)
+      History_resetPosition(this->history);
    IncSet_drawBar(this, CRT_colors[FUNCTION_BAR]);
 }
 
@@ -132,7 +150,7 @@ static void IncSet_deactivate(IncSet* this, Panel* panel) {
    FunctionBar_draw(this->defaultBar);
 }
 
-static bool IncMode_find(const IncMode* mode, Panel* panel, IncMode_GetPanelValue getPanelValue, int step) {
+static bool IncMode_find(IncMode* mode, Panel* panel, IncMode_GetPanelValue getPanelValue, int step) {
    int size = Panel_size(panel);
    int here = Panel_getSelectedIndex(panel);
    int i = here;
@@ -148,7 +166,7 @@ static bool IncMode_find(const IncMode* mode, Panel* panel, IncMode_GetPanelValu
          return false;
       }
 
-      if (String_contains_i(getPanelValue(panel, i), mode->buffer, true)) {
+      if (String_contains_i(getPanelValue(panel, i), LineEditor_getText(&mode->editor), true)) {
          Panel_setSelected(panel, i);
          return true;
       }
@@ -163,68 +181,110 @@ bool IncSet_handleKey(IncSet* this, int ch, Panel* panel, IncMode_GetPanelValue 
    int size = Panel_size(panel);
    bool filterChanged = false;
    bool doSearch = true;
+
+   /* Mouse click in the function bar input field: place cursor */
+   if (ch == KEY_MOUSE_BAR_CLICK) {
+      int fieldStartX = FunctionBar_getWidth(mode->bar);
+      LineEditor_click(&mode->editor, panel->lastMouseBarClickX, fieldStartX);
+      IncSet_drawBar(this, CRT_colors[FUNCTION_BAR]);
+      return false;
+   }
+
    if (ch == KEY_F(3) || ch == KEY_F(15)) {
       if (size == 0)
          return true;
 
       IncMode_find(mode, panel, getPanelValue, ch == KEY_F(3) ? 1 : -1);
       doSearch = false;
-   } else if (0 < ch && ch < 255 && isprint((unsigned char)ch)) {
-      if (mode->index < INCMODE_MAX) {
-         mode->buffer[mode->index] = (char) ch;
-         mode->index++;
-         mode->buffer[mode->index] = 0;
-         if (mode->isFilter) {
-            filterChanged = true;
-            if (mode->index == 1) {
-               this->filtering = true;
+   } else if (ch == KEY_UP) {
+      /* History navigation: older entry */
+      if (this->history) {
+         const char* entry = History_navigate(this->history, &mode->editor, true);
+         if (entry) {
+            LineEditor_setText(&mode->editor, entry);
+            if (mode->isFilter) {
+               filterChanged = true;
+               this->filtering = (LineEditor_getText(&mode->editor)[0] != '\0');
             }
          }
+         doSearch = !mode->isFilter;
+      } else {
+         doSearch = false;
       }
-   } else if (ch == KEY_CTRL('U')) {
-      mode->index = 0;
-      mode->buffer[mode->index] = 0;
-      if (mode->isFilter) {
-         filterChanged = true;
-         this->filtering = false;
-      }
-   } else if (ch == KEY_BACKSPACE || ch == 127) {
-      if (mode->index > 0) {
-         mode->index--;
-         mode->buffer[mode->index] = 0;
-         if (mode->isFilter) {
-            filterChanged = true;
-            if (mode->index == 0) {
-               this->filtering = false;
-               IncMode_reset(mode);
+   } else if (ch == KEY_DOWN) {
+      /* History navigation: newer entry */
+      if (this->history) {
+         const char* entry = History_navigate(this->history, &mode->editor, false);
+         if (entry) {
+            LineEditor_setText(&mode->editor, entry);
+            if (mode->isFilter) {
+               filterChanged = true;
+               this->filtering = (LineEditor_getText(&mode->editor)[0] != '\0');
             }
          }
+         doSearch = !mode->isFilter;
       } else {
          doSearch = false;
       }
    } else if (ch == KEY_RESIZE) {
-      doSearch = (mode->index > 0);
-   } else {
-      if (mode->isFilter) {
-         filterChanged = true;
-         if (ch == 27) {
-            this->filtering = false;
-            IncMode_reset(mode);
+      doSearch = (LineEditor_getText(&mode->editor)[0] != '\0');
+   } else if (ch == 13 || ch == '\r' || ch == KEY_ENTER) {
+      /* Enter confirms: add to history and deactivate */
+      if (this->history) {
+         const char* text = LineEditor_getText(&mode->editor);
+         if (text[0] != '\0') {
+            History_add(this->history, text);
+            History_save(this->history);
          }
-      } else {
-         if (ch == 27) {
-            IncMode_reset(mode);
-         }
+         History_resetPosition(this->history);
+      }
+      if (!mode->isFilter) {
+         /* For search: reset buffer on Enter */
+         IncMode_reset(mode);
       }
       IncSet_deactivate(this, panel);
       doSearch = false;
+      filterChanged = mode->isFilter;
+   } else if (ch == 27) {
+      /* Esc aborts */
+      if (this->history)
+         History_resetPosition(this->history);
+      if (mode->isFilter) {
+         filterChanged = true;
+         this->filtering = false;
+         IncMode_reset(mode);
+      } else {
+         IncMode_reset(mode);
+      }
+      IncSet_deactivate(this, panel);
+      doSearch = false;
+   } else {
+      /* Try line editor first */
+      bool textChanged = LineEditor_handleKey(&mode->editor, ch);
+      if (textChanged) {
+         if (mode->isFilter) {
+            filterChanged = true;
+            const char* buf = LineEditor_getText(&mode->editor);
+            this->filtering = (buf[0] != '\0');
+         }
+      } else {
+         /* Key was a movement key (no text change) or unrecognized */
+         doSearch = false;
+      }
    }
-   if (doSearch) {
+
+   if (doSearch && LineEditor_getText(&mode->editor)[0] != '\0') {
       this->found = search(this, panel, getPanelValue);
    }
    if (filterChanged && lines) {
       updateWeakPanel(this, panel, lines);
    }
+
+   /* Redraw the bar to reflect cursor / scroll position changes */
+   if (this->active) {
+      IncSet_drawBar(this, CRT_colors[FUNCTION_BAR]);
+   }
+
    return filterChanged;
 }
 
@@ -237,7 +297,20 @@ void IncSet_drawBar(const IncSet* this, int attr) {
    if (this->active) {
       if (!this->active->isFilter && !this->found)
          attr = CRT_colors[FAILED_SEARCH];
-      int cursorX = FunctionBar_drawExtra(this->active->bar, this->active->buffer, attr, true);
+
+      /* Draw the function keys and get the start of the input field */
+      int fieldStartX = FunctionBar_drawExtra(this->active->bar, NULL, -1, false);
+
+      /* Update scroll so the cursor remains visible */
+      int fieldWidth = COLS - fieldStartX;
+      if (fieldWidth < 1) fieldWidth = 1;
+      LineEditor_updateScroll(&this->active->editor, fieldWidth);
+
+      /* Draw the visible portion of the input text */
+      int cursorX = LineEditor_draw(&this->active->editor, fieldStartX, fieldWidth, attr);
+
+      curs_set(1);
+
       this->panel->cursorY = LINES - 1;
       this->panel->cursorX = cursorX;
    } else {
@@ -247,7 +320,13 @@ void IncSet_drawBar(const IncSet* this, int attr) {
 
 int IncSet_synthesizeEvent(IncSet* this, int x) {
    if (this->active) {
-      return FunctionBar_synthesizeEvent(this->active->bar, x);
+      int ev = FunctionBar_synthesizeEvent(this->active->bar, x);
+      /* Click in the input area: synthesize a bar-click event */
+      if (ev == ERR && x >= FunctionBar_getWidth(this->active->bar)) {
+         this->panel->lastMouseBarClickX = x;
+         return KEY_MOUSE_BAR_CLICK;
+      }
+      return ev;
    } else {
       return FunctionBar_synthesizeEvent(this->defaultBar, x);
    }

--- a/IncSet.h
+++ b/IncSet.h
@@ -11,11 +11,10 @@ in the source distribution for its full text.
 #include <stddef.h>
 
 #include "FunctionBar.h"
+#include "History.h"
+#include "LineEditor.h"
 #include "Panel.h"
 #include "Vector.h"
-
-
-#define INCMODE_MAX 128
 
 typedef enum {
    INC_SEARCH = 0,
@@ -23,9 +22,8 @@ typedef enum {
 } IncType;
 
 typedef struct IncMode_ {
-   char buffer[INCMODE_MAX + 1];
+   LineEditor editor;
    FunctionBar* bar;
-   size_t index;
    bool isFilter;
 } IncMode;
 
@@ -36,10 +34,11 @@ typedef struct IncSet_ {
    FunctionBar* defaultBar;
    bool filtering;
    bool found;
+   History* history;  /* shared history for search and filter; may be NULL */
 } IncSet;
 
-static inline const char* IncSet_filter(const IncSet* this) {
-   return this->filtering ? this->modes[INC_FILTER].buffer : NULL;
+static inline const char* IncSet_filter(IncSet* this) {
+   return this->filtering ? LineEditor_getText(&this->modes[INC_FILTER].editor) : NULL;
 }
 
 void IncSet_setFilter(IncSet* this, const char* filter);
@@ -51,6 +50,13 @@ void IncSet_reset(IncSet* this, IncType type);
 IncSet* IncSet_new(FunctionBar* bar);
 
 void IncSet_delete(IncSet* this);
+
+/* Set the history file path (creates/loads history from the given file).
+   Call this after IncSet_new when the settings path is available. */
+void IncSet_setHistoryFile(IncSet* this, const char* filename);
+
+/* Save the history to disk (noop if no history file was set) */
+void IncSet_saveHistory(const IncSet* this);
 
 bool IncSet_handleKey(IncSet* this, int ch, Panel* panel, IncMode_GetPanelValue getPanelValue, Vector* lines);
 

--- a/LineEditor.c
+++ b/LineEditor.c
@@ -1,0 +1,243 @@
+/*
+htop - LineEditor.c
+(C) 2004-2026 htop dev team
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include "config.h" // IWYU pragma: keep
+
+#include "LineEditor.h"
+
+#include <ctype.h>
+#include <string.h>
+
+#include "CRT.h"
+#include "Panel.h"
+#include "ProvideCurses.h"
+
+
+void LineEditor_init(LineEditor* this) {
+   LineEditor_initWithMax(this, LINEEDITOR_MAX);
+}
+
+void LineEditor_initWithMax(LineEditor* this, size_t maxLen) {
+   this->buffer[0] = '\0';
+   this->len = 0;
+   this->cursor = 0;
+   this->scroll = 0;
+   this->maxLen = (maxLen > 0 && maxLen <= LINEEDITOR_MAX) ? maxLen : LINEEDITOR_MAX;
+}
+
+void LineEditor_reset(LineEditor* this) {
+   this->buffer[0] = '\0';
+   this->len = 0;
+   this->cursor = 0;
+   this->scroll = 0;
+}
+
+void LineEditor_setText(LineEditor* this, const char* text) {
+   if (!text)
+      text = "";
+   size_t copyLen = this->maxLen;
+   strncpy(this->buffer, text, copyLen);
+   this->buffer[copyLen] = '\0';
+   this->len = strnlen(this->buffer, this->maxLen);
+   this->cursor = this->len;
+   this->scroll = 0;
+}
+
+/* Move cursor left by one character */
+static inline void moveCursorLeft(LineEditor* this) {
+   if (this->cursor > 0)
+      this->cursor--;
+}
+
+/* Move cursor right by one character */
+static inline void moveCursorRight(LineEditor* this) {
+   if (this->cursor < this->len)
+      this->cursor++;
+}
+
+/* Move cursor to the previous word boundary (Ctrl+Left / word-left) */
+static void moveCursorWordLeft(LineEditor* this) {
+   size_t pos = this->cursor;
+   /* skip whitespace before cursor */
+   while (pos > 0 && isspace((unsigned char)this->buffer[pos - 1]))
+      pos--;
+   /* skip non-whitespace (the word itself) */
+   while (pos > 0 && !isspace((unsigned char)this->buffer[pos - 1]))
+      pos--;
+   this->cursor = pos;
+}
+
+/* Move cursor to the next word boundary (Ctrl+Right / word-right) */
+static void moveCursorWordRight(LineEditor* this) {
+   size_t pos = this->cursor;
+   size_t len = this->len;
+   /* skip non-whitespace */
+   while (pos < len && !isspace((unsigned char)this->buffer[pos]))
+      pos++;
+   /* skip whitespace */
+   while (pos < len && isspace((unsigned char)this->buffer[pos]))
+      pos++;
+   this->cursor = pos;
+}
+
+/* Delete the character before cursor (Backspace) */
+static bool deleteCharBefore(LineEditor* this) {
+   if (this->cursor == 0)
+      return false;
+   size_t pos = this->cursor - 1;
+   memmove(this->buffer + pos, this->buffer + this->cursor, this->len - this->cursor + 1);
+   this->len--;
+   this->cursor = pos;
+   return true;
+}
+
+/* Delete the character at cursor (Delete) */
+static bool deleteCharAt(LineEditor* this) {
+   if (this->cursor >= this->len)
+      return false;
+   memmove(this->buffer + this->cursor, this->buffer + this->cursor + 1, this->len - this->cursor);
+   this->len--;
+   return true;
+}
+
+/* Insert a printable character at cursor */
+static bool insertChar(LineEditor* this, char ch) {
+   if (this->len >= this->maxLen)
+      return false;
+   memmove(this->buffer + this->cursor + 1, this->buffer + this->cursor, this->len - this->cursor + 1);
+   this->buffer[this->cursor] = ch;
+   this->cursor++;
+   this->len++;
+   return true;
+}
+
+bool LineEditor_handleKey(LineEditor* this, int ch) {
+   switch (ch) {
+      case KEY_LEFT:
+      case KEY_CTRL('B'):
+         moveCursorLeft(this);
+         return false;
+
+      case KEY_RIGHT:
+      case KEY_CTRL('F'):
+         moveCursorRight(this);
+         return false;
+
+      case KEY_HOME:
+      case KEY_CTRL('A'):
+         this->cursor = 0;
+         return false;
+
+      case KEY_END:
+      case KEY_CTRL('E'):
+         this->cursor = this->len;
+         return false;
+
+      case KEY_SLEFT:      /* Shift+Left (ncurses stock) and Ctrl+Left (htop home grown) */
+         moveCursorWordLeft(this);
+         return false;
+
+      case KEY_SRIGHT:     /* Shift+Right (ncurses stock) and Ctrl+Right (htop home grown) */
+         moveCursorWordRight(this);
+         return false;
+
+      case KEY_DC: /* Delete */
+         return deleteCharAt(this);
+
+      case KEY_BACKSPACE:
+      case 127: /* DEL / Backspace in some terminals */
+         return deleteCharBefore(this);
+
+      case KEY_CTRL('W'): {
+         /* Delete word before cursor (like bash Ctrl-W) */
+         size_t end = this->cursor;
+         /* skip whitespace before cursor */
+         while (this->cursor > 0 && isspace((unsigned char)this->buffer[this->cursor - 1]))
+            this->cursor--;
+         /* skip non-whitespace */
+         while (this->cursor > 0 && !isspace((unsigned char)this->buffer[this->cursor - 1]))
+            this->cursor--;
+         if (this->cursor == end)
+            return false;
+         size_t deleted = end - this->cursor;
+         memmove(this->buffer + this->cursor, this->buffer + end, this->len - end + 1);
+         this->len -= deleted;
+         return true;
+      }
+
+      case KEY_CTRL('K'):
+         /* Delete from cursor to end of line */
+         if (this->cursor >= this->len)
+            return false;
+         this->buffer[this->cursor] = '\0';
+         this->len = this->cursor;
+         return true;
+
+      case KEY_CTRL('U'):
+         /* Delete from start of line to cursor */
+         if (this->cursor == 0)
+            return false;
+         memmove(this->buffer, this->buffer + this->cursor, this->len - this->cursor + 1);
+         this->len -= this->cursor;
+         this->cursor = 0;
+         return true;
+
+      default:
+         if (ch > 0 && ch < 256 && isprint((unsigned char)ch)) {
+            return insertChar(this, (char)ch);
+         }
+         return false;
+   }
+}
+
+void LineEditor_updateScroll(LineEditor* this, int fieldWidth) {
+   if (fieldWidth <= 0)
+      return;
+   size_t fw = (size_t)fieldWidth;
+   /* Ensure cursor is visible */
+   if (this->cursor < this->scroll) {
+      this->scroll = this->cursor;
+   } else if (this->cursor >= this->scroll + fw) {
+      this->scroll = this->cursor - fw + 1;
+   }
+}
+
+int LineEditor_draw(LineEditor* this, int startX, int fieldWidth, int attr) {
+   if (attr == -1) {
+      attrset(CRT_colors[FUNCTION_BAR]);
+   } else {
+      attrset(attr);
+   }
+
+   /* Display the visible portion of the buffer */
+   const char* visibleStart = this->buffer + this->scroll;
+   int visibleLen = (int)this->len - (int)this->scroll;
+   if (visibleLen < 0)
+      visibleLen = 0;
+   if (visibleLen > fieldWidth)
+      visibleLen = fieldWidth;
+
+   mvaddnstr(LINES - 1, startX, visibleStart, visibleLen);
+
+   /* Pad remaining field with spaces */
+   for (int i = visibleLen; i < fieldWidth; i++) {
+      mvaddch(LINES - 1, startX + i, ' ');
+   }
+
+   int cursorX = startX + (int)(this->cursor - this->scroll);
+   return cursorX;
+}
+
+void LineEditor_click(LineEditor* this, int clickX, int fieldStartX) {
+   int offset = clickX - fieldStartX;
+   if (offset < 0)
+      offset = 0;
+   size_t newCursor = this->scroll + (size_t)offset;
+   if (newCursor > this->len)
+      newCursor = this->len;
+   this->cursor = newCursor;
+}

--- a/LineEditor.h
+++ b/LineEditor.h
@@ -1,0 +1,62 @@
+#ifndef HEADER_LineEditor
+#define HEADER_LineEditor
+/*
+htop - LineEditor.h
+(C) 2004-2026 htop dev team
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include <stdbool.h>
+#include <stddef.h>
+
+
+#define LINEEDITOR_MAX 128
+
+typedef struct LineEditor_ {
+   char buffer[LINEEDITOR_MAX + 1];
+   size_t len;        /* current text length */
+   size_t cursor;     /* cursor byte position (0..len) */
+   size_t scroll;     /* display scroll offset */
+   size_t maxLen;     /* maximum allowed input length (0 = use LINEEDITOR_MAX) */
+} LineEditor;
+
+/* Initialize a LineEditor with default max length */
+void LineEditor_init(LineEditor* this);
+
+/* Initialize a LineEditor with a custom maximum length */
+void LineEditor_initWithMax(LineEditor* this, size_t maxLen);
+
+/* Reset the editor to empty content */
+void LineEditor_reset(LineEditor* this);
+
+/* Set the buffer content and move cursor to the end */
+void LineEditor_setText(LineEditor* this, const char* text);
+
+/* Get a pointer to the current buffer content */
+static inline char* LineEditor_getText(LineEditor* this) {
+   return this->buffer;
+}
+
+/* Get current cursor position */
+static inline size_t LineEditor_getCursor(LineEditor* this) {
+   return this->cursor;
+}
+
+/* Process a keypress; returns true if the text content changed */
+bool LineEditor_handleKey(LineEditor* this, int ch);
+
+/* Update scroll offset so cursor is visible in a field of given display width.
+   Should be called before drawing whenever the cursor may have moved. */
+void LineEditor_updateScroll(LineEditor* this, int fieldWidth);
+
+/* Draw the visible portion of the buffer starting at screen column startX,
+   for a field of fieldWidth columns, using the given ncurses attribute.
+   Returns the screen X position where the cursor should be placed. */
+int LineEditor_draw(LineEditor* this, int startX, int fieldWidth, int attr);
+
+/* Handle a mouse click at screen column clickX, given that the field starts
+   at screen column fieldStartX. Moves the cursor to the appropriate position. */
+void LineEditor_click(LineEditor* this, int clickX, int fieldStartX);
+
+#endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -55,8 +55,10 @@ myhtopsources = \
 	Header.c \
 	HeaderOptionsPanel.c \
 	HostnameMeter.c \
+	History.c \
 	IncSet.c \
 	InfoScreen.c \
+	LineEditor.c \
 	ListItem.c \
 	LoadAverageMeter.c \
 	Machine.c \
@@ -122,8 +124,10 @@ myhtopheaders = \
 	HeaderLayout.h \
 	HeaderOptionsPanel.h \
 	HostnameMeter.h \
+	History.h \
 	IncSet.h \
 	InfoScreen.h \
+	LineEditor.h \
 	ListItem.h \
 	LoadAverageMeter.h \
 	Machine.h \

--- a/Panel.h
+++ b/Panel.h
@@ -76,6 +76,7 @@ struct Panel_ {
    bool needsRedraw;
    bool cursorOn;
    bool wasFocus;
+   int lastMouseBarClickX; /* X position of last mouse click on function bar (LINES-1) */
    FunctionBar* currentBar;
    FunctionBar* defaultBar;
    RichString header;
@@ -85,6 +86,10 @@ struct Panel_ {
 #define Panel_setDefaultBar(this_) do { (this_)->currentBar = (this_)->defaultBar; } while (0)
 
 #define KEY_CTRL(l) ((l)-'A'+1)
+
+/* Synthetic event: mouse click in the function-bar input field.
+   When set, Panel.lastMouseBarClickX holds the screen X of the click. */
+#define KEY_MOUSE_BAR_CLICK  (KEY_MAX + 50)
 
 extern const PanelClass Panel_class;
 

--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -286,6 +286,12 @@ void ScreenManager_run(ScreenManager* this, Panel** lastFocus, int* lastKey, con
             if (mevent.bstate & BUTTON1_RELEASED) {
                if (mevent.y == LINES - 1) {
                   ch = FunctionBar_synthesizeEvent(panelFocus->currentBar, mevent.x);
+                  /* When the panel is in cursor-input mode and the click landed past
+                     the function keys (in the text input area), signal a bar click. */
+                  if (ch == ERR && panelFocus->cursorOn) {
+                     panelFocus->lastMouseBarClickX = mevent.x;
+                     ch = KEY_MOUSE_BAR_CLICK;
+                  }
                } else {
                   for (size_t i = 0; i < this->panelCount; i++) {
                      Panel* panel = (Panel*) Vector_get(this->panels, i);

--- a/ScreenTabsPanel.c
+++ b/ScreenTabsPanel.c
@@ -18,6 +18,7 @@ in the source distribution for its full text.
 #include "CRT.h"
 #include "FunctionBar.h"
 #include "Hashtable.h"
+#include "LineEditor.h"
 #include "Macros.h"
 #include "ProvideCurses.h"
 #include "Settings.h"
@@ -192,7 +193,7 @@ static void ScreenNamesPanel_delete(Object* object) {
       item->ss = NULL;
    }
 
-   /* during renaming the ListItem's value points to our static buffer */
+   /* during renaming the ListItem's value points to the editor buffer */
    if (this->renamingItem)
       this->renamingItem->value = this->saved;
 
@@ -214,17 +215,6 @@ static void renameScreenSettings(ScreenNamesPanel* this, const ListItem* item) {
 static HandlerResult ScreenNamesPanel_eventHandlerRenaming(Panel* super, int ch) {
    ScreenNamesPanel* const this = (ScreenNamesPanel*) super;
 
-   if (ch >= 32 && ch < 127 && ch != '=') {
-      if (this->cursor < SCREEN_NAME_LEN - 1) {
-         this->buffer[this->cursor] = (char)ch;
-         this->cursor++;
-         super->selectedLen = strlen(this->buffer);
-         Panel_setCursorToSelection(super);
-      }
-
-      return HANDLED;
-   }
-
    switch (ch) {
       case EVENT_SET_SELECTED: {
          ListItem* item = (ListItem*) Panel_getSelected(super);
@@ -234,15 +224,6 @@ static HandlerResult ScreenNamesPanel_eventHandlerRenaming(Panel* super, int ch)
       }
       case EVENT_PANEL_LOST_FOCUS:
          goto renameFinish;
-      case 127:
-      case KEY_BACKSPACE:
-         if (this->cursor > 0) {
-            this->cursor--;
-            this->buffer[this->cursor] = '\0';
-            super->selectedLen = strlen(this->buffer);
-            Panel_setCursorToSelection(super);
-         }
-         break;
       case '\n':
       case '\r':
       case KEY_ENTER:
@@ -255,7 +236,7 @@ renameFinish:
          if (!this->renamingItem)
             break;
          free(this->saved);
-         this->renamingItem->value = xStrdup(this->buffer);
+         this->renamingItem->value = xStrdup(LineEditor_getText(&this->editor));
          super->cursorOn = false;
          Panel_setSelectionColor(super, PANEL_SELECTION_FOCUS);
          Panel_setDefaultBar(super);
@@ -276,6 +257,17 @@ renameFinish:
          Panel_setDefaultBar(super);
          break;
       }
+      default: {
+         /* Delegate editing keys to LineEditor. Exclude '=' which has special meaning. */
+         if (ch == '=')
+            break;
+         LineEditor_handleKey(&this->editor, ch);
+         super->selectedLen = LineEditor_getCursor(&this->editor);
+         Panel_setCursorToSelection(super);
+         if (this->renamingItem)
+            this->renamingItem->value = LineEditor_getText(&this->editor);
+         break;
+      }
    }
 
    return HANDLED;
@@ -292,12 +284,11 @@ static void startRenaming(Panel* super) {
    super->cursorOn = true;
    char* name = item->value;
    this->saved = name;
-   strncpy(this->buffer, name, SCREEN_NAME_LEN);
-   this->buffer[SCREEN_NAME_LEN] = '\0';
-   this->cursor = strlen(this->buffer);
-   item->value = this->buffer;
+   LineEditor_initWithMax(&this->editor, SCREEN_NAME_LEN - 1);
+   LineEditor_setText(&this->editor, name);
+   item->value = LineEditor_getText(&this->editor);
    Panel_setSelectionColor(super, PANEL_EDIT);
-   super->selectedLen = strlen(this->buffer);
+   super->selectedLen = LineEditor_getCursor(&this->editor);
    Panel_setCursorToSelection(super);
    super->currentBar = ScreenNames_renamingBar;
 }
@@ -384,10 +375,9 @@ ScreenNamesPanel* ScreenNamesPanel_new(Settings* settings) {
 
    this->settings = settings;
    this->renamingItem = NULL;
-   memset(this->buffer, 0, sizeof(this->buffer));
+   LineEditor_initWithMax(&this->editor, SCREEN_NAME_LEN - 1);
    this->ds = NULL;
    this->saved = NULL;
-   this->cursor = 0;
    super->cursorOn = false;
    Panel_setHeader(super, "Screens");
 

--- a/ScreenTabsPanel.h
+++ b/ScreenTabsPanel.h
@@ -8,6 +8,7 @@ in the source distribution for its full text.
 */
 
 #include "DynamicScreen.h"
+#include "LineEditor.h"
 #include "ListItem.h"
 #include "Object.h"
 #include "Panel.h"
@@ -21,10 +22,9 @@ typedef struct ScreenNamesPanel_ {
 
    ScreenManager* scr;
    Settings* settings;
-   char buffer[SCREEN_NAME_LEN + 1];
+   LineEditor editor;   /* line editor used during renaming */
    DynamicScreen* ds;
    char* saved;
-   size_t cursor;
    ListItem* renamingItem;
 } ScreenNamesPanel;
 

--- a/ScreensPanel.c
+++ b/ScreensPanel.c
@@ -19,6 +19,7 @@ in the source distribution for its full text.
 #include "CRT.h"
 #include "FunctionBar.h"
 #include "Hashtable.h"
+#include "LineEditor.h"
 #include "ProvideCurses.h"
 #include "Settings.h"
 #include "XUtils.h"
@@ -101,17 +102,6 @@ static void ScreensPanel_delete(Object* object) {
 static HandlerResult ScreensPanel_eventHandlerRenaming(Panel* super, int ch) {
    ScreensPanel* const this = (ScreensPanel*) super;
 
-   if (ch >= 32 && ch < 127 && ch != '=') {
-      if (this->cursor < SCREEN_NAME_LEN - 1) {
-         this->buffer[this->cursor] = (char)ch;
-         this->cursor++;
-         super->selectedLen = strlen(this->buffer);
-         Panel_setCursorToSelection(super);
-      }
-
-      return HANDLED;
-   }
-
    switch (ch) {
       case EVENT_SET_SELECTED: {
          ListItem* item = (ListItem*) Panel_getSelected(super);
@@ -121,15 +111,6 @@ static HandlerResult ScreensPanel_eventHandlerRenaming(Panel* super, int ch) {
       }
       case EVENT_PANEL_LOST_FOCUS:
          goto renameFinish;
-      case 127:
-      case KEY_BACKSPACE:
-         if (this->cursor > 0) {
-            this->cursor--;
-            this->buffer[this->cursor] = '\0';
-            super->selectedLen = strlen(this->buffer);
-            Panel_setCursorToSelection(super);
-         }
-         break;
       case '\n':
       case '\r':
       case KEY_ENTER:
@@ -142,7 +123,7 @@ renameFinish:
          if (!this->renamingItem)
             break;
          free(this->saved);
-         this->renamingItem->value = xStrdup(this->buffer);
+         this->renamingItem->value = xStrdup(LineEditor_getText(&this->editor));
          this->renamingItem = NULL;
          this->renamingNewItem = false;
          super->cursorOn = false;
@@ -177,6 +158,19 @@ renameFinish:
          Panel_setDefaultBar(super);
          break;
       }
+      default: {
+         /* Delegate editing keys (printable chars, cursor movement, etc.) to LineEditor.
+            Exclude '=' to not break the htop config format. */
+         if (ch == '=')
+            break;
+         LineEditor_handleKey(&this->editor, ch);
+         super->selectedLen = LineEditor_getCursor(&this->editor);
+         Panel_setCursorToSelection(super);
+         /* Keep item->value pointing to the display buffer */
+         if (this->renamingItem)
+            this->renamingItem->value = LineEditor_getText(&this->editor);
+         break;
+      }
    }
 
    return HANDLED;
@@ -192,12 +186,13 @@ static void startRenaming(Panel* super) {
    super->cursorOn = true;
    char* name = item->value;
    this->saved = name;
-   strncpy(this->buffer, name, SCREEN_NAME_LEN);
-   this->buffer[SCREEN_NAME_LEN] = '\0';
-   this->cursor = strlen(this->buffer);
-   item->value = this->buffer;
+   /* Initialise the line editor with the current name (limited to SCREEN_NAME_LEN - 1 chars) */
+   LineEditor_initWithMax(&this->editor, SCREEN_NAME_LEN - 1);
+   LineEditor_setText(&this->editor, name);
+   /* Point the item's value at the editor buffer so Panel draws it live */
+   item->value = LineEditor_getText(&this->editor);
    Panel_setSelectionColor(super, PANEL_EDIT);
-   super->selectedLen = strlen(this->buffer);
+   super->selectedLen = LineEditor_getCursor(&this->editor);
    Panel_setCursorToSelection(super);
    super->currentBar = Screens_renamingBar;
 }
@@ -399,8 +394,9 @@ ScreensPanel* ScreensPanel_new(Settings* settings) {
    this->moving = false;
    this->renamingItem = NULL;
    this->renamingNewItem = false;
+   this->saved = NULL;
    super->cursorOn = false;
-   this->cursor = 0;
+   LineEditor_initWithMax(&this->editor, SCREEN_NAME_LEN - 1);
    Panel_setHeader(super, "Screens");
 
    for (unsigned int i = 0; i < settings->nScreens; i++) {

--- a/ScreensPanel.h
+++ b/ScreensPanel.h
@@ -13,6 +13,7 @@ in the source distribution for its full text.
 #include "AvailableColumnsPanel.h"
 #include "ColumnsPanel.h"
 #include "DynamicScreen.h"
+#include "LineEditor.h"
 #include "ListItem.h"
 #include "Object.h"
 #include "Panel.h"
@@ -30,10 +31,10 @@ typedef struct ScreensPanel_ {
    Settings* settings;
    ColumnsPanel* columns;
    AvailableColumnsPanel* availableColumns;
-   char buffer[SCREEN_NAME_LEN + 1];
+   LineEditor editor;    /* line editor used during renaming */
+   char buffer[SCREEN_NAME_LEN + 1]; /* backing buffer (editor.buffer copied here) */
    bool moving;
-   char* saved;
-   size_t cursor;
+   char* saved;          /* saved original item->value pointer */
    ListItem* renamingItem;
    bool renamingNewItem;
 } ScreensPanel;


### PR DESCRIPTION
* Line editor with the most common movement and delete key-shortcuts
* History for Search and Filter (shared and saved as `htop_history`)

The Ctrl-left / Ctrl-right handling is xterm-compatible terminals only for now. Can be extended to other terminals if people care.
The Shift-left / Shift-right are stock ncurses from the extended set, so that should work everywhere™ but nobody used these for movement any more, I guess.

Assisted-by: Microsoft Copilot/Claude Sonnet 4.6
