### PR TITLE
Focus the target column after adding a meter

### DIFF
--- a/AvailableMetersPanel.c
+++ b/AvailableMetersPanel.c
@@ -44,6 +44,12 @@ static inline void AvailableMetersPanel_addMeter(Header* header, MetersPanel* pa
    Panel_setSelected((Panel*)panel, Panel_size((Panel*)panel) - 1);
 }
 
+static inline void AvailableMetersPanel_addMeterAndFocus(AvailableMetersPanel* this, size_t column, const MeterClass* type, unsigned int param) {
+   MetersPanel* target = this->meterPanels[column];
+   AvailableMetersPanel_addMeter(this->header, target, type, param, column);
+   ScreenManager_setPanelFocus(this->scr, (Panel*) target);
+}
+
 static HandlerResult AvailableMetersPanel_eventHandler(Panel* super, int ch) {
    AvailableMetersPanel* this = (AvailableMetersPanel*) super;
    Header* header = this->header;
@@ -61,7 +67,7 @@ static HandlerResult AvailableMetersPanel_eventHandler(Panel* super, int ch) {
       case KEY_F(5):
       case 'l':
       case 'L':
-         AvailableMetersPanel_addMeter(header, this->meterPanels[0], Platform_meterTypes[type], param, 0);
+         AvailableMetersPanel_addMeterAndFocus(this, 0, Platform_meterTypes[type], param);
          result = HANDLED;
          update = true;
          break;
@@ -72,8 +78,8 @@ static HandlerResult AvailableMetersPanel_eventHandler(Panel* super, int ch) {
       case 'r':
       case 'R':
       case KEY_RECLICK:
-         AvailableMetersPanel_addMeter(header, this->meterPanels[this->columns - 1], Platform_meterTypes[type], param, this->columns - 1);
-         result = (KEY_LEFT << 16) | SYNTH_KEY;
+         AvailableMetersPanel_addMeterAndFocus(this, this->columns - 1, Platform_meterTypes[type], param);
+         result = HANDLED;
          update = true;
          break;
    }

--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -37,6 +37,7 @@ ScreenManager* ScreenManager_new(Header* header, Machine* host, State* state, bo
    this->y2 = -1;
    this->panels = Vector_new(Class(Panel), owner, VECTOR_DEFAULT_SIZE);
    this->panelCount = 0;
+   this->pendingFocus = NULL;
    this->header = header;
    this->host = host;
    this->state = state;
@@ -117,6 +118,31 @@ void ScreenManager_resize(ScreenManager* this) {
    Panel* panel = (Panel*) Vector_get(this->panels, panels - 1);
    Panel_resize(panel, COLS - this->x1 + this->x2 - lastX, LINES - y1_header + this->y2);
    Panel_move(panel, lastX, y1_header);
+}
+
+void ScreenManager_setPanelFocus(ScreenManager* this, Panel* panel) {
+   this->pendingFocus = panel;
+}
+
+static void ScreenManager_applyPendingFocus(ScreenManager* this, size_t* focus, Panel** panelFocus) {
+   Panel* target = this->pendingFocus;
+   if (!target)
+      return;
+
+   this->pendingFocus = NULL;
+
+   for (size_t i = 0; i < this->panelCount; i++) {
+      Panel* panel = (Panel*) Vector_get(this->panels, i);
+      if (panel != target)
+         continue;
+
+      if (panel != *panelFocus && Panel_eventHandlerFn(*panelFocus)) {
+         Panel_eventHandler(*panelFocus, EVENT_PANEL_LOST_FOCUS);
+      }
+      *focus = i;
+      *panelFocus = panel;
+      return;
+   }
 }
 
 static void checkRecalculation(ScreenManager* this, double* oldTime, int* sortTimeout, bool* redraw, bool* rescan, bool* timedOut, bool* force_redraw) {
@@ -377,6 +403,7 @@ void ScreenManager_run(ScreenManager* this, Panel** lastFocus, int* lastKey, con
          rescan = true;
          sortTimeout = 0;
       }
+      ScreenManager_applyPendingFocus(this, &focus, &panelFocus);
       if (result & HANDLED) {
          continue;
       } else if (result & BREAK_LOOP) {

--- a/ScreenManager.h
+++ b/ScreenManager.h
@@ -24,6 +24,8 @@ typedef struct ScreenManager_ {
    bool allowFocusChange;
    uint32_t panelCount;
    Vector* panels;
+   /* One-shot focus transfer requested by an event handler during ScreenManager_run(). */
+   Panel* pendingFocus;
    const char* name;
    Header* header;
    Machine* host;
@@ -43,6 +45,9 @@ void ScreenManager_insert(ScreenManager* this, Panel* item, int size, int idx);
 Panel* ScreenManager_remove(ScreenManager* this, int idx);
 
 void ScreenManager_resize(ScreenManager* this);
+
+/* Request that the next ScreenManager_run() iteration redraw with this panel focused. */
+void ScreenManager_setPanelFocus(ScreenManager* this, Panel* panel);
 
 void ScreenManager_run(ScreenManager* this, Panel** lastFocus, int* lastKey, const char* name);
 


### PR DESCRIPTION
Fixes #1948.

Before this change, adding a meter from Available meters only moved focus when adding to the right-most column. `Add Lt` kept focus on Available meters, so the next keypress still acted on the source list even though the new meter was inserted into Column 1.

This requests focus for the destination column after adding a meter on either side, while keeping the existing bindings intact.

Validation:
- `./autogen.sh && ./configure --enable-werror && make -k -j4`
- `make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror'`\n- local PTY repro on 2-column and 3-column layouts: `Add Lt` and `Add Rt` both switch focus to the target column after insertion