### PR TITLE
README: update instructions for Arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ sudo zypper install ncurses-devel ncurses-devel-static automake autoconf gcc mak
 
 **Archlinux/Manjaro**
 ~~~ shell
-sudo pacman -S ncurses automake autoconf gcc
+sudo pacman -S --needed base-devel ncurses
 ~~~
 
 **macOS**


### PR DESCRIPTION
We have a meta package `base-devel` that defines the basic tools to build Arch Linux packages. Just install that and its dependencies, and `ncurses`.

Also add `--needed` to skip packages that are installed already.