### PR TITLE
Normalize physical core ID when `showCPUSMTLabels` is set

### DIFF
--- a/linux/LinuxMachine.c
+++ b/linux/LinuxMachine.c
@@ -748,6 +748,9 @@ static void LinuxMachine_computeThreadIndices(LinuxMachine* this) {
       cpus[i].coreIndex = coreIndex;
    }
 
+   /* Set core & thread indices to zero for cpu0 (average) */
+   cpus[0].coreIndex = 0;
+   cpus[0].threadIndex = 0;
 }
 
 static void LinuxMachine_scanCPUFrequency(LinuxMachine* this) {

--- a/linux/LinuxMachine.c
+++ b/linux/LinuxMachine.c
@@ -739,13 +739,13 @@ static void LinuxMachine_computeThreadIndices(LinuxMachine* this) {
       because CoreIDs are not contiguous or because cpus are
       enumerated in an alternative order, or both. */
    for (size_t i = 1; i <= super->existingCPUs; i++) {
-      int coreIndex = 0;
-      for (size_t j = 1; j < i; j++) {
+      cpus[i].coreIndex = 0;
+      for (size_t j = i - 1; j >= 1; j--) {
          if (cpus[i].threadIndex == cpus[j].threadIndex) {
-            coreIndex++;
+            cpus[i].coreIndex = cpus[j].coreIndex + 1;
+            break;
          }
       }
-      cpus[i].coreIndex = coreIndex;
    }
 
    /* Set core & thread indices to zero for cpu0 (average) */

--- a/linux/LinuxMachine.c
+++ b/linux/LinuxMachine.c
@@ -731,6 +731,23 @@ static void LinuxMachine_computeThreadIndices(LinuxMachine* this) {
       }
       cpus[i].threadIndex = threadIndex;
    }
+
+   /* Now compute a normalized physical core index for each CPU.
+      On many systems, this index will match the following:
+        physicalID*(maxPhysicalID+1)+coreID
+      But there are some systems where this is not true, either
+      because CoreIDs are not contiguous or because cpus are
+      enumerated in an alternative order, or both. */
+   for (size_t i = 1; i <= super->existingCPUs; i++) {
+      int coreIndex = 0;
+      for (size_t j = 1; j < i; j++) {
+         if (cpus[i].threadIndex == cpus[j].threadIndex) {
+            coreIndex++;
+         }
+      }
+      cpus[i].coreIndex = coreIndex;
+   }
+
 }
 
 static void LinuxMachine_scanCPUFrequency(LinuxMachine* this) {
@@ -850,9 +867,7 @@ int Machine_getCPUPhysicalCoreID(const Machine* super, unsigned int id) {
    const LinuxMachine* this = (const LinuxMachine*) super;
 
    assert(id < super->existingCPUs);
-
-   const CPUData* cpu = &this->cpuData[id + 1];
-   return cpu->physicalID * (this->maxCoreID + 1) + cpu->coreID;
+   return this->cpuData[id + 1].coreIndex;
 }
 
 int Machine_getCPUThreadIndex(const Machine* super, unsigned int id) {

--- a/linux/LinuxMachine.h
+++ b/linux/LinuxMachine.h
@@ -54,6 +54,7 @@ typedef struct CPUData_ {
    int physicalID;      /* different for each CPU socket */
    int coreID;          /* same for hyperthreading */
    int ccdID;           /* same for each AMD chiplet */
+   int coreIndex;       /* Normalized physical core ID */
    int threadIndex;     /* SMT thread index: 0 for first thread, 1 for second, etc. */
 
    bool online;


### PR DESCRIPTION
### Summary                                                                                                                                                                           
                                                                                                                                                                                      
This PR normalizes the physical core IDs used when the `showCPUSMTLabels` option is set.                                                                                              
                                                                                                                                                                                      
### Changes                                                                                                                                                                           
                                                                                                                                                                                      
  - add `coreIndex` in `LinuxMachine` which tracks normalized ID
  - return `coreIndex` in `Machine_getCPUPhysicalCoreID()`

### Motivation

This fixes the IDs displayed on systems with non-contiguous core IDs such as the xeon system that @lilydjwg tested on in #1902
[cpuinfo.txt](https://github.com/user-attachments/files/26490538/cpuinfo.txt)

### Future Work

It would be cool to have a mode that renders the CPU IDs as `socket.core.thread`, but this requires more than the three characters of space currently available.
