### PR TITLE
Guard against null pointers in actionBacktrace()

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -618,10 +618,10 @@ static Htop_Reaction actionBacktrace(State *st) {
    const Vector* allProcesses = st->mainPanel->super.items;
 
    Vector* processes = Vector_new(Class(Process), false, VECTOR_DEFAULT_SIZE);
-   if (!Process_isUserlandThread(selectedProcess)) {
+   if (selectedProcess && !Process_isUserlandThread(selectedProcess)) {
       for (int i = 0; i < Vector_size(allProcesses); i++) {
          Process* process = (Process *)Vector_get(allProcesses, i);
-         if (Process_getThreadGroup(process) == Process_getThreadGroup(selectedProcess)) {
+         if (process && Process_getThreadGroup(process) == Process_getThreadGroup(selectedProcess)) {
             Vector_add(processes, process);
          }
       }


### PR DESCRIPTION
A warning was produced in GCC's LTO (GCC 13, Ubuntu 24.04) in `-O2 -flto` mode:

```
In function ‘Process_isUserlandThread’,
    inlined from ‘actionBacktrace’ at Action.c:621:9:
Process.h:287:15: error: null pointer dereference [-Werror=null-dereference]
  287 |    return this->isUserlandThread;
      |               ^
```

[Full build log in the CI](https://github.com/Explorer09/htop-1/actions/runs/24628978855/job/72012897382)

Note: the warning is not triggered in `-O3 -flto` mode.
