### PR TITLE
Align AvailableMeters function bar & key behaviors with AvailableColumnsPanel

### DIFF
--- a/AvailableMetersPanel.c
+++ b/AvailableMetersPanel.c
@@ -58,21 +58,12 @@ static HandlerResult AvailableMetersPanel_eventHandler(Panel* super, int ch) {
    bool update = false;
 
    switch (ch) {
-      case KEY_F(5):
-      case 'l':
-      case 'L':
-         AvailableMetersPanel_addMeter(header, this->meterPanels[0], Platform_meterTypes[type], param, 0);
-         result = HANDLED;
-         update = true;
-         break;
       case 0x0a:
       case 0x0d:
       case KEY_ENTER:
-      case KEY_F(6):
-      case 'r':
-      case 'R':
+      case KEY_F(5):
          AvailableMetersPanel_addMeter(header, this->meterPanels[this->columns - 1], Platform_meterTypes[type], param, this->columns - 1);
-         result = (KEY_LEFT << 16) | SYNTH_KEY;
+         result = HANDLED;
          update = true;
          break;
    }

--- a/AvailableMetersPanel.c
+++ b/AvailableMetersPanel.c
@@ -29,6 +29,8 @@ in the source distribution for its full text.
 #include "XUtils.h"
 
 
+static const char* const AvailableMetersFunctions[] = {"      ", "      ", "      ", "      ", "Add   ", "      ", "      ", "      ", "      ", "Done  ", NULL};
+
 static void AvailableMetersPanel_delete(Object* object) {
    AvailableMetersPanel* this = (AvailableMetersPanel*) object;
    free(this->meterPanels);
@@ -145,7 +147,7 @@ AvailableMetersPanel* AvailableMetersPanel_new(Machine* host, Header* header, si
    AvailableMetersPanel* this = AllocThis(AvailableMetersPanel);
    Panel* super = &this->super;
 
-   FunctionBar* fuBar = FunctionBar_newEnterEsc("Add   ", "Done   ");
+   FunctionBar* fuBar = FunctionBar_new(AvailableMetersFunctions, NULL, NULL);
    Panel_init(super, 1, 1, 1, 1, Class(ListItem), true, fuBar);
 
    this->host = host;

--- a/AvailableMetersPanel.c
+++ b/AvailableMetersPanel.c
@@ -61,6 +61,7 @@ static HandlerResult AvailableMetersPanel_eventHandler(Panel* super, int ch) {
       case 0x0a:
       case 0x0d:
       case KEY_ENTER:
+      case KEY_RECLICK:
       case KEY_F(5):
          AvailableMetersPanel_addMeter(header, this->meterPanels[this->columns - 1], Platform_meterTypes[type], param, this->columns - 1);
          result = HANDLED;


### PR DESCRIPTION
1. Make AvailableMeters functions bar same as in AvailableColumns functions.
2. Merge the F5 ("Add") and Enter events, and obsolete old key events ('L', 'R' and F6) in AvailableMeters panel.
3. Allow `KEY_RECLICK` to add a meter.