### PR TITLE
Stable tree view

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -373,18 +373,27 @@ static Htop_Reaction actionExpandCollapseOrSortColumn(State* st) {
    return st->host->settings->ss->treeView ? actionExpandOrCollapse(st) : actionSetSortColumn(st);
 }
 
-static inline void setActiveScreen(Settings* settings, State* st, unsigned int ssIdx) {
+static inline bool setActiveScreen(Settings* settings, State* st, unsigned int ssIdx) {
    assert(settings->ssIndex == ssIdx);
    Machine* host = st->host;
+
+   // Save following state from current table before switching screens
+   int following = host->activeTable->following;
 
    settings->ss = settings->screens[ssIdx];
    if (!settings->ss->table)
       settings->ss->table = host->processTable;
    host->activeTable = settings->ss->table;
 
+   // Transfer following state to new table if it doesn't already have one
+   if (following != -1 && host->activeTable->following == -1)
+      host->activeTable->following = following;
+
    // set correct functionBar - readonly if requested, and/or with non-process screens
    bool readonly = Settings_isReadonly() || (host->activeTable != host->processTable);
    MainPanel_setFunctionBar(st->mainPanel, readonly);
+
+   return host->activeTable->following != -1;
 }
 
 static Htop_Reaction actionNextScreen(State* st) {
@@ -393,8 +402,10 @@ static Htop_Reaction actionNextScreen(State* st) {
    if (settings->ssIndex == settings->nScreens) {
       settings->ssIndex = 0;
    }
-   setActiveScreen(settings, st, settings->ssIndex);
-   return HTOP_UPDATE_PANELHDR | HTOP_REFRESH | HTOP_REDRAW_BAR;
+   Htop_Reaction reaction = HTOP_UPDATE_PANELHDR | HTOP_REFRESH | HTOP_REDRAW_BAR;
+   if (setActiveScreen(settings, st, settings->ssIndex))
+      reaction |= HTOP_KEEP_FOLLOWING;
+   return reaction;
 }
 
 static Htop_Reaction actionPrevScreen(State* st) {
@@ -404,8 +415,10 @@ static Htop_Reaction actionPrevScreen(State* st) {
    } else {
       settings->ssIndex--;
    }
-   setActiveScreen(settings, st, settings->ssIndex);
-   return HTOP_UPDATE_PANELHDR | HTOP_REFRESH | HTOP_REDRAW_BAR;
+   Htop_Reaction reaction = HTOP_UPDATE_PANELHDR | HTOP_REFRESH | HTOP_REDRAW_BAR;
+   if (setActiveScreen(settings, st, settings->ssIndex))
+      reaction |= HTOP_KEEP_FOLLOWING;
+   return reaction;
 }
 
 Htop_Reaction Action_setScreenTab(State* st, int x) {
@@ -422,8 +435,10 @@ Htop_Reaction Action_setScreenTab(State* st, int x) {
       int width = rem >= bracketWidth ? (int)strnlen(tab, rem - bracketWidth + 1) : 0;
       if (width >= rem - bracketWidth + 1) {
          settings->ssIndex = i;
-         setActiveScreen(settings, st, i);
-         return HTOP_UPDATE_PANELHDR | HTOP_REFRESH | HTOP_REDRAW_BAR;
+         Htop_Reaction reaction = HTOP_UPDATE_PANELHDR | HTOP_REFRESH | HTOP_REDRAW_BAR;
+         if (setActiveScreen(settings, st, i))
+            reaction |= HTOP_KEEP_FOLLOWING;
+         return reaction;
       }
 
       rem -= bracketWidth + width;
@@ -566,7 +581,14 @@ static Htop_Reaction actionFilterByUser(State* st) {
 }
 
 Htop_Reaction Action_follow(State* st) {
-   st->host->activeTable->following = MainPanel_selectedRow(st->mainPanel);
+   int selectedRow = MainPanel_selectedRow(st->mainPanel);
+   if (st->host->activeTable->following == selectedRow) {
+      /* Toggle: unfollow when F is pressed on the already-followed process */
+      st->host->activeTable->following = -1;
+      Panel_setSelectionColor((Panel*)st->mainPanel, PANEL_SELECTION_FOCUS);
+      return HTOP_OK;
+   }
+   st->host->activeTable->following = selectedRow;
    Panel_setSelectionColor((Panel*)st->mainPanel, PANEL_SELECTION_FOLLOW);
    return HTOP_KEEP_FOLLOWING;
 }

--- a/CRT.c
+++ b/CRT.c
@@ -1243,6 +1243,11 @@ IGNORE_WCASTQUAL_BEGIN
       /* These are a bit of a gamble: */
       define_key("\033[1;5D", KEY_CTRL_LEFT);
       define_key("\033[1;5C", KEY_CTRL_RIGHT);
+      define_key("\033[1;2A", KEY_SR); // SR = scroll reverse, Shift-UP
+      define_key("\033[1;2B", KEY_SF); // SF = scroll forward, Shift-DOWN
+      define_key("\033[1;3A", KEY_SR); // SR = scroll reverse, Alt-UP
+      define_key("\033[1;3B", KEY_SF); // SF = scroll forward, Alt-DOWN
+
 
       char sequence[3] = "\033a";
       for (char c = 'a'; c <= 'z'; c++) {

--- a/CommandLine.c
+++ b/CommandLine.c
@@ -68,7 +68,7 @@ static void printHelpFlag(const char* name) {
           "-p --pid=PID[,PID,PID...]       Show only the given PIDs\n"
           "   --readonly                   Disable all system and process changing features\n"
           "-s --sort-key=COLUMN            Sort by COLUMN in list view (try --sort-key=help for a list)\n"
-          "-t --tree                       Show the tree view (can be combined with -s)\n"
+          "-t --tree[=MODE]                Show the tree view (MODE: classic|soft|hard); can be combined with -s\n"
           "-u --user[=USERNAME]            Show only processes for a given user (or $USER)\n"
           "-U --no-unicode                 Do not use unicode but plain ASCII\n"
           "-V --version                    Print version info\n");
@@ -99,6 +99,25 @@ typedef struct CommandLineSettings_ {
    bool hideMeters;
    bool hideFunctionBar;
 } CommandLineSettings;
+
+static bool parseTreeStableMode(const char* arg, int* stableTreeView) {
+   if (String_eq(arg, "0") || String_eq(arg, "classic") || String_eq(arg, "legacy") || String_eq(arg, "jumpy")) {
+      *stableTreeView = 0;
+      return true;
+   }
+
+   if (String_eq(arg, "1") || String_eq(arg, "soft") || String_eq(arg, "stable")) {
+      *stableTreeView = 1;
+      return true;
+   }
+
+   if (String_eq(arg, "2") || String_eq(arg, "hard") || String_eq(arg, "STABLE")) {
+      *stableTreeView = 2;
+      return true;
+   }
+
+   return false;
+}
 
 static CommandLineStatus parseArguments(int argc, char** argv, CommandLineSettings* flags) {
 
@@ -250,6 +269,20 @@ static CommandLineStatus parseArguments(int argc, char** argv, CommandLineSettin
             flags->hideMeters = true;
             break;
          case 't':
+            if (!optarg && optind < argc &&
+                (argv[optind][0] != '\0' && argv[optind][0] != '-')) {
+               int stableTreeView = -1;
+               if (parseTreeStableMode(argv[optind], &stableTreeView)) {
+                  flags->stableTreeView = stableTreeView;
+                  optarg = argv[optind++];
+               }
+            }
+            if (optarg) {
+               if (!parseTreeStableMode(optarg, &flags->stableTreeView)) {
+                  fprintf(stderr, "Error: invalid tree mode \"%s\" (expected: classic, soft, hard (or 0, 1, 2)).\n", optarg);
+                  return STATUS_ERROR_EXIT;
+               }
+            }
             flags->treeView = true;
             break;
          case 'p': {

--- a/CommandLine.c
+++ b/CommandLine.c
@@ -92,6 +92,7 @@ typedef struct CommandLineSettings_ {
    bool enableMouse;
 #endif
    bool treeView;
+   int stableTreeView;
    bool allowUnicode;
    bool highlightChanges;
    int highlightDelaySecs;
@@ -134,6 +135,7 @@ static CommandLineStatus parseArguments(int argc, char** argv, CommandLineSettin
 #endif
       .treeView = false,
       .allowUnicode = true,
+      .stableTreeView = -1,
       .highlightChanges = false,
       .highlightDelaySecs = -1,
       .readonly = false,
@@ -162,7 +164,7 @@ static CommandLineStatus parseArguments(int argc, char** argv, CommandLineSettin
       {"no-mouse",   no_argument,         0, 'M'},
       {"no-unicode", no_argument,         0, 'U'},
       {"no-meters",  no_argument,         0, 129},
-      {"tree",       no_argument,         0, 't'},
+      {"tree",       optional_argument,   0, 't'},
       {"pid",        required_argument,   0, 'p'},
       {"filter",     required_argument,   0, 'F'},
       {"no-functionbar", no_argument,     0, 130},
@@ -175,7 +177,7 @@ static CommandLineStatus parseArguments(int argc, char** argv, CommandLineSettin
 
    int opt, opti = 0;
    /* Parse arguments */
-   while ((opt = getopt_long(argc, argv, "hVMCs:td:n:u::Up:F:H::", long_opts, &opti))) {
+   while ((opt = getopt_long(argc, argv, "hVMCs:t::d:n:u::Up:F:H::", long_opts, &opti))) {
       if (opt == EOF)
          break;
 
@@ -415,6 +417,8 @@ int CommandLine_run(int argc, char** argv) {
 #endif
    if (flags.treeView)
       settings->ss->treeView = true;
+   if (flags.stableTreeView != -1)
+      settings->ss->stableTreeView = flags.stableTreeView;
    if (flags.highlightChanges)
       settings->highlightChanges = true;
    if (flags.highlightDelaySecs != -1)

--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -270,6 +270,7 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    Panel_add(super, (Object*) CheckItem_newByRef("Tree view", &(settings->ss->treeView)));
    Panel_add(super, (Object*) CheckItem_newByRef("- Tree view is always sorted by PID (htop 2 behavior)", &(settings->ss->treeViewAlwaysByPID)));
    Panel_add(super, (Object*) CheckItem_newByRef("- Tree view is collapsed by default", &(settings->ss->allBranchesCollapsed)));
+   Panel_add(super, (Object*) NumberItem_newByRef("- Tree view is kept visually stable (0 - off, 1 - soft, 2 - hard)", &(settings->ss->stableTreeView), 0, 0, 2));
    Panel_add(super, (Object*) TextItem_new("Global options:"));
    Panel_add(super, (Object*) CheckItem_newByRef("Show tabs for screens", &(settings->screenTabs)));
    Panel_add(super, (Object*) CheckItem_newByRef("Shadow other users' processes", &(settings->shadowOtherUsers)));

--- a/MainPanel.c
+++ b/MainPanel.c
@@ -112,6 +112,10 @@ static HandlerResult MainPanel_eventHandler(Panel* super, int ch) {
       result = HANDLED;
    } else if (ch == 27) {
       this->state->hideSelection = true;
+      if (host->activeTable->following != -1) {
+         host->activeTable->following = -1;
+         Panel_setSelectionColor(super, PANEL_SELECTION_FOCUS);
+      }
       return HANDLED;
    } else if (ch != ERR && ch > 0 && ch < KEY_MAX && this->keys[ch]) {
       reaction |= (this->keys[ch])(this->state);
@@ -149,8 +153,7 @@ static HandlerResult MainPanel_eventHandler(Panel* super, int ch) {
    if ((reaction & HTOP_QUIT) == HTOP_QUIT) {
       return BREAK_LOOP;
    }
-   if ((reaction & HTOP_KEEP_FOLLOWING) != HTOP_KEEP_FOLLOWING) {
-      host->activeTable->following = -1;
+   if (host->activeTable->following == -1) {
       Panel_setSelectionColor(super, PANEL_SELECTION_FOCUS);
    }
    return result;

--- a/Panel.c
+++ b/Panel.c
@@ -64,6 +64,7 @@ void Panel_init(Panel* this, int x, int y, int w, int h, const ObjectClass* type
    this->needsRedraw = true;
    this->cursorOn = false;
    this->wasFocus = false;
+   this->allowExcessScrollV = false;
    RichString_beginAllocated(this->header);
    this->defaultBar = fuBar;
    this->currentBar = fuBar;
@@ -118,6 +119,7 @@ void Panel_prune(Panel* this) {
    this->selected = 0;
    this->oldSelected = 0;
    this->needsRedraw = true;
+   this->allowExcessScrollV = false;
 }
 
 void Panel_add(Panel* this, Object* o) {
@@ -262,11 +264,20 @@ void Panel_draw(Panel* this, bool force_redraw, bool focus, bool highlightSelect
       h--;
    }
 
-   // ensure scroll area is on screen
-   if (this->scrollV < 0) {
-      this->scrollV = 0;
-      this->needsRedraw = true;
-   } else if (this->scrollV > size - h) {
+   /* ensure scroll area is on screen
+      Note: when allowExcessScrollV is set, negative scrollV is allowed to display
+      empty lines above the first row, and scrollV > size-h is allowed to display
+      empty lines below the last row. Both are used by stable tree view hard mode
+      to keep the selected row at a fixed screen position. */
+   if (!this->allowExcessScrollV) {
+      if (this->scrollV < 0) {
+         this->scrollV = 0;
+         this->needsRedraw = true;
+      } else if (this->scrollV > size - h) {
+         this->scrollV = MAXIMUM(size - h, 0);
+         this->needsRedraw = true;
+      }
+   }   if (!this->allowExcessScrollV && this->scrollV > size - h) {
       this->scrollV = MAXIMUM(size - h, 0);
       this->needsRedraw = true;
    }
@@ -279,8 +290,10 @@ void Panel_draw(Panel* this, bool force_redraw, bool focus, bool highlightSelect
       this->needsRedraw = true;
    }
 
-   int first = this->scrollV;
-   int upTo = MINIMUM(first + h, size);
+   // topPad: empty screen lines above the first row (non-zero when scrollV is negative)
+   int topPad = (this->scrollV < 0) ? -this->scrollV : 0;
+   int first = this->scrollV + topPad;
+   int upTo = MINIMUM(first + h - topPad, size);
 
    int selectionColor = focus
       ? CRT_colors[this->selectionColorId]
@@ -289,6 +302,10 @@ void Panel_draw(Panel* this, bool force_redraw, bool focus, bool highlightSelect
    RichString_begin(item);
    if (this->needsRedraw || force_redraw) {
       int line = 0;
+      while (line < topPad) {
+         mvhline(y + line, x, ' ', this->w);
+         line++;
+      }
       for (int i = first; line < h && i < upTo; i++) {
          const Object* itemObj = Vector_get(this->items, i);
          RichString_rewind(&item, RichString_size(&item));
@@ -321,9 +338,9 @@ void Panel_draw(Panel* this, bool force_redraw, bool focus, bool highlightSelect
       RichString_rewind(&item, RichString_size(&item));
       Object_display(oldObj, &item);
       int oldLen = RichString_sizeVal(item);
-      mvhline(y + this->oldSelected - first, x + 0, ' ', this->w);
+      mvhline(y + this->oldSelected - this->scrollV, x + 0, ' ', this->w);
       if (scrollH < oldLen)
-         RichString_printoffnVal(item, y + this->oldSelected - first, x,
+         RichString_printoffnVal(item, y + this->oldSelected - this->scrollV, x,
             scrollH, MINIMUM(oldLen - scrollH, this->w));
 
       const Object* newObj = Vector_get(this->items, this->selected);
@@ -333,10 +350,10 @@ void Panel_draw(Panel* this, bool force_redraw, bool focus, bool highlightSelect
       int newLen = RichString_sizeVal(item);
       this->selectedLen = newLen;
       attrset(selectionColor);
-      mvhline(y + this->selected - first, x + 0, ' ', this->w);
+      mvhline(y + this->selected - this->scrollV, x + 0, ' ', this->w);
       RichString_setAttr(&item, selectionColor);
       if (scrollH < newLen)
-         RichString_printoffnVal(item, y + this->selected - first, x,
+         RichString_printoffnVal(item, y + this->selected - this->scrollV, x,
             scrollH, MINIMUM(newLen - scrollH, this->w));
       attrset(CRT_colors[RESET_COLOR]);
    }

--- a/Panel.c
+++ b/Panel.c
@@ -381,6 +381,8 @@ bool Panel_onKey(Panel* this, int key) {
    assert(this != NULL);
 
    const int size = Vector_size(this->items);
+   const int availableHeight = this->h - Panel_headerHeight(this);
+   const int maxScroll = MAXIMUM(0, size - availableHeight);
 
    #define PANEL_SCROLL(amount)                                                                                     \
    do {                                                                                                             \
@@ -434,6 +436,26 @@ bool Panel_onKey(Panel* this, int key) {
 
       case KEY_WHEELDOWN:
          PANEL_SCROLL(+CRT_scrollWheelVAmount);
+         break;
+
+      case KEY_SR:
+         if (this->scrollV > 0) {
+            // keep selection within the now-visible area
+            if (this->selected < this->scrollV + availableHeight) {
+               this->scrollV--;
+               this->needsRedraw = true;
+            }
+         }
+         break;
+
+      case KEY_SF:
+         if (this->scrollV < maxScroll) {
+            // keep selection within the now-visible area
+            if (this->selected >= this->scrollV) {
+               this->scrollV++;
+               this->needsRedraw = true;
+            }
+         }
          break;
 
       case KEY_HOME:

--- a/Panel.h
+++ b/Panel.h
@@ -76,6 +76,7 @@ struct Panel_ {
    bool needsRedraw;
    bool cursorOn;
    bool wasFocus;
+   bool allowExcessScrollV; /* when true, scrollV > size-h is permitted (blank lines at bottom) */
    int lastMouseBarClickX; /* X position of last mouse click on function bar (LINES-1) */
    FunctionBar* currentBar;
    FunctionBar* defaultBar;

--- a/Settings.c
+++ b/Settings.c
@@ -279,6 +279,7 @@ ScreenSettings* Settings_newScreen(Settings* this, const ScreenDefaults* default
       .treeView = false,
       .treeViewAlwaysByPID = false,
       .allBranchesCollapsed = false,
+      .stableTreeView = 0,
    };
    return Settings_initScreenSettings(ss, this, defaults->columns);
 }
@@ -554,6 +555,9 @@ static bool Settings_read(Settings* this, const char* fileName, const Machine* h
       } else if (String_eq(option[0], ".all_branches_collapsed")) {
          if (screen)
             screen->allBranchesCollapsed = atoi(option[1]);
+      } else if (String_eq(option[0], ".stable_tree_view")) {
+         if (screen)
+            screen->stableTreeView = atoi(option[1]);
       } else if (String_eq(option[0], ".dynamic")) {
          if (screen) {
             free_and_xStrdup(&screen->dynamic, option[1]);
@@ -767,6 +771,7 @@ int Settings_write(const Settings* this, bool onCrash) {
       printSettingInteger(".sort_direction", ss->direction);
       printSettingInteger(".tree_sort_direction", ss->treeDirection);
       printSettingInteger(".all_branches_collapsed", ss->allBranchesCollapsed);
+      printSettingInteger(".stable_tree_view", ss->stableTreeView);
    }
 
    #undef printSettingString

--- a/Settings.h
+++ b/Settings.h
@@ -52,6 +52,7 @@ typedef struct ScreenSettings_ {
    bool treeView;
    bool treeViewAlwaysByPID;
    bool allBranchesCollapsed;
+   int stableTreeView;   /* 0=off, 1=soft, 2=hard (allow empty space above PID 1) */
 } ScreenSettings;
 
 typedef struct Settings_ {

--- a/Table.c
+++ b/Table.c
@@ -19,6 +19,7 @@ in the source distribution for its full text.
 #include "Machine.h"
 #include "Macros.h"
 #include "Panel.h"
+#include "Row.h"
 #include "RowField.h"
 #include "Vector.h"
 
@@ -29,6 +30,8 @@ Table* Table_init(Table* this, const ObjectClass* klass, Machine* host) {
    this->table = Hashtable_new(200, false);
    this->needsSort = true;
    this->following = -1;
+   this->stableId = -1;
+   this->stableLastIdx = 0;
    this->host = host;
    return this;
 }
@@ -71,6 +74,7 @@ void Table_add(Table* this, Row* row) {
 // breaking dying process highlighting.
 static void Table_removeIndex(Table* this, const Row* row, int idx) {
    int rowid = row->id;
+   int rowparent = Row_getGroupOrParent(row);  /* save before row is freed */
 
    assert(row == (Row*)Vector_get(this->rows, idx));
    assert(Hashtable_get(this->table, rowid) != NULL);
@@ -81,6 +85,16 @@ static void Table_removeIndex(Table* this, const Row* row, int idx) {
    if (this->following != -1 && this->following == rowid) {
       this->following = -1;
       Panel_setSelectionColor(this->panel, PANEL_SELECTION_FOCUS);
+   }
+
+   /* When the stable-tree-view anchor exits, walk up to its parent */
+   if (this->stableId != -1 && this->stableId == rowid) {
+      if (rowparent != 0 && rowparent != rowid &&
+          Hashtable_get(this->table, rowparent) != NULL) {
+         this->stableId = rowparent;
+      } else {
+         this->stableId = -1;
+      }
    }
 
    assert(Hashtable_get(this->table, rowid) == NULL);
@@ -232,9 +246,22 @@ void Table_collapseAllBranches(Table* this) {
 void Table_rebuildPanel(Table* this) {
    Table_updateDisplayList(this);
 
+   const Settings* settings = this->host->settings;
+   const ScreenSettings* ss = settings->ss;
+   const bool stableMode = ss->treeView && ss->stableTreeView > 0;
+   const bool hardMode = ss->treeView && ss->stableTreeView == 2;
+
    const int currPos = Panel_getSelectedIndex(this->panel);
    const int currScrollV = this->panel->scrollV;
    const int currSize = Panel_size(this->panel);
+
+   /* Stable tree view: the anchor is active when stableId is set, following
+    * is not in use, and the cursor has not moved since the last rebuild. */
+   const int stableOffset = currPos - currScrollV;
+   const bool stableActive = stableMode
+      && (this->following == -1)
+      && (this->stableId != -1)
+      && (currPos == this->stableLastIdx);
 
    Panel_prune(this->panel);
 
@@ -250,6 +277,7 @@ void Table_rebuildPanel(Table* this) {
 
    const int rowCount = Vector_size(this->displayList);
    bool foundFollowed = false;
+   int stableFoundIdx = -1;
    int idx = 0;
 
    for (int i = 0; i < rowCount; i++) {
@@ -263,9 +291,25 @@ void Table_rebuildPanel(Table* this) {
       if (this->following != -1 && row->id == this->following) {
          foundFollowed = true;
          Panel_setSelected(this->panel, idx);
-         /* Keep scroll position relative to followed row */
-         this->panel->scrollV = idx - (currPos - currScrollV);
+         /* Keep scroll position relative to followed row.
+            Allow negative scrollV in hard mode so that blank lines
+            above row 0 can appear (keeping the followed row at its
+            visual offset), but clip to 0 in soft mode or when the
+            followed row is at index 0 (nothing above it to scroll
+            off). */
+         int newScrollV = idx - (currPos - currScrollV);
+         if (!hardMode || idx == 0) {
+            if (newScrollV < 0)
+               newScrollV = 0;
+         }
+         this->panel->scrollV = newScrollV;
+         this->panel->allowExcessScrollV = true;
       }
+
+      if (stableActive && row->id == this->stableId) {
+         stableFoundIdx = idx;
+      }
+
       idx++;
    }
 
@@ -276,13 +320,48 @@ void Table_rebuildPanel(Table* this) {
    }
 
    if (this->following == -1) {
-      /* If the last item was selected, keep the new last item selected */
-      if (currPos > 0 && currPos == currSize - 1)
-         Panel_setSelected(this->panel, Panel_size(this->panel) - 1);
-      else
-         Panel_setSelected(this->panel, currPos);
+      if (stableActive && stableFoundIdx != -1) {
+         /* Stable tree view: keep the anchor row at the same screen line.
+            In hard mode, scrollV may go negative to render empty lines above row 0,
+            but only when the root is not selected (reset to 0 when root is at the top).
+            In soft mode, scrollV is clamped to 0 so no empty space appears above.
+            In both modes, scrollV may exceed size-h (empty lines below the last row)
+            so that processes above the anchor can be scrolled off the top of the
+            viewport rather than pushing the anchor down. */
+         Panel_setSelected(this->panel, stableFoundIdx);
+         int newScrollV = stableFoundIdx - stableOffset;
+         if (!hardMode || stableFoundIdx == 0) {
+            /* soft mode: no empty lines above row 0;
+             * hard mode + root selected: reset to top of panel */
+            if (newScrollV < 0)
+               newScrollV = 0;
+         }
+         this->panel->scrollV = newScrollV;
+         this->panel->allowExcessScrollV = true;
+         this->stableLastIdx = stableFoundIdx;
+      } else {
+         /* Normal behavior: restore position by index */
+         if (currPos > 0 && currPos == currSize - 1)
+            Panel_setSelected(this->panel, Panel_size(this->panel) - 1);
+         else
+            Panel_setSelected(this->panel, currPos);
 
-      this->panel->scrollV = currScrollV;
+         this->panel->scrollV = currScrollV;
+         this->panel->allowExcessScrollV = false;
+      }
+
+      /* Update stable anchor from the newly selected row */
+      if (stableMode) {
+         const Row* sel = (const Row*) Panel_getSelected(this->panel);
+         if (sel) {
+            this->stableId = sel->id;
+            this->stableLastIdx = Panel_getSelectedIndex(this->panel);
+         } else {
+            this->stableId = -1;
+         }
+      } else {
+         this->stableId = -1;
+      }
    }
 }
 

--- a/Table.h
+++ b/Table.h
@@ -34,6 +34,8 @@ typedef struct Table_ {
    const char* incFilter;
    bool needsSort;
    int following;         /* -1 or row being visually tracked in the user interface */
+   int stableId;          /* stable tree view: row ID to keep at fixed screen position (-1 = inactive) */
+   int stableLastIdx;     /* panel index where stableId row was placed in the last rebuild */
 
    struct Panel_* panel;
 } Table;

--- a/htop.1.in
+++ b/htop.1.in
@@ -85,9 +85,14 @@ Disable all system and process changing features
 \fB\-V \-\-version
 Output version information and exit
 .TP
-\fB\-t \-\-tree
-Show processes in tree view. This can be used to force a tree view when
-requesting a sort order with -s.
+\fB\-t \-\-tree[=MODE]
+Show processes in tree view.
+This can be used to force a tree view when requesting a sort order with -s.
+The optional MODE can used to set the stable tree mode (0/classic ;
+1/soft/stable ; 2/hard/STABLE).
+Soft mode will try to stabilize the current PID line visually on the screen.
+Hard mode will additionally allow to move the whole tree down, creating
+empty space above the root when necessary.
 .TP
 \fB\-H \-\-highlight-changes=DELAY\fR
 Highlight new and old processes


### PR DESCRIPTION
Improvements to the following function are needed to make the stable tree view make sense (otherwise it would be quite just a duplication of functionality). Hence commit #1.

The stable tree view comes in two flavors:
soft = htop tries to keep the tree view stable but does not allow blank space above the tree root (PID 0) to accommodate all possible tree refreshs
hard = htop allows blank lines above the tree root (PID 0) to keep the visual line at nearly all cost

The default is off, so retain existing jumpiness.

I did not implement a hot key for switching as I *think* people who like stable tree view will just switch it on and keep it that way.

Fixes #1905
