### PR TITLE
Extend BatteryMeter display

### DIFF
--- a/BatteryMeter.c
+++ b/BatteryMeter.c
@@ -25,21 +25,23 @@ static const int BatteryMeter_attributes[] = {
 };
 
 static void BatteryMeter_updateValues(Meter* this) {
-   ACPresence isOnAC;
-   double percent;
+   BatteryInfo info = {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
 
-   Platform_getBattery(&percent, &isOnAC);
+   Platform_getBattery(&info);
 
-   if (!isNonnegative(percent)) {
+   if (!isNonnegative(info.percent)) {
       this->values[0] = NAN;
       xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "N/A");
       return;
    }
 
-   this->values[0] = percent;
+   this->values[0] = info.percent;
 
    const char* text;
-   switch (isOnAC) {
+   switch (info.ac) {
       case AC_PRESENT:
          text = this->mode == TEXT_METERMODE ? " (Running on A/C)" : "(A/C)";
          break;
@@ -52,7 +54,7 @@ static void BatteryMeter_updateValues(Meter* this) {
          break;
    }
 
-   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%.1f%%%s", percent, text);
+   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%.1f%%%s", info.percent, text);
 }
 
 const MeterClass BatteryMeter_class = {

--- a/BatteryMeter.c
+++ b/BatteryMeter.c
@@ -28,6 +28,7 @@ static void BatteryMeter_updateValues(Meter* this) {
    BatteryInfo info = {
       .ac = AC_ERROR,
       .percent = NAN,
+      .powerCurr = NAN,
       .energyCurr = NAN,
       .energyFull = NAN,
    };

--- a/BatteryMeter.c
+++ b/BatteryMeter.c
@@ -28,6 +28,8 @@ static void BatteryMeter_updateValues(Meter* this) {
    BatteryInfo info = {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 
    Platform_getBattery(&info);

--- a/BatteryMeter.c
+++ b/BatteryMeter.c
@@ -41,23 +41,140 @@ static void BatteryMeter_updateValues(Meter* this) {
       return;
    }
 
+   info.percent = CLAMP(info.percent, 0.0, 100.0);
    this->values[0] = info.percent;
 
-   const char* text;
-   switch (info.ac) {
-      case AC_PRESENT:
-         text = this->mode == TEXT_METERMODE ? " (Running on A/C)" : "(A/C)";
-         break;
-      case AC_ABSENT:
-         text = this->mode == TEXT_METERMODE ? " (Running on battery)" : "(bat)";
-         break;
-      case AC_ERROR:
-      default:
-         text = "";
-         break;
+   bool havePower = isfinite(info.powerCurr);
+   bool haveEnergy = isNonnegative(info.energyCurr) && isNonnegative(info.energyFull);
+
+   /* Without energy data there is nothing useful to show beyond the percent. */
+   if (!haveEnergy) {
+      if (havePower) {
+         if (info.ac == AC_PRESENT) {
+            xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "AC %+.1fW, %.1f%%", info.powerCurr, info.percent);
+         } else if (info.ac == AC_ABSENT) {
+            xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "bat %+.1fW, %.1f%%", info.powerCurr, info.percent);
+         } else {
+            xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%+.1fW, %.1f%%", info.powerCurr, info.percent);
+         }
+      } else if (info.ac == AC_PRESENT) {
+         xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "AC %.1f%%", info.percent);
+      } else if (info.ac == AC_ABSENT) {
+         xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "bat %.1f%%", info.percent);
+      } else {
+         xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%.1f%%", info.percent);
+      }
+      return;
    }
 
-   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%.1f%%%s", info.percent, text);
+   /* stable: power unknown or |power| < 5 W – time estimate would be unreliable */
+   bool isDischarging = havePower && info.powerCurr <= -5.0;
+   bool isCharging = havePower && info.powerCurr >= 5.0;
+
+   /* time estimate in whole minutes; -1 means not available */
+   int timeMinutes = -1;
+   if (isDischarging && isPositive(info.energyCurr)) {
+      /* floor for discharge; powerCurr is negative, use negative scaling when dividing */
+      timeMinutes = (int)floor(info.energyCurr / info.powerCurr * -60.0);
+   } else if (isCharging && 0.95 * info.energyFull > info.energyCurr) {
+      /* ceil for charge; uses 95% to avoid slow charging tail near full */
+      timeMinutes = (int)ceil((0.95 * info.energyFull - info.energyCurr) / info.powerCurr * 60.0);
+   }
+
+   char* buf = this->txtBuffer;
+   size_t len = sizeof(this->txtBuffer);
+   int ret = 0;
+
+   if (this->mode == TEXT_METERMODE) {
+      if (info.ac == AC_PRESENT) {
+         ret = xSnprintf(buf, len, "Using %s", isDischarging ? "AC+bat" : "AC");
+         buf += ret; len -= ret;
+      } else if (info.ac == AC_ABSENT) {
+         ret = xSnprintf(buf, len, "Using bat");
+         buf += ret; len -= ret;
+      }
+
+      if (ret && len > 2) {
+         *buf++ = ',';
+         *buf++ = ' ';
+         *buf = 0;
+         len -= 2;
+      }
+
+      if (isDischarging) {
+         ret = xSnprintf(
+            buf, len, "discharging at %.1fW, %.1f/%.1fWh (%.1f%%)",
+            -info.powerCurr, info.energyCurr, info.energyFull, info.percent
+         );
+         buf += ret; len -= ret;
+         if (timeMinutes >= 0) {
+            ret = xSnprintf(buf, len, ", time remaining: %dh%02dm", timeMinutes / 60, timeMinutes % 60);
+            buf += ret; len -= ret;
+         }
+      } else if (isCharging) {
+         ret = xSnprintf(
+            buf, len, "charging at %.1fW, %.1f/%.1fWh (%.1f%%)",
+            info.powerCurr, info.energyCurr, info.energyFull, info.percent
+         );
+         buf += ret; len -= ret;
+
+         if (timeMinutes >= 0) {
+            ret = xSnprintf(
+               buf, len, ", time to full: %dh%02dm",
+               timeMinutes / 60, timeMinutes % 60
+            );
+            buf += ret; len -= ret;
+         }
+      } else {
+         ret = xSnprintf(
+            buf, len, "stable at %.1f/%.1fWh (%.1f%%)",
+            info.energyCurr, info.energyFull, info.percent
+         );
+         buf += ret; len -= ret;
+      }
+   } else {
+      /* compact label for bar / graph modes */
+      if (info.ac == AC_PRESENT) {
+         ret = xSnprintf(buf, len, "%s", isDischarging ? "AC+bat" : "AC");
+         buf += ret; len -= ret;
+      } else if (info.ac == AC_ABSENT) {
+         ret = xSnprintf(buf, len, "bat");
+         buf += ret; len -= ret;
+      }
+
+      if (ret && len > 1) {
+         *buf++ = ' ';
+         *buf = 0;
+         len--;
+      }
+
+      if (isCharging || isDischarging) {
+         ret = xSnprintf(
+            buf, len, "%+.1fW @ %.1f/%.1fWh",
+            info.powerCurr, info.energyCurr, info.energyFull
+         );
+         buf += ret; len -= ret;
+
+         if (timeMinutes >= 0) {
+            ret = xSnprintf(
+               buf, len, ", %dh%02dm",
+               timeMinutes / 60, timeMinutes % 60
+            );
+            buf += ret; len -= ret;
+         }
+      } else {
+         ret = xSnprintf(
+            buf, len, "stable @ %.1f/%.1fWh",
+            info.energyCurr, info.energyFull
+         );
+         buf += ret; len -= ret;
+      }
+   }
+
+   // Avoid compiler warning about unused variables
+   (void)ret;
+   (void)buf;
+   (void)len;
 }
 
 const MeterClass BatteryMeter_class = {

--- a/BatteryMeter.h
+++ b/BatteryMeter.h
@@ -22,6 +22,8 @@ typedef struct BatteryInfo_ {
    ACPresence ac;
 
    double percent;          /* [0..100], NAN if unknown */
+   double energyCurr;       /* Wh, NAN if unknown */
+   double energyFull;       /* Wh, NAN if unknown */
 } BatteryInfo;
 
 extern const MeterClass BatteryMeter_class;

--- a/BatteryMeter.h
+++ b/BatteryMeter.h
@@ -18,6 +18,12 @@ typedef enum ACPresence_ {
    AC_ERROR
 } ACPresence;
 
+typedef struct BatteryInfo_ {
+   ACPresence ac;
+
+   double percent;          /* [0..100], NAN if unknown */
+} BatteryInfo;
+
 extern const MeterClass BatteryMeter_class;
 
 #endif

--- a/BatteryMeter.h
+++ b/BatteryMeter.h
@@ -22,6 +22,7 @@ typedef struct BatteryInfo_ {
    ACPresence ac;
 
    double percent;          /* [0..100], NAN if unknown */
+   double powerCurr;        /* instantaneous power in W, NAN if unknown, derivative of stored battery energy */
    double energyCurr;       /* Wh, NAN if unknown */
    double energyFull;       /* Wh, NAN if unknown */
 } BatteryInfo;

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -49,6 +49,7 @@ in the source distribution for its full text.
 #include "SysArchMeter.h"
 #include "TasksMeter.h"
 #include "UptimeMeter.h"
+#include "XUtils.h"
 #include "darwin/DarwinMachine.h"
 #include "darwin/PlatformHelpers.h"
 #include "generic/fdstat_sysctl.h"
@@ -727,8 +728,39 @@ void Platform_getBattery(BatteryInfo* info) {
 
    if (cap_max > 0.0) {
       info->percent = 100.0 * cap_current / cap_max;
-      info->energyCurr = cap_current;
-      info->energyFull = cap_max;
+   }
+
+   io_service_t batt = IOServiceGetMatchingService(iokit_port, IOServiceMatching("AppleSmartBattery"));
+   if (batt) {
+      CFNumberRef voltRef = IORegistryEntryCreateCFProperty(batt, CFSTR("Voltage"), kCFAllocatorDefault, 0);
+      CFNumberRef currCapRef = IORegistryEntryCreateCFProperty(batt, CFSTR("AppleRawCurrentCapacity"), kCFAllocatorDefault, 0);
+      CFNumberRef maxCapRef = IORegistryEntryCreateCFProperty(batt, CFSTR("AppleRawMaxCapacity"), kCFAllocatorDefault, 0);
+
+      if (currCapRef && maxCapRef && voltRef) {
+         double currMAh = 0.0;
+         CFNumberGetValue(currCapRef, kCFNumberDoubleType, &currMAh);
+
+         double maxMAh = 0.0;
+         CFNumberGetValue(maxCapRef, kCFNumberDoubleType, &maxMAh);
+
+         double voltMV = 0.0;
+         CFNumberGetValue(voltRef, kCFNumberDoubleType, &voltMV);
+
+         /* Approximate energy from charge and current battery voltage: mAh * mV / 1e6 = Wh. */
+         if (maxMAh > 0.0 && voltMV > 0.0) {
+            info->energyCurr = CLAMP(currMAh, 0.0, maxMAh) * voltMV / 1e6;
+            info->energyFull = maxMAh * voltMV / 1e6;
+         }
+      }
+
+      if (maxCapRef)
+         CFRelease(maxCapRef);
+      if (currCapRef)
+         CFRelease(currCapRef);
+      if (voltRef)
+         CFRelease(voltRef);
+
+      IOObjectRelease(batt);
    }
 
 cleanup:

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -681,6 +681,8 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 
    CFArrayRef list = NULL;
@@ -723,8 +725,11 @@ void Platform_getBattery(BatteryInfo* info) {
       cap_max += tmp;
    }
 
-   if (cap_max > 0.0)
+   if (cap_max > 0.0) {
       info->percent = 100.0 * cap_current / cap_max;
+      info->energyCurr = cap_current;
+      info->energyFull = cap_max;
+   }
 
 cleanup:
    if (list)

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -677,9 +677,11 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    return true;
 }
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC) {
-   *percent = NAN;
-   *isOnAC = AC_ERROR;
+void Platform_getBattery(BatteryInfo* info) {
+   *info = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
 
    CFArrayRef list = NULL;
 
@@ -710,8 +712,8 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
       /* Determine the AC state */
       CFStringRef power_state = CFDictionaryGetValue(power_source, CFSTR(kIOPSPowerSourceStateKey));
 
-      if (*isOnAC != AC_PRESENT)
-         *isOnAC = (kCFCompareEqualTo == CFStringCompare(power_state, CFSTR(kIOPSACPowerValue), 0)) ? AC_PRESENT : AC_ABSENT;
+      if (info->ac != AC_PRESENT)
+         info->ac = (kCFCompareEqualTo == CFStringCompare(power_state, CFSTR(kIOPSACPowerValue), 0)) ? AC_PRESENT : AC_ABSENT;
 
       /* Get the percentage remaining */
       double tmp;
@@ -722,7 +724,7 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
    }
 
    if (cap_max > 0.0)
-      *percent = 100.0 * cap_current / cap_max;
+      info->percent = 100.0 * cap_current / cap_max;
 
 cleanup:
    if (list)

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -682,6 +682,7 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .powerCurr = NAN,
       .energyCurr = NAN,
       .energyFull = NAN,
    };
@@ -732,9 +733,21 @@ void Platform_getBattery(BatteryInfo* info) {
 
    io_service_t batt = IOServiceGetMatchingService(iokit_port, IOServiceMatching("AppleSmartBattery"));
    if (batt) {
+      CFNumberRef ampRef = IORegistryEntryCreateCFProperty(batt, CFSTR("Amperage"), kCFAllocatorDefault, 0);
       CFNumberRef voltRef = IORegistryEntryCreateCFProperty(batt, CFSTR("Voltage"), kCFAllocatorDefault, 0);
       CFNumberRef currCapRef = IORegistryEntryCreateCFProperty(batt, CFSTR("AppleRawCurrentCapacity"), kCFAllocatorDefault, 0);
       CFNumberRef maxCapRef = IORegistryEntryCreateCFProperty(batt, CFSTR("AppleRawMaxCapacity"), kCFAllocatorDefault, 0);
+
+      if (ampRef && voltRef) {
+         double ampMA = 0.0;
+         CFNumberGetValue(ampRef, kCFNumberDoubleType, &ampMA);
+
+         double voltMV = 0.0;
+         CFNumberGetValue(voltRef, kCFNumberDoubleType, &voltMV);
+
+         // Follows the Smart Battery System (SBS) Standard
+         info->powerCurr = ampMA * voltMV / 1e6;
+      }
 
       if (currCapRef && maxCapRef && voltRef) {
          double currMAh = 0.0;
@@ -759,6 +772,8 @@ void Platform_getBattery(BatteryInfo* info) {
          CFRelease(currCapRef);
       if (voltRef)
          CFRelease(voltRef);
+      if (ampRef)
+         CFRelease(ampRef);
 
       IOObjectRelease(batt);
    }

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -683,6 +683,8 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 
    CFArrayRef list = NULL;
@@ -725,8 +727,11 @@ void Platform_getBattery(BatteryInfo* info) {
       cap_max += tmp;
    }
 
-   if (cap_max > 0.0)
+   if (cap_max > 0.0) {
       info->percent = 100.0 * cap_current / cap_max;
+      info->energyCurr = cap_current;
+      info->energyFull = cap_max;
+   }
 
 cleanup:
    if (list)

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -679,9 +679,11 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    return true;
 }
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC) {
-   *percent = NAN;
-   *isOnAC = AC_ERROR;
+void Platform_getBattery(BatteryInfo* info) {
+   *info = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
 
    CFArrayRef list = NULL;
 
@@ -712,8 +714,8 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
       /* Determine the AC state */
       CFStringRef power_state = CFDictionaryGetValue(power_source, CFSTR(kIOPSPowerSourceStateKey));
 
-      if (*isOnAC != AC_PRESENT)
-         *isOnAC = (kCFCompareEqualTo == CFStringCompare(power_state, CFSTR(kIOPSACPowerValue), 0)) ? AC_PRESENT : AC_ABSENT;
+      if (info->ac != AC_PRESENT)
+         info->ac = (kCFCompareEqualTo == CFStringCompare(power_state, CFSTR(kIOPSACPowerValue), 0)) ? AC_PRESENT : AC_ABSENT;
 
       /* Get the percentage remaining */
       double tmp;
@@ -724,7 +726,7 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
    }
 
    if (cap_max > 0.0)
-      *percent = 100.0 * cap_current / cap_max;
+      info->percent = 100.0 * cap_current / cap_max;
 
 cleanup:
    if (list)

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -684,6 +684,7 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .powerCurr = NAN,
       .energyCurr = NAN,
       .energyFull = NAN,
    };
@@ -734,9 +735,21 @@ void Platform_getBattery(BatteryInfo* info) {
 
    io_service_t batt = IOServiceGetMatchingService(iokit_port, IOServiceMatching("AppleSmartBattery"));
    if (batt) {
+      CFNumberRef ampRef = IORegistryEntryCreateCFProperty(batt, CFSTR("Amperage"), kCFAllocatorDefault, 0);
       CFNumberRef voltRef = IORegistryEntryCreateCFProperty(batt, CFSTR("Voltage"), kCFAllocatorDefault, 0);
       CFNumberRef currCapRef = IORegistryEntryCreateCFProperty(batt, CFSTR("AppleRawCurrentCapacity"), kCFAllocatorDefault, 0);
       CFNumberRef maxCapRef = IORegistryEntryCreateCFProperty(batt, CFSTR("AppleRawMaxCapacity"), kCFAllocatorDefault, 0);
+
+      if (ampRef && voltRef) {
+         double ampMA = 0.0;
+         CFNumberGetValue(ampRef, kCFNumberDoubleType, &ampMA);
+
+         double voltMV = 0.0;
+         CFNumberGetValue(voltRef, kCFNumberDoubleType, &voltMV);
+
+         // Follows the Smart Battery System (SBS) Standard
+         info->powerCurr = ampMA * voltMV / 1e6;
+      }
 
       if (currCapRef && maxCapRef && voltRef) {
          double currMAh = 0.0;
@@ -761,6 +774,8 @@ void Platform_getBattery(BatteryInfo* info) {
          CFRelease(currCapRef);
       if (voltRef)
          CFRelease(voltRef);
+      if (ampRef)
+         CFRelease(ampRef);
 
       IOObjectRelease(batt);
    }

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -49,6 +49,7 @@ in the source distribution for its full text.
 #include "SysArchMeter.h"
 #include "TasksMeter.h"
 #include "UptimeMeter.h"
+#include "XUtils.h"
 #include "darwin/DarwinMachine.h"
 #include "darwin/PlatformHelpers.h"
 #include "generic/fdstat_sysctl.h"
@@ -729,8 +730,39 @@ void Platform_getBattery(BatteryInfo* info) {
 
    if (cap_max > 0.0) {
       info->percent = 100.0 * cap_current / cap_max;
-      info->energyCurr = cap_current;
-      info->energyFull = cap_max;
+   }
+
+   io_service_t batt = IOServiceGetMatchingService(iokit_port, IOServiceMatching("AppleSmartBattery"));
+   if (batt) {
+      CFNumberRef voltRef = IORegistryEntryCreateCFProperty(batt, CFSTR("Voltage"), kCFAllocatorDefault, 0);
+      CFNumberRef currCapRef = IORegistryEntryCreateCFProperty(batt, CFSTR("AppleRawCurrentCapacity"), kCFAllocatorDefault, 0);
+      CFNumberRef maxCapRef = IORegistryEntryCreateCFProperty(batt, CFSTR("AppleRawMaxCapacity"), kCFAllocatorDefault, 0);
+
+      if (currCapRef && maxCapRef && voltRef) {
+         double currMAh = 0.0;
+         CFNumberGetValue(currCapRef, kCFNumberDoubleType, &currMAh);
+
+         double maxMAh = 0.0;
+         CFNumberGetValue(maxCapRef, kCFNumberDoubleType, &maxMAh);
+
+         double voltMV = 0.0;
+         CFNumberGetValue(voltRef, kCFNumberDoubleType, &voltMV);
+
+         /* Approximate energy from charge and current battery voltage: mAh * mV / 1e6 = Wh. */
+         if (maxMAh > 0.0 && voltMV > 0.0) {
+            info->energyCurr = CLAMP(currMAh, 0.0, maxMAh) * voltMV / 1e6;
+            info->energyFull = maxMAh * voltMV / 1e6;
+         }
+      }
+
+      if (maxCapRef)
+         CFRelease(maxCapRef);
+      if (currCapRef)
+         CFRelease(currCapRef);
+      if (voltRef)
+         CFRelease(voltRef);
+
+      IOObjectRelease(batt);
    }
 
 cleanup:

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -83,7 +83,7 @@ bool Platform_getDiskIO(DiskIOData* data);
 
 bool Platform_getNetworkIO(NetworkIOData* data);
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC);
+void Platform_getBattery(BatteryInfo* info);
 
 static inline void Platform_getHostname(char* buffer, size_t size) {
    Generic_hostname(buffer, size);

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -367,6 +367,8 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 
    int life;

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -363,18 +363,19 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    return true;
 }
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC) {
+void Platform_getBattery(BatteryInfo* info) {
+   *info = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
+
    int life;
    size_t life_len = sizeof(life);
-   if (sysctlbyname("hw.acpi.battery.life", &life, &life_len, NULL, 0) == -1)
-      *percent = NAN;
-   else
-      *percent = life;
+   if (sysctlbyname("hw.acpi.battery.life", &life, &life_len, NULL, 0) != -1)
+      info->percent = life;
 
    int acline;
    size_t acline_len = sizeof(acline);
-   if (sysctlbyname("hw.acpi.acline", &acline, &acline_len, NULL, 0) == -1)
-      *isOnAC = AC_ERROR;
-   else
-      *isOnAC = acline == 0 ? AC_ABSENT : AC_PRESENT;
+   if (sysctlbyname("hw.acpi.acline", &acline, &acline_len, NULL, 0) != -1)
+      info->ac = (acline == 0) ? AC_ABSENT : AC_PRESENT;
 }

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -380,4 +380,76 @@ void Platform_getBattery(BatteryInfo* info) {
    size_t acline_len = sizeof(acline);
    if (sysctlbyname("hw.acpi.acline", &acline, &acline_len, NULL, 0) != -1)
       info->ac = (acline == 0) ? AC_ABSENT : AC_PRESENT;
+
+   int units = 0;
+   int fd = open("/dev/acpi", O_RDONLY | O_CLOEXEC);
+   if (fd == -1)
+      return;
+
+   if (ioctl(fd, ACPIIO_BATT_GET_UNITS, &units) == -1 || units <= 0) {
+      close(fd);
+      return;
+   }
+
+   bool haveTotalRemain = false;
+   bool haveTotalFull = false;
+
+   int64_t totalRemain = 0;
+   int64_t totalFull = 0;
+
+   for (int u = 0; u < units; u++) {
+      union acpi_battery_ioctl_arg bifArg = { .unit = u };
+      if (ioctl(fd, ACPIIO_BATT_GET_BIF, &bifArg) == -1)
+         continue;
+
+      union acpi_battery_ioctl_arg bstArg = { .unit = u };
+      if (ioctl(fd, ACPIIO_BATT_GET_BST, &bstArg) == -1)
+         continue;
+
+      const struct acpi_bif* bif = &bifArg.bif;
+      const struct acpi_bst* bst = &bstArg.bst;
+
+      bool haveBatteryEnergyCurr = false;
+      bool haveBatteryEnergyFull = false;
+
+      int64_t batteryEnergyCurr = 0;
+      int64_t batteryEnergyFull = 0;
+
+      if (bif->lfcap != ACPI_BATT_UNKNOWN && bst->cap != ACPI_BATT_UNKNOWN) {
+         if (bif->units == ACPI_BIF_UNITS_MW) {
+            batteryEnergyCurr = (int64_t) bst->cap * 1000;
+            batteryEnergyFull = (int64_t) bif->lfcap * 1000;
+            haveBatteryEnergyCurr = true;
+            haveBatteryEnergyFull = true;
+         } else {
+            uint32_t batteryVoltage = (bst->volt != ACPI_BATT_UNKNOWN) ? bst->volt : bif->dvol;
+            if (batteryVoltage != ACPI_BATT_UNKNOWN && batteryVoltage != 0) {
+               batteryEnergyCurr = (int64_t) bst->cap * batteryVoltage;
+               batteryEnergyFull = (int64_t) bif->lfcap * batteryVoltage;
+               haveBatteryEnergyCurr = true;
+               haveBatteryEnergyFull = true;
+            }
+         }
+      }
+
+      if (haveBatteryEnergyCurr && haveBatteryEnergyFull && batteryEnergyFull > 0) {
+         totalRemain += batteryEnergyCurr;
+         haveTotalRemain = true;
+
+         totalFull += batteryEnergyFull;
+         haveTotalFull = true;
+      }
+   }
+
+   close(fd);
+
+   if (haveTotalRemain && haveTotalFull && totalFull > 0) {
+      if (isnan(info->percent)) {
+         info->percent = ((double) totalRemain * 100.0) / (double) totalFull;
+         if (totalRemain >= totalFull)
+            info->percent = 100;
+      }
+      info->energyCurr = (double) totalRemain / 1000000.0;
+      info->energyFull = (double) totalFull / 1000000.0;
+   }
 }

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -12,9 +12,13 @@ in the source distribution for its full text.
 
 #include <devstat.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <ifaddrs.h>
 #include <math.h>
 #include <time.h>
+#include <unistd.h>
+#include <dev/acpica/acpiio.h>
+#include <sys/ioctl.h>
 #include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/sysctl.h>
@@ -367,6 +371,7 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .powerCurr = NAN,
       .energyCurr = NAN,
       .energyFull = NAN,
    };
@@ -393,9 +398,11 @@ void Platform_getBattery(BatteryInfo* info) {
 
    bool haveTotalRemain = false;
    bool haveTotalFull = false;
+   bool haveTotalPower = false;
 
    int64_t totalRemain = 0;
    int64_t totalFull = 0;
+   int64_t totalPower = 0;
 
    for (int u = 0; u < units; u++) {
       union acpi_battery_ioctl_arg bifArg = { .unit = u };
@@ -411,9 +418,11 @@ void Platform_getBattery(BatteryInfo* info) {
 
       bool haveBatteryEnergyCurr = false;
       bool haveBatteryEnergyFull = false;
+      bool haveBatteryPower = false;
 
       int64_t batteryEnergyCurr = 0;
       int64_t batteryEnergyFull = 0;
+      int64_t batteryPower = 0;
 
       if (bif->lfcap != ACPI_BATT_UNKNOWN && bst->cap != ACPI_BATT_UNKNOWN) {
          if (bif->units == ACPI_BIF_UNITS_MW) {
@@ -439,6 +448,30 @@ void Platform_getBattery(BatteryInfo* info) {
          totalFull += batteryEnergyFull;
          haveTotalFull = true;
       }
+
+      if (bst->rate == ACPI_BATT_UNKNOWN)
+         continue;
+
+      if (bif->units == ACPI_BIF_UNITS_MW) {
+         batteryPower = (int64_t) bst->rate * 1000;
+         haveBatteryPower = true;
+      } else {
+         uint32_t batteryVoltage = (bst->volt != ACPI_BATT_UNKNOWN) ? bst->volt : bif->dvol;
+
+         if (batteryVoltage != ACPI_BATT_UNKNOWN && batteryVoltage != 0) {
+            batteryPower = (int64_t) bst->rate * batteryVoltage;
+            haveBatteryPower = true;
+         }
+      }
+
+      if (!haveBatteryPower)
+         continue;
+
+      if (bst->state & ACPI_BATT_STAT_DISCHARG)
+         batteryPower = -batteryPower;
+
+      totalPower += batteryPower;
+      haveTotalPower = true;
    }
 
    close(fd);
@@ -451,5 +484,9 @@ void Platform_getBattery(BatteryInfo* info) {
       }
       info->energyCurr = (double) totalRemain / 1000000.0;
       info->energyFull = (double) totalFull / 1000000.0;
+   }
+
+   if (haveTotalPower) {
+      info->powerCurr = (double) totalPower / 1000000.0;
    }
 }

--- a/dragonflybsd/Platform.h
+++ b/dragonflybsd/Platform.h
@@ -71,7 +71,7 @@ bool Platform_getDiskIO(DiskIOData* data);
 
 bool Platform_getNetworkIO(NetworkIOData* data);
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC);
+void Platform_getBattery(BatteryInfo* info);
 
 static inline void Platform_getHostname(char* buffer, size_t size) {
    Generic_hostname(buffer, size);

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -388,6 +388,8 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 
    int life;

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -10,14 +10,18 @@ in the source distribution for its full text.
 #include "freebsd/Platform.h"
 
 #include <devstat.h>
+#include <fcntl.h>
 #include <math.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <time.h>
+#include <unistd.h>
+#include <dev/acpica/acpiio.h>
 #include <net/if.h>
 #include <net/if_mib.h>
 #include <sys/_types.h>
 #include <sys/devicestat.h>
+#include <sys/ioctl.h>
 #include <sys/param.h>
 #include <sys/resource.h>
 #include <sys/socket.h>
@@ -401,4 +405,73 @@ void Platform_getBattery(BatteryInfo* info) {
    size_t acline_len = sizeof(acline);
    if (sysctlbyname("hw.acpi.acline", &acline, &acline_len, NULL, 0) != -1)
       info->ac = (acline == 0) ? AC_ABSENT : AC_PRESENT;
+
+   int units = 0;
+   size_t units_len = sizeof(units);
+   if (sysctlbyname("hw.acpi.battery.units", &units, &units_len, NULL, 0) == -1 || units <= 0)
+      return;
+
+   int fd = open("/dev/acpi", O_RDONLY | O_CLOEXEC);
+   if (fd == -1)
+      return;
+
+   bool haveTotalRemain = false;
+   bool haveTotalFull = false;
+
+   int64_t totalRemain = 0;
+   int64_t totalFull = 0;
+
+   for (int u = 0; u < units; u++) {
+      union acpi_battery_ioctl_arg bixArg = { .unit = u };
+      if (ioctl(fd, ACPIIO_BATT_GET_BIX, &bixArg) == -1)
+         continue;
+
+      union acpi_battery_ioctl_arg bstArg = { .unit = u };
+      if (ioctl(fd, ACPIIO_BATT_GET_BST, &bstArg) == -1)
+         continue;
+
+      const struct acpi_bix* bix = &bixArg.bix;
+      const struct acpi_bst* bst = &bstArg.bst;
+
+      bool haveBatteryEnergyCurr = false;
+      bool haveBatteryEnergyFull = false;
+
+      int64_t batteryEnergyCurr = 0;
+      int64_t batteryEnergyFull = 0;
+
+      if (bix->lfcap != ACPI_BATT_UNKNOWN && bst->cap != ACPI_BATT_UNKNOWN) {
+         if (bix->units == ACPI_BIX_UNITS_MW) {
+            batteryEnergyCurr = (int64_t) bst->cap * 1000;
+            batteryEnergyFull = (int64_t) bix->lfcap * 1000;
+            haveBatteryEnergyCurr = true;
+            haveBatteryEnergyFull = true;
+         } else {
+            uint32_t batteryVoltage = (bst->volt != ACPI_BATT_UNKNOWN) ? bst->volt : bix->dvol;
+            if (batteryVoltage != ACPI_BATT_UNKNOWN && batteryVoltage != 0) {
+               batteryEnergyCurr = (int64_t) bst->cap * batteryVoltage;
+               batteryEnergyFull = (int64_t) bix->lfcap * batteryVoltage;
+               haveBatteryEnergyCurr = true;
+               haveBatteryEnergyFull = true;
+            }
+         }
+      }
+
+      if (haveBatteryEnergyCurr && haveBatteryEnergyFull && batteryEnergyFull > 0) {
+         totalRemain += batteryEnergyCurr;
+         totalFull += batteryEnergyFull;
+         haveTotalRemain = true;
+         haveTotalFull = true;
+      }
+   }
+
+   close(fd);
+
+   if (haveTotalRemain && haveTotalFull && totalFull > 0) {
+      info->percent = ((double) totalRemain * 100.0) / (double) totalFull;
+      if (totalRemain >= totalFull)
+         info->percent = 100;
+
+      info->energyCurr = (double) totalRemain / 1000000.0;
+      info->energyFull = (double) totalFull / 1000000.0;
+   }
 }

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -392,6 +392,7 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .powerCurr = NAN,
       .energyCurr = NAN,
       .energyFull = NAN,
    };
@@ -417,9 +418,11 @@ void Platform_getBattery(BatteryInfo* info) {
 
    bool haveTotalRemain = false;
    bool haveTotalFull = false;
+   bool haveTotalPower = false;
 
    int64_t totalRemain = 0;
    int64_t totalFull = 0;
+   int64_t totalPower = 0;
 
    for (int u = 0; u < units; u++) {
       union acpi_battery_ioctl_arg bixArg = { .unit = u };
@@ -435,9 +438,11 @@ void Platform_getBattery(BatteryInfo* info) {
 
       bool haveBatteryEnergyCurr = false;
       bool haveBatteryEnergyFull = false;
+      bool haveBatteryPower = false;
 
       int64_t batteryEnergyCurr = 0;
       int64_t batteryEnergyFull = 0;
+      int64_t batteryPower = 0;
 
       if (bix->lfcap != ACPI_BATT_UNKNOWN && bst->cap != ACPI_BATT_UNKNOWN) {
          if (bix->units == ACPI_BIX_UNITS_MW) {
@@ -462,6 +467,27 @@ void Platform_getBattery(BatteryInfo* info) {
          haveTotalRemain = true;
          haveTotalFull = true;
       }
+
+      if (bst->rate != ACPI_BATT_UNKNOWN && bst->rate > 0) {
+         if (bix->units == ACPI_BIX_UNITS_MW) {
+            batteryPower = (int64_t) bst->rate * 1000;
+            haveBatteryPower = true;
+         } else {
+            uint32_t rateVoltage = (bst->volt != ACPI_BATT_UNKNOWN) ? bst->volt : bix->dvol;
+
+            if (rateVoltage != ACPI_BATT_UNKNOWN && rateVoltage != 0) {
+               batteryPower = (int64_t) bst->rate * rateVoltage;
+               haveBatteryPower = true;
+            }
+         }
+      }
+
+      if (haveBatteryPower) {
+         if (bst->state & ACPI_BATT_STAT_DISCHARG)
+            batteryPower = -batteryPower;
+         totalPower += batteryPower;
+         haveTotalPower = true;
+      }
    }
 
    close(fd);
@@ -473,5 +499,9 @@ void Platform_getBattery(BatteryInfo* info) {
 
       info->energyCurr = (double) totalRemain / 1000000.0;
       info->energyFull = (double) totalFull / 1000000.0;
+   }
+
+   if (haveTotalPower) {
+      info->powerCurr = (double) totalPower / 1000000.0;
    }
 }

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -384,18 +384,19 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    return true;
 }
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC) {
+void Platform_getBattery(BatteryInfo* info) {
+   *info = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
+
    int life;
    size_t life_len = sizeof(life);
-   if (sysctlbyname("hw.acpi.battery.life", &life, &life_len, NULL, 0) == -1)
-      *percent = NAN;
-   else
-      *percent = life;
+   if (sysctlbyname("hw.acpi.battery.life", &life, &life_len, NULL, 0) != -1)
+      info->percent = life;
 
    int acline;
    size_t acline_len = sizeof(acline);
-   if (sysctlbyname("hw.acpi.acline", &acline, &acline_len, NULL, 0) == -1)
-      *isOnAC = AC_ERROR;
-   else
-      *isOnAC = acline == 0 ? AC_ABSENT : AC_PRESENT;
+   if (sysctlbyname("hw.acpi.acline", &acline, &acline_len, NULL, 0) != -1)
+      info->ac = (acline == 0) ? AC_ABSENT : AC_PRESENT;
 }

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -71,7 +71,7 @@ bool Platform_getDiskIO(DiskIOData* data);
 
 bool Platform_getNetworkIO(NetworkIOData* data);
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC);
+void Platform_getBattery(BatteryInfo* info);
 
 static inline void Platform_getHostname(char* buffer, size_t size) {
    Generic_hostname(buffer, size);

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -166,6 +166,8 @@ static time_t Platform_Battery_cacheTime;
 static BatteryInfo Platform_Battery_cache = {
    .ac = AC_ERROR,
    .percent = NAN,
+   .energyCurr = NAN,
+   .energyFull = NAN,
 };
 
 #ifdef HAVE_LIBCAP
@@ -850,6 +852,8 @@ static void Platform_Battery_getProcData(BatteryInfo* info) {
 static void Platform_Battery_getSysData(BatteryInfo* info) {
    info->percent = NAN;
    info->ac = AC_ERROR;
+   info->energyCurr = NAN;
+   info->energyFull = NAN;
 
    DIR* dir = opendir(SYS_POWERSUPPLY_DIR);
    if (!dir)
@@ -964,6 +968,10 @@ next:
    closedir(dir);
 
    info->percent = totalFull > 0 ? ((double) totalRemain * 100.0) / (double) totalFull : NAN;
+   if (totalFull > 0) {
+      info->energyCurr = (double) totalRemain;
+      info->energyFull = (double) totalFull;
+   }
 }
 
 void Platform_getBattery(BatteryInfo* info) {
@@ -977,6 +985,8 @@ void Platform_getBattery(BatteryInfo* info) {
    Platform_Battery_cache = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 
    if (Platform_Battery_method == BAT_PROC) {

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -904,46 +904,109 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
          if (r < 0)
             goto next;
 
-         bool full = false;
-         bool now = false;
+         bool haveBatteryEnergyFull = false;
+         bool haveBatteryEnergyCurr = false;
 
-         double fullCharge = 0;
-         double capacityLevel = NAN;
+         bool haveBatteryChargeFull = false;
+         bool haveBatteryChargeCurr = false;
+
+         uint8_t haveBatteryVoltage = 0; // 0 = no, 1 = min_voltage, 2 = curr_voltage
+         bool haveBatteryLevel = false;
+
+         uint64_t batteryEnergyFull = 0;
+         uint64_t batteryEnergyCurr = 0;
+
+         uint64_t batteryChargeFull = 0;
+         uint64_t batteryChargeCurr = 0;
+
+         uint64_t batteryVoltage = 0;
+         uint64_t batteryLevel = 0;
+
          const char* line;
 
          char* buf = buffer;
          while ((line = strsep(&buf, "\n")) != NULL) {
             char field[100] = {0};
-            int val = 0;
-            if (2 != sscanf(line, "POWER_SUPPLY_%99[^=]=%d", field, &val))
+            int64_t val = 0;
+            if (2 != sscanf(line, "POWER_SUPPLY_%99[^=]=%" SCNd64, field, &val)) {
+               char strField[100] = {0};
+               char strVal[32] = {0};
+               if (2 == sscanf(line, "POWER_SUPPLY_%99[^=]=%31s", strField, strVal) &&
+                   String_eq(strField, "STATUS"))
+                  batteryIsDischarging = String_eq(strVal, "Discharging");
                continue;
+            }
 
             if (String_eq(field, "CAPACITY")) {
-               capacityLevel = val / 100.0;
+               batteryLevel = val;
+               haveBatteryLevel = true;
                continue;
             }
 
-            if (String_eq(field, "ENERGY_FULL") || String_eq(field, "CHARGE_FULL")) {
-               fullCharge = val;
-               totalFull += fullCharge;
-               full = true;
-               if (now)
-                  break;
+            if (String_eq(field, "ENERGY_FULL")) {
+               batteryEnergyFull = val;
+               haveBatteryEnergyFull = true;
                continue;
             }
 
-            if (String_eq(field, "ENERGY_NOW") || String_eq(field, "CHARGE_NOW")) {
-               totalRemain += val;
-               now = true;
-               if (full)
-                  break;
+            if (String_eq(field, "CHARGE_FULL")) {
+               batteryChargeFull = val;
+               haveBatteryChargeFull = true;
+               continue;
+            }
+
+            if (String_eq(field, "ENERGY_NOW")) {
+               batteryEnergyCurr = val;
+               haveBatteryEnergyCurr = true;
+               continue;
+            }
+
+            if (String_eq(field, "CHARGE_NOW")) {
+               batteryChargeCurr = val;
+               haveBatteryChargeCurr = true;
+               continue;
+            }
+
+            if (haveBatteryVoltage < 1 && String_eq(field, "VOLTAGE_MIN_DESIGN")) {
+               batteryVoltage = val;
+               haveBatteryVoltage = 1;
+               continue;
+            }
+
+            if (haveBatteryVoltage < 2 && String_eq(field, "VOLTAGE_NOW")) {
+               batteryVoltage = val;
+               haveBatteryVoltage = 2;
                continue;
             }
          }
 
-         if (!now && full && isNonnegative(capacityLevel))
-            totalRemain += capacityLevel * fullCharge;
+         if (haveBatteryLevel) {
+            // If we have capacity level but not charge or energy, we infer approximate values
+            if (haveBatteryChargeFull && !haveBatteryChargeCurr) {
+               batteryChargeCurr = batteryChargeFull * batteryLevel / 100.0;
+               haveBatteryChargeCurr = true;
+            }
+            if (haveBatteryEnergyFull && !haveBatteryEnergyCurr) {
+               batteryEnergyCurr = batteryEnergyFull * batteryLevel / 100.0;
+               haveBatteryEnergyCurr = true;
+            }
+         }
 
+         if (haveBatteryEnergyFull && haveBatteryEnergyCurr) {
+            // No need for conversion needed
+         } else if (haveBatteryChargeFull && haveBatteryChargeCurr && haveBatteryVoltage) {
+            // Convert charge to energy using voltage
+            batteryEnergyFull = (batteryChargeFull * batteryVoltage) / 1000000;
+            haveBatteryEnergyFull = true;
+
+            batteryEnergyCurr = (batteryChargeCurr * batteryVoltage) / 1000000;
+            haveBatteryEnergyCurr = true;
+         }
+
+         if (haveBatteryEnergyFull && haveBatteryEnergyCurr && batteryEnergyFull > 0) {
+            totalFull += batteryEnergyFull;
+            totalRemain += batteryEnergyCurr > batteryEnergyFull ? batteryEnergyFull : batteryEnergyCurr;
+         }
       } else if (type == AC) {
          if (info->ac != AC_ERROR)
             goto next;
@@ -967,10 +1030,10 @@ next:
 
    closedir(dir);
 
-   info->percent = totalFull > 0 ? ((double) totalRemain * 100.0) / (double) totalFull : NAN;
    if (totalFull > 0) {
-      info->energyCurr = (double) totalRemain;
-      info->energyFull = (double) totalFull;
+      info->percent = ((double) totalRemain * 100.0) / (double) totalFull;
+      info->energyCurr = (double) totalRemain / 1000000.0;
+      info->energyFull = (double) totalFull / 1000000.0;
    }
 }
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -163,8 +163,10 @@ const unsigned int Platform_numberOfMemoryClasses = ARRAYSIZE(Platform_memoryCla
 
 static enum { BAT_PROC, BAT_SYS, BAT_ERR } Platform_Battery_method = BAT_PROC;
 static time_t Platform_Battery_cacheTime;
-static double Platform_Battery_cachePercent = NAN;
-static ACPresence Platform_Battery_cacheIsOnAC;
+static BatteryInfo Platform_Battery_cache = {
+   .ac = AC_ERROR,
+   .percent = NAN,
+};
 
 #ifdef HAVE_LIBCAP
 static enum CapMode Platform_capabilitiesMode = CAP_MODE_BASIC;
@@ -836,18 +838,18 @@ static ACPresence procAcpiCheck(void) {
    return String_eq(buffer, "on-line") ? AC_PRESENT : AC_ABSENT;
 }
 
-static void Platform_Battery_getProcData(double* percent, ACPresence* isOnAC) {
-   *isOnAC = procAcpiCheck();
-   *percent = AC_ERROR != *isOnAC ? Platform_Battery_getProcBatInfo() : NAN;
+static void Platform_Battery_getProcData(BatteryInfo* info) {
+   info->ac = procAcpiCheck();
+   info->percent = AC_ERROR != info->ac ? Platform_Battery_getProcBatInfo() : NAN;
 }
 
 // ----------------------------------------
 // READ FROM /sys
 // ----------------------------------------
 
-static void Platform_Battery_getSysData(double* percent, ACPresence* isOnAC) {
-   *percent = NAN;
-   *isOnAC = AC_ERROR;
+static void Platform_Battery_getSysData(BatteryInfo* info) {
+   info->percent = NAN;
+   info->ac = AC_ERROR;
 
    DIR* dir = opendir(SYS_POWERSUPPLY_DIR);
    if (!dir)
@@ -939,20 +941,20 @@ static void Platform_Battery_getSysData(double* percent, ACPresence* isOnAC) {
             totalRemain += capacityLevel * fullCharge;
 
       } else if (type == AC) {
-         if (*isOnAC != AC_ERROR)
+         if (info->ac != AC_ERROR)
             goto next;
 
          char buffer[2];
          ssize_t r = Compat_readfileat(entryFd, "online", buffer, sizeof(buffer));
          if (r < 1) {
-            *isOnAC = AC_ERROR;
+            info->ac = AC_ERROR;
             goto next;
          }
 
          if (buffer[0] == '0')
-            *isOnAC = AC_ABSENT;
+            info->ac = AC_ABSENT;
          else if (buffer[0] == '1')
-            *isOnAC = AC_PRESENT;
+            info->ac = AC_PRESENT;
       }
 
 next:
@@ -961,37 +963,39 @@ next:
 
    closedir(dir);
 
-   *percent = totalFull > 0 ? ((double) totalRemain * 100.0) / (double) totalFull : NAN;
+   info->percent = totalFull > 0 ? ((double) totalRemain * 100.0) / (double) totalFull : NAN;
 }
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC) {
+void Platform_getBattery(BatteryInfo* info) {
    time_t now = time(NULL);
    // update battery reading is slow. Update it each 10 seconds only.
    if (now < Platform_Battery_cacheTime + 10) {
-      *percent = Platform_Battery_cachePercent;
-      *isOnAC = Platform_Battery_cacheIsOnAC;
+      *info = Platform_Battery_cache;
       return;
    }
 
+   Platform_Battery_cache = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
+
    if (Platform_Battery_method == BAT_PROC) {
-      Platform_Battery_getProcData(percent, isOnAC);
-      if (!isNonnegative(*percent))
+      Platform_Battery_getProcData(&Platform_Battery_cache);
+      if (!isNonnegative(Platform_Battery_cache.percent))
          Platform_Battery_method = BAT_SYS;
    }
    if (Platform_Battery_method == BAT_SYS) {
-      Platform_Battery_getSysData(percent, isOnAC);
-      if (!isNonnegative(*percent))
+      Platform_Battery_getSysData(&Platform_Battery_cache);
+      if (!isNonnegative(Platform_Battery_cache.percent))
          Platform_Battery_method = BAT_ERR;
    }
-   if (Platform_Battery_method == BAT_ERR) {
-      *percent = NAN;
-      *isOnAC = AC_ERROR;
-   } else {
-      *percent = CLAMP(*percent, 0.0, 100.0);
+   if (Platform_Battery_method != BAT_ERR) {
+      Platform_Battery_cache.percent = CLAMP(Platform_Battery_cache.percent, 0.0, 100.0);
    }
-   Platform_Battery_cachePercent = *percent;
-   Platform_Battery_cacheIsOnAC = *isOnAC;
+
    Platform_Battery_cacheTime = now;
+
+   *info = Platform_Battery_cache;
 }
 
 void Platform_longOptionsUsage(const char* name)

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -166,6 +166,7 @@ static time_t Platform_Battery_cacheTime;
 static BatteryInfo Platform_Battery_cache = {
    .ac = AC_ERROR,
    .percent = NAN,
+   .powerCurr = NAN,
    .energyCurr = NAN,
    .energyFull = NAN,
 };
@@ -852,6 +853,7 @@ static void Platform_Battery_getProcData(BatteryInfo* info) {
 static void Platform_Battery_getSysData(BatteryInfo* info) {
    info->percent = NAN;
    info->ac = AC_ERROR;
+   info->powerCurr = NAN;
    info->energyCurr = NAN;
    info->energyFull = NAN;
 
@@ -861,6 +863,9 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
 
    uint64_t totalFull = 0;
    uint64_t totalRemain = 0;
+   int64_t totalPower = 0;
+
+   bool havePower = false;
 
    const struct dirent* dirEntry;
    while ((dirEntry = readdir(dir))) {
@@ -913,6 +918,9 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
          uint8_t haveBatteryVoltage = 0; // 0 = no, 1 = min_voltage, 2 = curr_voltage
          bool haveBatteryLevel = false;
 
+         bool haveBatteryCurrent = false;
+         bool haveBatteryPower = false;
+
          uint64_t batteryEnergyFull = 0;
          uint64_t batteryEnergyCurr = 0;
 
@@ -921,6 +929,11 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
 
          uint64_t batteryVoltage = 0;
          uint64_t batteryLevel = 0;
+
+         int64_t batteryCurrent = 0;
+         int64_t batteryPower = 0;
+
+         bool batteryIsDischarging = false;
 
          const char* line;
 
@@ -978,6 +991,18 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
                haveBatteryVoltage = 2;
                continue;
             }
+
+            if (String_eq(field, "CURRENT_NOW")) {
+               batteryCurrent = val;
+               haveBatteryCurrent = true;
+               continue;
+            }
+
+            if (String_eq(field, "POWER_NOW")) {
+               batteryPower += val;
+               haveBatteryPower = true;
+               continue;
+            }
          }
 
          if (haveBatteryLevel) {
@@ -1007,6 +1032,19 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
             totalFull += batteryEnergyFull;
             totalRemain += batteryEnergyCurr > batteryEnergyFull ? batteryEnergyFull : batteryEnergyCurr;
          }
+
+         if (!haveBatteryPower && haveBatteryCurrent && haveBatteryVoltage) {
+            batteryPower = (batteryCurrent * batteryVoltage) / 1000000;
+            haveBatteryPower = true;
+         }
+
+         if (haveBatteryPower) {
+            if (batteryIsDischarging)
+               batteryPower = -batteryPower;
+
+            totalPower += batteryPower;
+            havePower = true;
+         }
       } else if (type == AC) {
          if (info->ac != AC_ERROR)
             goto next;
@@ -1035,6 +1073,10 @@ next:
       info->energyCurr = (double) totalRemain / 1000000.0;
       info->energyFull = (double) totalFull / 1000000.0;
    }
+
+   if (havePower) {
+      info->powerCurr = (double) totalPower / 1000000.0;
+   }
 }
 
 void Platform_getBattery(BatteryInfo* info) {
@@ -1048,6 +1090,7 @@ void Platform_getBattery(BatteryInfo* info) {
    Platform_Battery_cache = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .powerCurr = NAN,
       .energyCurr = NAN,
       .energyFull = NAN,
    };

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -905,46 +905,109 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
          if (r < 0)
             goto next;
 
-         bool full = false;
-         bool now = false;
+         bool haveBatteryEnergyFull = false;
+         bool haveBatteryEnergyCurr = false;
 
-         double fullCharge = 0;
-         double capacityLevel = NAN;
+         bool haveBatteryChargeFull = false;
+         bool haveBatteryChargeCurr = false;
+
+         uint8_t haveBatteryVoltage = 0; // 0 = no, 1 = min_voltage, 2 = curr_voltage
+         bool haveBatteryLevel = false;
+
+         uint64_t batteryEnergyFull = 0;
+         uint64_t batteryEnergyCurr = 0;
+
+         uint64_t batteryChargeFull = 0;
+         uint64_t batteryChargeCurr = 0;
+
+         uint64_t batteryVoltage = 0;
+         uint64_t batteryLevel = 0;
+
          const char* line;
 
          char* buf = buffer;
          while ((line = strsep(&buf, "\n")) != NULL) {
             char field[100] = {0};
-            int val = 0;
-            if (2 != sscanf(line, "POWER_SUPPLY_%99[^=]=%d", field, &val))
+            int64_t val = 0;
+            if (2 != sscanf(line, "POWER_SUPPLY_%99[^=]=%" SCNd64, field, &val)) {
+               char strField[100] = {0};
+               char strVal[32] = {0};
+               if (2 == sscanf(line, "POWER_SUPPLY_%99[^=]=%31s", strField, strVal) &&
+                   String_eq(strField, "STATUS"))
+                  batteryIsDischarging = String_eq(strVal, "Discharging");
                continue;
+            }
 
             if (String_eq(field, "CAPACITY")) {
-               capacityLevel = val / 100.0;
+               batteryLevel = val;
+               haveBatteryLevel = true;
                continue;
             }
 
-            if (String_eq(field, "ENERGY_FULL") || String_eq(field, "CHARGE_FULL")) {
-               fullCharge = val;
-               totalFull += fullCharge;
-               full = true;
-               if (now)
-                  break;
+            if (String_eq(field, "ENERGY_FULL")) {
+               batteryEnergyFull = val;
+               haveBatteryEnergyFull = true;
                continue;
             }
 
-            if (String_eq(field, "ENERGY_NOW") || String_eq(field, "CHARGE_NOW")) {
-               totalRemain += val;
-               now = true;
-               if (full)
-                  break;
+            if (String_eq(field, "CHARGE_FULL")) {
+               batteryChargeFull = val;
+               haveBatteryChargeFull = true;
+               continue;
+            }
+
+            if (String_eq(field, "ENERGY_NOW")) {
+               batteryEnergyCurr = val;
+               haveBatteryEnergyCurr = true;
+               continue;
+            }
+
+            if (String_eq(field, "CHARGE_NOW")) {
+               batteryChargeCurr = val;
+               haveBatteryChargeCurr = true;
+               continue;
+            }
+
+            if (haveBatteryVoltage < 1 && String_eq(field, "VOLTAGE_MIN_DESIGN")) {
+               batteryVoltage = val;
+               haveBatteryVoltage = 1;
+               continue;
+            }
+
+            if (haveBatteryVoltage < 2 && String_eq(field, "VOLTAGE_NOW")) {
+               batteryVoltage = val;
+               haveBatteryVoltage = 2;
                continue;
             }
          }
 
-         if (!now && full && isNonnegative(capacityLevel))
-            totalRemain += capacityLevel * fullCharge;
+         if (haveBatteryLevel) {
+            // If we have capacity level but not charge or energy, we infer approximate values
+            if (haveBatteryChargeFull && !haveBatteryChargeCurr) {
+               batteryChargeCurr = batteryChargeFull * batteryLevel / 100.0;
+               haveBatteryChargeCurr = true;
+            }
+            if (haveBatteryEnergyFull && !haveBatteryEnergyCurr) {
+               batteryEnergyCurr = batteryEnergyFull * batteryLevel / 100.0;
+               haveBatteryEnergyCurr = true;
+            }
+         }
 
+         if (haveBatteryEnergyFull && haveBatteryEnergyCurr) {
+            // No need for conversion needed
+         } else if (haveBatteryChargeFull && haveBatteryChargeCurr && haveBatteryVoltage) {
+            // Convert charge to energy using voltage
+            batteryEnergyFull = (batteryChargeFull * batteryVoltage) / 1000000;
+            haveBatteryEnergyFull = true;
+
+            batteryEnergyCurr = (batteryChargeCurr * batteryVoltage) / 1000000;
+            haveBatteryEnergyCurr = true;
+         }
+
+         if (haveBatteryEnergyFull && haveBatteryEnergyCurr && batteryEnergyFull > 0) {
+            totalFull += batteryEnergyFull;
+            totalRemain += batteryEnergyCurr > batteryEnergyFull ? batteryEnergyFull : batteryEnergyCurr;
+         }
       } else if (type == AC) {
          if (info->ac != AC_ERROR)
             goto next;
@@ -968,10 +1031,10 @@ next:
 
    closedir(dir);
 
-   info->percent = totalFull > 0 ? ((double) totalRemain * 100.0) / (double) totalFull : NAN;
    if (totalFull > 0) {
-      info->energyCurr = (double) totalRemain;
-      info->energyFull = (double) totalFull;
+      info->percent = ((double) totalRemain * 100.0) / (double) totalFull;
+      info->energyCurr = (double) totalRemain / 1000000.0;
+      info->energyFull = (double) totalFull / 1000000.0;
    }
 }
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -166,6 +166,7 @@ static time_t Platform_Battery_cacheTime;
 static BatteryInfo Platform_Battery_cache = {
    .ac = AC_ERROR,
    .percent = NAN,
+   .powerCurr = NAN,
    .energyCurr = NAN,
    .energyFull = NAN,
 };
@@ -852,6 +853,7 @@ static void Platform_Battery_getProcData(BatteryInfo* info) {
 static void Platform_Battery_getSysData(BatteryInfo* info) {
    info->percent = NAN;
    info->ac = AC_ERROR;
+   info->powerCurr = NAN;
    info->energyCurr = NAN;
    info->energyFull = NAN;
 
@@ -861,6 +863,9 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
 
    uint64_t totalFull = 0;
    uint64_t totalRemain = 0;
+   int64_t totalPower = 0;
+
+   bool havePower = false;
 
    const struct dirent* dirEntry;
    while ((dirEntry = readdir(dir))) {
@@ -914,6 +919,9 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
          uint8_t haveBatteryVoltage = 0; // 0 = no, 1 = min_voltage, 2 = curr_voltage
          bool haveBatteryLevel = false;
 
+         bool haveBatteryCurrent = false;
+         bool haveBatteryPower = false;
+
          uint64_t batteryEnergyFull = 0;
          uint64_t batteryEnergyCurr = 0;
 
@@ -922,6 +930,11 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
 
          uint64_t batteryVoltage = 0;
          uint64_t batteryLevel = 0;
+
+         int64_t batteryCurrent = 0;
+         int64_t batteryPower = 0;
+
+         bool batteryIsDischarging = false;
 
          const char* line;
 
@@ -979,6 +992,18 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
                haveBatteryVoltage = 2;
                continue;
             }
+
+            if (String_eq(field, "CURRENT_NOW")) {
+               batteryCurrent = val;
+               haveBatteryCurrent = true;
+               continue;
+            }
+
+            if (String_eq(field, "POWER_NOW")) {
+               batteryPower += val;
+               haveBatteryPower = true;
+               continue;
+            }
          }
 
          if (haveBatteryLevel) {
@@ -1008,6 +1033,19 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
             totalFull += batteryEnergyFull;
             totalRemain += batteryEnergyCurr > batteryEnergyFull ? batteryEnergyFull : batteryEnergyCurr;
          }
+
+         if (!haveBatteryPower && haveBatteryCurrent && haveBatteryVoltage) {
+            batteryPower = (batteryCurrent * batteryVoltage) / 1000000;
+            haveBatteryPower = true;
+         }
+
+         if (haveBatteryPower) {
+            if (batteryIsDischarging)
+               batteryPower = -batteryPower;
+
+            totalPower += batteryPower;
+            havePower = true;
+         }
       } else if (type == AC) {
          if (info->ac != AC_ERROR)
             goto next;
@@ -1036,6 +1074,10 @@ next:
       info->energyCurr = (double) totalRemain / 1000000.0;
       info->energyFull = (double) totalFull / 1000000.0;
    }
+
+   if (havePower) {
+      info->powerCurr = (double) totalPower / 1000000.0;
+   }
 }
 
 void Platform_getBattery(BatteryInfo* info) {
@@ -1049,6 +1091,7 @@ void Platform_getBattery(BatteryInfo* info) {
    Platform_Battery_cache = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .powerCurr = NAN,
       .energyCurr = NAN,
       .energyFull = NAN,
    };

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -163,8 +163,10 @@ const unsigned int Platform_numberOfMemoryClasses = ARRAYSIZE(Platform_memoryCla
 
 static enum { BAT_PROC, BAT_SYS, BAT_ERR } Platform_Battery_method = BAT_PROC;
 static time_t Platform_Battery_cacheTime;
-static double Platform_Battery_cachePercent = NAN;
-static ACPresence Platform_Battery_cacheIsOnAC;
+static BatteryInfo Platform_Battery_cache = {
+   .ac = AC_ERROR,
+   .percent = NAN,
+};
 
 #ifdef HAVE_LIBCAP
 static enum CapMode Platform_capabilitiesMode = CAP_MODE_BASIC;
@@ -836,18 +838,18 @@ static ACPresence procAcpiCheck(void) {
    return String_eq(buffer, "on-line") ? AC_PRESENT : AC_ABSENT;
 }
 
-static void Platform_Battery_getProcData(double* percent, ACPresence* isOnAC) {
-   *isOnAC = procAcpiCheck();
-   *percent = AC_ERROR != *isOnAC ? Platform_Battery_getProcBatInfo() : NAN;
+static void Platform_Battery_getProcData(BatteryInfo* info) {
+   info->ac = procAcpiCheck();
+   info->percent = AC_ERROR != info->ac ? Platform_Battery_getProcBatInfo() : NAN;
 }
 
 // ----------------------------------------
 // READ FROM /sys
 // ----------------------------------------
 
-static void Platform_Battery_getSysData(double* percent, ACPresence* isOnAC) {
-   *percent = NAN;
-   *isOnAC = AC_ERROR;
+static void Platform_Battery_getSysData(BatteryInfo* info) {
+   info->percent = NAN;
+   info->ac = AC_ERROR;
 
    DIR* dir = opendir(SYS_POWERSUPPLY_DIR);
    if (!dir)
@@ -940,20 +942,20 @@ static void Platform_Battery_getSysData(double* percent, ACPresence* isOnAC) {
             totalRemain += capacityLevel * fullCharge;
 
       } else if (type == AC) {
-         if (*isOnAC != AC_ERROR)
+         if (info->ac != AC_ERROR)
             goto next;
 
          char buffer[2];
          ssize_t r = Compat_readfileat(entryFd, "online", buffer, sizeof(buffer));
          if (r < 1) {
-            *isOnAC = AC_ERROR;
+            info->ac = AC_ERROR;
             goto next;
          }
 
          if (buffer[0] == '0')
-            *isOnAC = AC_ABSENT;
+            info->ac = AC_ABSENT;
          else if (buffer[0] == '1')
-            *isOnAC = AC_PRESENT;
+            info->ac = AC_PRESENT;
       }
 
 next:
@@ -962,37 +964,39 @@ next:
 
    closedir(dir);
 
-   *percent = totalFull > 0 ? ((double) totalRemain * 100.0) / (double) totalFull : NAN;
+   info->percent = totalFull > 0 ? ((double) totalRemain * 100.0) / (double) totalFull : NAN;
 }
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC) {
+void Platform_getBattery(BatteryInfo* info) {
    time_t now = time(NULL);
    // update battery reading is slow. Update it each 10 seconds only.
    if (now < Platform_Battery_cacheTime + 10) {
-      *percent = Platform_Battery_cachePercent;
-      *isOnAC = Platform_Battery_cacheIsOnAC;
+      *info = Platform_Battery_cache;
       return;
    }
 
+   Platform_Battery_cache = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
+
    if (Platform_Battery_method == BAT_PROC) {
-      Platform_Battery_getProcData(percent, isOnAC);
-      if (!isNonnegative(*percent))
+      Platform_Battery_getProcData(&Platform_Battery_cache);
+      if (!isNonnegative(Platform_Battery_cache.percent))
          Platform_Battery_method = BAT_SYS;
    }
    if (Platform_Battery_method == BAT_SYS) {
-      Platform_Battery_getSysData(percent, isOnAC);
-      if (!isNonnegative(*percent))
+      Platform_Battery_getSysData(&Platform_Battery_cache);
+      if (!isNonnegative(Platform_Battery_cache.percent))
          Platform_Battery_method = BAT_ERR;
    }
-   if (Platform_Battery_method == BAT_ERR) {
-      *percent = NAN;
-      *isOnAC = AC_ERROR;
-   } else {
-      *percent = CLAMP(*percent, 0.0, 100.0);
+   if (Platform_Battery_method != BAT_ERR) {
+      Platform_Battery_cache.percent = CLAMP(Platform_Battery_cache.percent, 0.0, 100.0);
    }
-   Platform_Battery_cachePercent = *percent;
-   Platform_Battery_cacheIsOnAC = *isOnAC;
+
    Platform_Battery_cacheTime = now;
+
+   *info = Platform_Battery_cache;
 }
 
 void Platform_longOptionsUsage(const char* name)

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -166,6 +166,8 @@ static time_t Platform_Battery_cacheTime;
 static BatteryInfo Platform_Battery_cache = {
    .ac = AC_ERROR,
    .percent = NAN,
+   .energyCurr = NAN,
+   .energyFull = NAN,
 };
 
 #ifdef HAVE_LIBCAP
@@ -850,6 +852,8 @@ static void Platform_Battery_getProcData(BatteryInfo* info) {
 static void Platform_Battery_getSysData(BatteryInfo* info) {
    info->percent = NAN;
    info->ac = AC_ERROR;
+   info->energyCurr = NAN;
+   info->energyFull = NAN;
 
    DIR* dir = opendir(SYS_POWERSUPPLY_DIR);
    if (!dir)
@@ -965,6 +969,10 @@ next:
    closedir(dir);
 
    info->percent = totalFull > 0 ? ((double) totalRemain * 100.0) / (double) totalFull : NAN;
+   if (totalFull > 0) {
+      info->energyCurr = (double) totalRemain;
+      info->energyFull = (double) totalFull;
+   }
 }
 
 void Platform_getBattery(BatteryInfo* info) {
@@ -978,6 +986,8 @@ void Platform_getBattery(BatteryInfo* info) {
    Platform_Battery_cache = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 
    if (Platform_Battery_method == BAT_PROC) {

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -92,7 +92,7 @@ bool Platform_getDiskIO(DiskIOData* data);
 
 bool Platform_getNetworkIO(NetworkIOData* data);
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC);
+void Platform_getBattery(BatteryInfo* info);
 
 static inline void Platform_getHostname(char* buffer, size_t size) {
    Generic_hostname(buffer, size);

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -446,15 +446,17 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    return true;
 }
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC) {
+void Platform_getBattery(BatteryInfo* info) {
    prop_dictionary_t dict, fields, props;
    prop_object_t device, class;
 
    intmax_t totalCharge = 0;
    intmax_t totalCapacity = 0;
 
-   *percent = NAN;
-   *isOnAC = AC_ERROR;
+   *info = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
 
    int fd = open(_PATH_SYSMON, O_RDONLY);
    if (fd == -1)
@@ -522,11 +524,12 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
          totalCapacity += maxCharge;
       }
 
-      if (isACAdapter && *isOnAC != AC_PRESENT) {
-         *isOnAC = isConnected ? AC_PRESENT : AC_ABSENT;
+      if (isACAdapter && info->ac != AC_PRESENT) {
+         info->ac = isConnected ? AC_PRESENT : AC_ABSENT;
       }
    }
-   *percent = totalCapacity > 0 ? ((double)totalCharge / (double)totalCapacity) * 100.0 : NAN;
+
+   info->percent = totalCapacity > 0 ? ((double)totalCharge / (double)totalCapacity) * 100.0 : NAN;
 
 error:
    if (fd != -1)

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -488,6 +488,11 @@ void Platform_getBattery(BatteryInfo* info) {
       intmax_t isConnected = 0;
       intmax_t curCharge = 0;
       intmax_t maxCharge = 0;
+      intmax_t voltage = 0;
+      intmax_t designVoltage = 0;
+
+      bool haveCharge = false;
+      bool chargeIsAmpHours = false;
 
       while ((fields = prop_object_iterator_next(fieldsIter)) != NULL) {
          props = prop_dictionary_get(fields, "device-properties");
@@ -505,6 +510,7 @@ void Platform_getBattery(BatteryInfo* info) {
          prop_object_t curValue = prop_dictionary_get(fields, "cur-value");
          prop_object_t maxValue = prop_dictionary_get(fields, "max-value");
          prop_object_t descField = prop_dictionary_get(fields, "description");
+         prop_object_t typeField = prop_dictionary_get(fields, "type");
 
          if (descField == NULL || curValue == NULL)
             continue;
@@ -513,17 +519,48 @@ void Platform_getBattery(BatteryInfo* info) {
             isConnected = prop_number_signed_value(curValue);
          } else if (prop_string_equals_string(descField, "present")) {
             isPresent = prop_number_signed_value(curValue);
+         } else if (prop_string_equals_string(descField, "voltage")) {
+            voltage = prop_number_signed_value(curValue);
+         } else if (prop_string_equals_string(descField, "design voltage")) {
+            designVoltage = prop_number_signed_value(curValue);
          } else if (prop_string_equals_string(descField, "charge")) {
             if (maxValue == NULL)
                continue;
             curCharge = prop_number_signed_value(curValue);
             maxCharge = prop_number_signed_value(maxValue);
+            haveCharge = true;
+            chargeIsAmpHours = typeField != NULL &&
+               prop_string_equals_string(typeField, "Ampere hour");
          }
       }
 
       if (isBattery && isPresent) {
-         totalCharge += curCharge;
-         totalCapacity += maxCharge;
+         intmax_t batteryVoltage = (voltage != 0) ? voltage : designVoltage;
+
+         bool haveBatteryCharge = false;
+
+         intmax_t batteryCharge = 0;
+         intmax_t batteryCapacity = 0;
+
+         if (haveCharge) {
+            if (chargeIsAmpHours) {
+               if (batteryVoltage > 0) {
+                  batteryCharge = curCharge * batteryVoltage / 1000000;
+                  batteryCapacity = maxCharge * batteryVoltage / 1000000;
+                  haveBatteryCharge = true;
+               }
+            } else {
+               batteryCharge = curCharge;
+               batteryCapacity = maxCharge;
+               haveBatteryCharge = true;
+            }
+         }
+
+         if (haveBatteryCharge) {
+            totalCharge += batteryCharge;
+            totalCapacity += batteryCapacity;
+         }
+
       }
 
       if (isACAdapter && info->ac != AC_PRESENT) {
@@ -532,9 +569,12 @@ void Platform_getBattery(BatteryInfo* info) {
    }
 
    if (totalCapacity > 0) {
-      info->percent = ((double)totalCharge / (double)totalCapacity) * 100.0;
-      info->energyCurr = (double) totalCharge;
-      info->energyFull = (double) totalCapacity;
+      info->percent = ((double) totalCharge * 100.0) / (double) totalCapacity;
+      if (totalCharge >= totalCapacity)
+         info->percent = 100.0;
+
+      info->energyCurr = (double) totalCharge / 1000000.0;
+      info->energyFull = (double) totalCapacity / 1000000.0;
    }
 
 error:

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -456,6 +456,8 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 
    int fd = open(_PATH_SYSMON, O_RDONLY);
@@ -529,7 +531,11 @@ void Platform_getBattery(BatteryInfo* info) {
       }
    }
 
-   info->percent = totalCapacity > 0 ? ((double)totalCharge / (double)totalCapacity) * 100.0 : NAN;
+   if (totalCapacity > 0) {
+      info->percent = ((double)totalCharge / (double)totalCapacity) * 100.0;
+      info->energyCurr = (double) totalCharge;
+      info->energyFull = (double) totalCapacity;
+   }
 
 error:
    if (fd != -1)

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -453,9 +453,13 @@ void Platform_getBattery(BatteryInfo* info) {
    intmax_t totalCharge = 0;
    intmax_t totalCapacity = 0;
 
+   bool havePower = false;
+   intmax_t totalPower = 0;
+
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .powerCurr = NAN,
       .energyCurr = NAN,
       .energyFull = NAN,
    };
@@ -488,11 +492,17 @@ void Platform_getBattery(BatteryInfo* info) {
       intmax_t isConnected = 0;
       intmax_t curCharge = 0;
       intmax_t maxCharge = 0;
+      intmax_t chargeRate = 0;
+      intmax_t dischargeRate = 0;
       intmax_t voltage = 0;
       intmax_t designVoltage = 0;
 
       bool haveCharge = false;
+      bool haveChargeRate = false;
+      bool haveDischargeRate = false;
       bool chargeIsAmpHours = false;
+      bool chargeRateIsAmps = false;
+      bool dischargeRateIsAmps = false;
 
       while ((fields = prop_object_iterator_next(fieldsIter)) != NULL) {
          props = prop_dictionary_get(fields, "device-properties");
@@ -531,14 +541,29 @@ void Platform_getBattery(BatteryInfo* info) {
             haveCharge = true;
             chargeIsAmpHours = typeField != NULL &&
                prop_string_equals_string(typeField, "Ampere hour");
+         } else if (prop_string_equals_string(descField, "charge rate")) {
+            chargeRate = prop_number_signed_value(curValue);
+            chargeRateIsAmps = typeField != NULL &&
+               prop_string_equals_string(typeField, "Ampere");
+            haveChargeRate = true;
+         } else if (prop_string_equals_string(descField, "discharge rate")) {
+            dischargeRate = prop_number_signed_value(curValue);
+            dischargeRateIsAmps = typeField != NULL &&
+               prop_string_equals_string(typeField, "Ampere");
+            haveDischargeRate = true;
          }
       }
 
       if (isBattery && isPresent) {
          intmax_t batteryVoltage = (voltage != 0) ? voltage : designVoltage;
 
+         bool haveBatteryChargeRate = false;
+         bool haveBatteryDischargeRate = false;
+
          bool haveBatteryCharge = false;
 
+         intmax_t batteryChargeRate = 0;
+         intmax_t batteryDischargeRate = 0;
          intmax_t batteryCharge = 0;
          intmax_t batteryCapacity = 0;
 
@@ -556,11 +581,39 @@ void Platform_getBattery(BatteryInfo* info) {
             }
          }
 
+         if (haveChargeRate) {
+            if (chargeRateIsAmps) {
+               if (batteryVoltage > 0) {
+                  batteryChargeRate = chargeRate * batteryVoltage / 1000000;
+                  haveBatteryChargeRate = true;
+               }
+            } else {
+               batteryChargeRate = chargeRate;
+               haveBatteryChargeRate = true;
+            }
+         }
+
+         if (haveDischargeRate) {
+            if (dischargeRateIsAmps) {
+               if (batteryVoltage > 0) {
+                  batteryDischargeRate = dischargeRate * batteryVoltage / 1000000;
+                  haveBatteryDischargeRate = true;
+               }
+            } else {
+               batteryDischargeRate = dischargeRate;
+               haveBatteryDischargeRate = true;
+            }
+         }
+
          if (haveBatteryCharge) {
             totalCharge += batteryCharge;
             totalCapacity += batteryCapacity;
          }
 
+         if (haveBatteryChargeRate || haveBatteryDischargeRate) {
+            totalPower += batteryChargeRate - batteryDischargeRate;
+            havePower = true;
+         }
       }
 
       if (isACAdapter && info->ac != AC_PRESENT) {
@@ -575,6 +628,10 @@ void Platform_getBattery(BatteryInfo* info) {
 
       info->energyCurr = (double) totalCharge / 1000000.0;
       info->energyFull = (double) totalCapacity / 1000000.0;
+   }
+
+   if (havePower) {
+      info->powerCurr = (double) totalPower / 1000000.0;
    }
 
 error:

--- a/netbsd/Platform.h
+++ b/netbsd/Platform.h
@@ -77,7 +77,7 @@ bool Platform_getDiskIO(DiskIOData* data);
 
 bool Platform_getNetworkIO(NetworkIOData* data);
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC);
+void Platform_getBattery(BatteryInfo* info);
 
 static inline void Platform_getHostname(char* buffer, size_t size) {
    Generic_hostname(buffer, size);

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -373,16 +373,20 @@ static bool findDevice(const char* name, int* mib, struct sensordev* snsrdev, si
    }
 }
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC) {
+void Platform_getBattery(BatteryInfo* info) {
    int mib[] = {CTL_HW, HW_SENSORS, 0, 0, 0};
    struct sensor s;
    size_t slen = sizeof(struct sensor);
    struct sensordev snsrdev;
    size_t sdlen = sizeof(struct sensordev);
 
+   *info = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
+
    bool found = findDevice("acpibat0", mib, &snsrdev, &sdlen);
 
-   *percent = NAN;
    if (found) {
       /* See "sys/dev/acpi/acpibat.c" of OpenBSD source code for the indices
          of the last field. */
@@ -396,23 +400,21 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
          mib[4] = 3; /* "remaining capacity" */
          if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1) {
             double charge = s.value;
-            *percent = 100 * (charge / last_full_capacity);
-            if (charge >= last_full_capacity) {
-               *percent = 100;
-            }
+            info->percent = 100 * (charge / last_full_capacity);
+            if (charge >= last_full_capacity)
+               info->percent = 100;
          }
       }
    }
 
    found = findDevice("acpiac0", mib, &snsrdev, &sdlen);
 
-   *isOnAC = AC_ERROR;
    if (found) {
       /* See "sys/dev/acpi/acpiac.c" of OpenBSD source code.
          There is only one "sensor" for this device. */
       mib[3] = SENSOR_INDICATOR;
       mib[4] = 0; /* "power supply" (status indicator) */
       if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1)
-         *isOnAC = s.value != 0 ? AC_PRESENT : AC_ABSENT;
+         info->ac = s.value != 0 ? AC_PRESENT : AC_ABSENT;
    }
 }

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -383,6 +383,8 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 
    bool found = findDevice("acpibat0", mib, &snsrdev, &sdlen);
@@ -403,6 +405,8 @@ void Platform_getBattery(BatteryInfo* info) {
             info->percent = 100 * (charge / last_full_capacity);
             if (charge >= last_full_capacity)
                info->percent = 100;
+            info->energyCurr = charge;
+            info->energyFull = last_full_capacity;
          }
       }
    }

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -390,24 +390,45 @@ void Platform_getBattery(BatteryInfo* info) {
    bool found = findDevice("acpibat0", mib, &snsrdev, &sdlen);
 
    if (found) {
+      bool haveTotalFull = false;
+      bool haveTotalRemain = false;
+
+      int64_t totalFull = 0;
+      int64_t totalRemain = 0;
+
       /* See "sys/dev/acpi/acpibat.c" of OpenBSD source code for the indices
          of the last field. */
       mib[3] = SENSOR_WATTHOUR;
       mib[4] = 0; /* "last full capacity" */
-      double last_full_capacity = 0;
+      bool haveBatteryFull = false;
+      int64_t batteryFull = 0;
       if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1)
-         last_full_capacity = s.value;
-      if (last_full_capacity > 0) {
+         batteryFull = s.value;
+
+      if (batteryFull > 0)
+         haveBatteryFull = true;
+
+      if (haveBatteryFull) {
          mib[3] = SENSOR_WATTHOUR;
          mib[4] = 3; /* "remaining capacity" */
          if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1) {
-            double charge = s.value;
-            info->percent = 100 * (charge / last_full_capacity);
-            if (charge >= last_full_capacity)
-               info->percent = 100;
-            info->energyCurr = charge;
-            info->energyFull = last_full_capacity;
+            int64_t batteryRemain = s.value;
+            if (batteryRemain >= 0) {
+               totalRemain += batteryRemain;
+               totalFull += batteryFull;
+               haveTotalRemain = true;
+               haveTotalFull = true;
+            }
          }
+      }
+
+      if (haveTotalRemain && haveTotalFull && totalFull > 0) {
+         info->percent = ((double) totalRemain * 100.0) / (double) totalFull;
+         if (totalRemain >= totalFull)
+            info->percent = 100;
+
+         info->energyCurr = (double) totalRemain / 1000000.0;
+         info->energyFull = (double) totalFull / 1000000.0;
       }
    }
 

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -383,6 +383,7 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .powerCurr = NAN,
       .energyCurr = NAN,
       .energyFull = NAN,
    };
@@ -392,9 +393,11 @@ void Platform_getBattery(BatteryInfo* info) {
    if (found) {
       bool haveTotalFull = false;
       bool haveTotalRemain = false;
+      bool haveTotalPower = false;
 
       int64_t totalFull = 0;
       int64_t totalRemain = 0;
+      int64_t totalPower = 0;
 
       /* See "sys/dev/acpi/acpibat.c" of OpenBSD source code for the indices
          of the last field. */
@@ -429,6 +432,27 @@ void Platform_getBattery(BatteryInfo* info) {
 
          info->energyCurr = (double) totalRemain / 1000000.0;
          info->energyFull = (double) totalFull / 1000000.0;
+      }
+
+      mib[3] = SENSOR_INTEGER;
+      mib[4] = 0; /* "battery state" */
+      int64_t batteryState = 0;
+      if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1)
+         batteryState = s.value;
+
+      mib[3] = SENSOR_WATTS;
+      mib[4] = 0; /* "rate" */
+      if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1) {
+         int64_t batteryPower = s.value;
+         if (batteryState & 0x01)
+            batteryPower = -batteryPower;
+
+         totalPower += batteryPower;
+         haveTotalPower = true;
+      }
+
+      if (haveTotalPower) {
+         info->powerCurr = (double) totalPower / 1000000.0;
       }
    }
 

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -69,7 +69,7 @@ bool Platform_getDiskIO(DiskIOData* data);
 
 bool Platform_getNetworkIO(NetworkIOData* data);
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC);
+void Platform_getBattery(BatteryInfo* info);
 
 static inline void Platform_getHostname(char* buffer, size_t size) {
    Generic_hostname(buffer, size);

--- a/pcp/Metric.h
+++ b/pcp/Metric.h
@@ -107,6 +107,7 @@ typedef enum Metric_ {
    PCP_MEM_ZSWAPPED,            /* mem.util.zswapped */
    PCP_VFS_FILES_COUNT,         /* vfs.files.count */
    PCP_VFS_FILES_MAX,           /* vfs.files.max */
+   PCP_DENKI_POWER_NOW,         /* denki.bat.power_now */
    PCP_DENKI_ENERGY_NOW,        /* denki.bat.energy_now */
    PCP_DENKI_ENERGY_FULL,       /* denki.bat.capacity */
 

--- a/pcp/Metric.h
+++ b/pcp/Metric.h
@@ -107,6 +107,8 @@ typedef enum Metric_ {
    PCP_MEM_ZSWAPPED,            /* mem.util.zswapped */
    PCP_VFS_FILES_COUNT,         /* vfs.files.count */
    PCP_VFS_FILES_MAX,           /* vfs.files.max */
+   PCP_DENKI_ENERGY_NOW,        /* denki.bat.energy_now */
+   PCP_DENKI_ENERGY_FULL,       /* denki.bat.capacity */
 
    PCP_PROC_PID,                /* proc.psinfo.pid */
    PCP_PROC_PPID,               /* proc.psinfo.ppid */

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -867,6 +867,8 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 }
 

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -863,9 +863,11 @@ void Platform_getFileDescriptors(double* used, double* max) {
       *max = value.l;
 }
 
-void Platform_getBattery(double* level, ACPresence* isOnAC) {
-   *level = NAN;
-   *isOnAC = AC_ERROR;
+void Platform_getBattery(BatteryInfo* info) {
+   *info = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
 }
 
 const char* Platform_getFailedState(void) {

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -234,6 +234,8 @@ static const char* Platform_metricNames[] = {
    [PCP_MEM_ZSWAPPED] = "mem.util.zswapped",
    [PCP_VFS_FILES_COUNT] = "vfs.files.count",
    [PCP_VFS_FILES_MAX] = "vfs.files.max",
+   [PCP_DENKI_ENERGY_NOW] = "denki.bat.energy_now",
+   [PCP_DENKI_ENERGY_FULL] = "denki.bat.capacity",
 
    [PCP_PROC_PID] = "proc.psinfo.pid",
    [PCP_PROC_PPID] = "proc.psinfo.ppid",
@@ -864,12 +866,41 @@ void Platform_getFileDescriptors(double* used, double* max) {
 }
 
 void Platform_getBattery(BatteryInfo* info) {
-   *info = (BatteryInfo) {
-      .ac = AC_ERROR,
-      .percent = NAN,
-      .energyCurr = NAN,
-      .energyFull = NAN,
-   };
+   info->ac = AC_ERROR;
+   info->percent = NAN;
+   info->energyCurr = NAN;
+   info->energyFull = NAN;
+
+   int energyCount = 0;
+   if (Metric_desc(PCP_DENKI_ENERGY_NOW) != NULL) {
+      energyCount = Metric_instanceCount(PCP_DENKI_ENERGY_NOW);
+   }
+
+   if (energyCount < 1) {
+      info->ac = AC_PRESENT;
+      return;
+   }
+
+   if (energyCount > 0) {
+      pmAtomValue* batteryEnergyCurr = xCalloc(energyCount, sizeof(pmAtomValue));
+      pmAtomValue* batteryEnergyFull = xCalloc(energyCount, sizeof(pmAtomValue));
+      if (Metric_values(PCP_DENKI_ENERGY_NOW, batteryEnergyCurr, energyCount, PM_TYPE_DOUBLE) &&
+          Metric_values(PCP_DENKI_ENERGY_FULL, batteryEnergyFull, energyCount, PM_TYPE_DOUBLE)) {
+         info->energyCurr = 0.0;
+         info->energyFull = 0.0;
+         for (int i = 0; i < energyCount; i++) {
+            double full = isNonnegative(batteryEnergyFull[i].d) ? batteryEnergyFull[i].d : 0.0;
+            info->energyCurr += CLAMP(batteryEnergyCurr[i].d, 0.0, full);
+            info->energyFull += full;
+         }
+
+         if (info->energyFull > 0) {
+            info->percent = CLAMP((info->energyCurr / info->energyFull) * 100.0, 0.0, 100.0);
+         }
+      }
+      free(batteryEnergyCurr);
+      free(batteryEnergyFull);
+   }
 }
 
 const char* Platform_getFailedState(void) {

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -234,6 +234,7 @@ static const char* Platform_metricNames[] = {
    [PCP_MEM_ZSWAPPED] = "mem.util.zswapped",
    [PCP_VFS_FILES_COUNT] = "vfs.files.count",
    [PCP_VFS_FILES_MAX] = "vfs.files.max",
+   [PCP_DENKI_POWER_NOW] = "denki.bat.power_now",
    [PCP_DENKI_ENERGY_NOW] = "denki.bat.energy_now",
    [PCP_DENKI_ENERGY_FULL] = "denki.bat.capacity",
 
@@ -868,6 +869,7 @@ void Platform_getFileDescriptors(double* used, double* max) {
 void Platform_getBattery(BatteryInfo* info) {
    info->ac = AC_ERROR;
    info->percent = NAN;
+   info->powerCurr = NAN;
    info->energyCurr = NAN;
    info->energyFull = NAN;
 
@@ -876,7 +878,12 @@ void Platform_getBattery(BatteryInfo* info) {
       energyCount = Metric_instanceCount(PCP_DENKI_ENERGY_NOW);
    }
 
-   if (energyCount < 1) {
+   int powerCount = 0;
+   if (Metric_desc(PCP_DENKI_POWER_NOW) != NULL) {
+      powerCount = Metric_instanceCount(PCP_DENKI_POWER_NOW);
+   }
+
+   if (energyCount < 1 && powerCount < 1) {
       info->ac = AC_PRESENT;
       return;
    }
@@ -900,6 +907,21 @@ void Platform_getBattery(BatteryInfo* info) {
       }
       free(batteryEnergyCurr);
       free(batteryEnergyFull);
+   }
+
+   if (powerCount > 0) {
+      pmAtomValue* batteryPowerCurr = xCalloc(powerCount, sizeof(pmAtomValue));
+      if (Metric_values(PCP_DENKI_POWER_NOW, batteryPowerCurr, powerCount, PM_TYPE_DOUBLE)) {
+         info->powerCurr = 0.0;
+         for (int i = 0; i < powerCount; i++) {
+            info->powerCurr += batteryPowerCurr[i].d;
+         }
+      }
+      free(batteryPowerCurr);
+   }
+
+   if (info->powerCurr < 0) {
+      info->ac = AC_ABSENT;
    }
 }
 

--- a/pcp/Platform.h
+++ b/pcp/Platform.h
@@ -121,7 +121,7 @@ bool Platform_getDiskIO(DiskIOData* data);
 
 bool Platform_getNetworkIO(NetworkIOData* data);
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC);
+void Platform_getBattery(BatteryInfo* info);
 
 void Platform_getHostname(char* buffer, size_t size);
 

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -346,5 +346,7 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 }

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -342,7 +342,9 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    return false;
 }
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC) {
-   *percent = NAN;
-   *isOnAC = AC_ERROR;
+void Platform_getBattery(BatteryInfo* info) {
+   *info = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
 }

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -346,6 +346,7 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .powerCurr = NAN,
       .energyCurr = NAN,
       .energyFull = NAN,
    };

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -97,7 +97,7 @@ bool Platform_getDiskIO(DiskIOData* data);
 
 bool Platform_getNetworkIO(NetworkIOData* data);
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC);
+void Platform_getBattery(BatteryInfo* info);
 
 static inline void Platform_getHostname(char* buffer, size_t size) {
    Generic_hostname(buffer, size);

--- a/unsupported/Platform.c
+++ b/unsupported/Platform.c
@@ -170,6 +170,8 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 }
 

--- a/unsupported/Platform.c
+++ b/unsupported/Platform.c
@@ -166,9 +166,11 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    return false;
 }
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC) {
-   *percent = NAN;
-   *isOnAC = AC_ERROR;
+void Platform_getBattery(BatteryInfo* info) {
+   *info = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
 }
 
 void Platform_getHostname(char* buffer, size_t size) {

--- a/unsupported/Platform.c
+++ b/unsupported/Platform.c
@@ -170,6 +170,7 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .powerCurr = NAN,
       .energyCurr = NAN,
       .energyFull = NAN,
    };

--- a/unsupported/Platform.h
+++ b/unsupported/Platform.h
@@ -66,7 +66,7 @@ bool Platform_getDiskIO(DiskIOData* data);
 
 bool Platform_getNetworkIO(NetworkIOData* data);
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC);
+void Platform_getBattery(BatteryInfo* info);
 
 void Platform_getHostname(char* buffer, size_t size);
 


### PR DESCRIPTION
This is the beginning of a series of commits to extend the BatteryMeter to provide additional information like battery capacity, charge rate and (dis)charge time estimates.

For the BSD parts of this PR I'll need some input from the people on these platforms regarding the actual interface to use to get the following values:
- current power draw (voltage + current OR direct)
- battery capacity and current charge
- time to (dis)charge (can potentially be filled in generically if the power draw is available)

Pointers for sample code on each of the different platforms would be nice.