### PR TITLE
Fix search function

### DIFF
--- a/IncSet.c
+++ b/IncSet.c
@@ -246,8 +246,8 @@ bool IncSet_handleKey(IncSet* this, int ch, Panel* panel, IncMode_GetPanelValue 
       IncSet_deactivate(this, panel);
       doSearch = false;
       filterChanged = mode->isFilter;
-   } else if (ch == 27) {
-      /* Esc aborts */
+   } else if (ch == 27 || ch == KEY_MOUSE || ch == KEY_RECLICK) {
+      /* Esc or panel click aborts */
       if (this->history)
          History_resetPosition(this->history);
       if (mode->isFilter) {

--- a/MainPanel.c
+++ b/MainPanel.c
@@ -105,7 +105,8 @@ static HandlerResult MainPanel_eventHandler(Panel* super, int ch) {
          reaction = HTOP_REFRESH | HTOP_REDRAW_BAR;
       }
       if (this->inc->found && this->inc->active && !this->inc->active->isFilter) {
-         reaction |= Action_follow(this->state);
+         host->activeTable->following = MainPanel_selectedRow(this);
+         Panel_setSelectionColor(super, PANEL_SELECTION_FOLLOW);
          reaction |= HTOP_KEEP_FOLLOWING;
       }
       result = HANDLED;


### PR DESCRIPTION
Fixing two funny bugs that remained after the line editor introduction:

1. Clicking into the panel does not deactivate the search function
1. Search activates the following function on every second keypress. Toggle != activate :)
