### PR TITLE
NetworkIOMeter: shorten the label

### DIFF
--- a/NetworkIOMeter.c
+++ b/NetworkIOMeter.c
@@ -179,5 +179,5 @@ const MeterClass NetworkIOMeter_class = {
    .name = "NetworkIO",
    .uiName = "Network IO",
    .description = "Network bytes & packets received/sent per second",
-   .caption = "Network: "
+   .caption = "Net: "
 };


### PR DESCRIPTION
This brings it in line with other meters, for example the DiskIOMeter which comes with just "Dsk:". Also it allows for more information on limited width.