### PR TITLE
linux: show M_PRIV instead of M_SHARE in default columns

### DIFF
--- a/htop.1.in
+++ b/htop.1.in
@@ -434,6 +434,10 @@ process's used physical memory).
 .B M_SHARE (SHR)
 The size of the process's shared pages.
 .TP
+.B M_PRIV (PRIV)
+The private memory size of the process (i.e. the resident set size minus the
+shared memory size).
+.TP
 .B M_TRS (CODE)
 The text resident set size of the process (i.e. the size of the process's
 executable instructions).

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -90,7 +90,7 @@ bool Running_containerized = false;
 const ScreenDefaults Platform_defaultScreens[] = {
    {
       .name = "Main",
-      .columns = "PID USER PRIORITY NICE M_VIRT M_RESIDENT M_SHARE STATE PERCENT_CPU PERCENT_MEM TIME Command",
+      .columns = "PID USER PRIORITY NICE M_VIRT M_RESIDENT M_PRIV STATE PERCENT_CPU PERCENT_MEM TIME Command",
       .sortKey = "PERCENT_CPU",
    },
    {

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -60,7 +60,7 @@ Platform* pcp;
 const ScreenDefaults Platform_defaultScreens[] = {
    {
       .name = "Main",
-      .columns = "PID USER PRIORITY NICE M_VIRT M_RESIDENT M_SHARE STATE PERCENT_CPU PERCENT_MEM TIME Command",
+      .columns = "PID USER PRIORITY NICE M_VIRT M_RESIDENT M_PRIV STATE PERCENT_CPU PERCENT_MEM TIME Command",
       .sortKey = "PERCENT_CPU",
    },
    {


### PR DESCRIPTION
Replaces M_SHARE with M_PRIV in the default Linux Main screen columns, as suggested in #492. M_PRIV (RES - SHR) is a more actionable per-process memory metric than shared pages alone.

M_RESIDENT is kept as it remains the de-facto standard memory column across process viewers. M_SHARE is removed since it becomes redundant with M_PRIV. Users who want either column back can re-add them via the Setup screen (F2).

PCP also exposes M_PRIV but its defaults are left unchanged to keep this PR focused on Linux; happy to extend in a follow-up if desired.

Also documents M_PRIV in the man page.

Tested on Debian aarch64 with a fresh config: PRIV column appears in place of SHR, sorting works, config saves and reloads cleanly.

Closes #492