### PR TITLE
Add configurable SI decimal vs IEC binary unit prefixes

### DIFF
--- a/DiskIOMeter.c
+++ b/DiskIOMeter.c
@@ -14,10 +14,12 @@ in the source distribution for its full text.
 #include "CRT.h"
 #include "Machine.h"
 #include "Macros.h"
+#include "Meter.h"
 #include "Object.h"
 #include "Platform.h"
 #include "RichString.h"
 #include "Row.h"
+#include "Settings.h"
 #include "XUtils.h"
 
 
@@ -40,6 +42,7 @@ static double cached_read_diff;
 static char cached_read_diff_str[6];
 static double cached_write_diff;
 static char cached_write_diff_str[6];
+static const char* cached_disk_unit_suffix = "iB/s";
 static uint64_t cached_num_disks;
 static double cached_utilisation_diff;
 static double cached_utilisation_norm;
@@ -75,6 +78,7 @@ static void DiskIOUpdateCache(const Machine* host) {
    static uint64_t cached_msTimeSpend_total;
 
    if (status != RATESTATUS_INIT) {
+      const bool decimal = host->settings->decimalUnits;
       uint64_t diff;
 
       if (data.totalBytesRead > cached_read_total) {
@@ -84,7 +88,7 @@ static void DiskIOUpdateCache(const Machine* host) {
          diff = 0;
       }
       cached_read_diff = diff;
-      Meter_humanUnit(cached_read_diff_str, cached_read_diff / ONE_K, sizeof(cached_read_diff_str));
+      cached_disk_unit_suffix = Meter_ioRateUnit(cached_read_diff_str, sizeof(cached_read_diff_str), cached_read_diff, decimal);
 
       if (data.totalBytesWritten > cached_write_total) {
          diff = data.totalBytesWritten - cached_write_total;
@@ -93,7 +97,7 @@ static void DiskIOUpdateCache(const Machine* host) {
          diff = 0;
       }
       cached_write_diff = diff;
-      Meter_humanUnit(cached_write_diff_str, cached_write_diff / ONE_K, sizeof(cached_write_diff_str));
+      Meter_ioRateUnit(cached_write_diff_str, sizeof(cached_write_diff_str), cached_write_diff, decimal);
 
       cached_num_disks = data.numDisks;
       cached_utilisation_diff = 0.0;
@@ -133,7 +137,7 @@ static void DiskIORateMeter_updateValues(Meter* this) {
          break;
    }
 
-   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "r:%siB/s w:%siB/s", cached_read_diff_str, cached_write_diff_str);
+   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "r:%s%s w:%s%s", cached_read_diff_str, cached_disk_unit_suffix, cached_write_diff_str, cached_disk_unit_suffix);
 }
 
 static void DiskIORateMeter_display(ATTR_UNUSED const Object* cast, RichString* out) {
@@ -153,11 +157,11 @@ static void DiskIORateMeter_display(ATTR_UNUSED const Object* cast, RichString* 
 
    RichString_appendAscii(out, CRT_colors[METER_TEXT], "read: ");
    RichString_appendAscii(out, CRT_colors[METER_VALUE_IOREAD], cached_read_diff_str);
-   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOREAD], "iB/s");
+   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOREAD], cached_disk_unit_suffix);
 
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " write: ");
    RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], cached_write_diff_str);
-   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], "iB/s");
+   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], cached_disk_unit_suffix);
 }
 
 static void DiskIOTimeMeter_updateValues(Meter* this) {

--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -314,6 +314,7 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    Panel_add(super, (Object*) CheckItem_newByRef("Highlight new and old processes", &(settings->highlightChanges)));
    Panel_add(super, (Object*) NumberItem_newByRef("- Highlight time (in seconds)", &(settings->highlightDelaySecs), 0, 1, 24 * 60 * 60));
    Panel_add(super, (Object*) NumberItem_newByRef("Hide main function bar (0 - off, 1 - on ESC until next input, 2 - permanently)", &(settings->hideFunctionBar), 0, 0, 2));
+   Panel_add(super, (Object*) CheckItem_newByRef("Display I/O rates in decimal SI units (KB/s, MB/s, GB/s) instead of binary IEC (KiB/s, MiB/s, GiB/s)", &(settings->decimalUnits)));
    #ifdef HAVE_LIBHWLOC
    Panel_add(super, (Object*) CheckItem_newByRef("Show topology when selecting affinity by default", &(settings->topologyAffinity)));
    #endif

--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -316,6 +316,7 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    Panel_add(super, (Object*) NumberItem_newByRef("- Highlight time (in seconds)", &(settings->highlightDelaySecs), 0, 1, 24 * 60 * 60));
    Panel_add(super, (Object*) NumberItem_newByRef("Hide main function bar (0 - off, 1 - on ESC until next input, 2 - permanently)", &(settings->hideFunctionBar), 0, 0, 2));
    Panel_add(super, (Object*) CheckItem_newByRef("Sticky follow", &(settings->stickyFollow)));
+   Panel_add(super, (Object*) CheckItem_newByRef("Display I/O rates in decimal SI units (KB/s, MB/s, GB/s) instead of binary IEC (KiB/s, MiB/s, GiB/s)", &(settings->decimalUnits)));
    #ifdef HAVE_LIBHWLOC
    Panel_add(super, (Object*) CheckItem_newByRef("Show topology when selecting affinity by default", &(settings->topologyAffinity)));
    #endif

--- a/Meter.c
+++ b/Meter.c
@@ -505,6 +505,29 @@ int Meter_humanUnit(char* buffer, double value, size_t size) {
    return xSnprintf(buffer, size, "%.*f%c", precision, value, unitPrefixes[i]);
 }
 
+const char* Meter_ioRateUnit(char* buffer, size_t size, double bytesPerSec, bool decimal) {
+   if (!decimal) {
+      Meter_humanUnit(buffer, bytesPerSec / ONE_K, size);
+      return "iB/s";
+   }
+
+   double val = bytesPerSec / ONE_DECIMAL_K;
+   size_t i = 0;
+   while (val >= ONE_DECIMAL_K && i < ARRAYSIZE(unitPrefixes) - 1) {
+      val /= ONE_DECIMAL_K;
+      ++i;
+   }
+   if (i >= ARRAYSIZE(unitPrefixes) - 1 && val > 9999.0) {
+      xSnprintf(buffer, size, "inf");
+      return "B/s";
+   }
+   int precision = 0;
+   if (i > 0)
+      precision = val <= 99.9 ? (val <= 9.99 ? 2 : 1) : 0;
+   xSnprintf(buffer, size, "%.*f%c", precision, val, unitPrefixes[i]);
+   return "B/s";
+}
+
 void Meter_delete(Object* cast) {
    if (!cast)
       return;

--- a/Meter.c
+++ b/Meter.c
@@ -504,6 +504,29 @@ int Meter_humanUnit(char* buffer, double value, size_t size) {
    return xSnprintf(buffer, size, "%.*f%c", precision, value, unitPrefixes[i]);
 }
 
+const char* Meter_ioRateUnit(char* buffer, size_t size, double bytesPerSec, bool decimal) {
+   if (!decimal) {
+      Meter_humanUnit(buffer, bytesPerSec / ONE_K, size);
+      return "iB/s";
+   }
+
+   double val = bytesPerSec / ONE_DECIMAL_K;
+   size_t i = 0;
+   while (val >= ONE_DECIMAL_K && i < ARRAYSIZE(unitPrefixes) - 1) {
+      val /= ONE_DECIMAL_K;
+      ++i;
+   }
+   if (i >= ARRAYSIZE(unitPrefixes) - 1 && val > 9999.0) {
+      xSnprintf(buffer, size, "inf");
+      return "B/s";
+   }
+   int precision = 0;
+   if (i > 0)
+      precision = val <= 99.9 ? (val <= 9.99 ? 2 : 1) : 0;
+   xSnprintf(buffer, size, "%.*f%c", precision, val, unitPrefixes[i]);
+   return "B/s";
+}
+
 void Meter_delete(Object* cast) {
    if (!cast)
       return;

--- a/Meter.h
+++ b/Meter.h
@@ -143,6 +143,10 @@ Meter* Meter_new(const Machine* host, unsigned int param, const MeterClass* type
    Example output strings: "0K", "1023K", "98.7M" and "1.23G" */
 int Meter_humanUnit(char* buffer, double value, size_t size);
 
+/* Formats 'bytesPerSec' into a string and returns the unit suffix
+   ("iB/s" for IEC binary, "B/s" for SI decimal). */
+const char* Meter_ioRateUnit(char* buffer, size_t size, double bytesPerSec, bool decimal);
+
 void Meter_delete(Object* cast);
 
 void Meter_setCaption(Meter* this, const char* caption);

--- a/NetworkIOMeter.c
+++ b/NetworkIOMeter.c
@@ -19,6 +19,7 @@ in the source distribution for its full text.
 #include "Platform.h"
 #include "RichString.h"
 #include "Row.h"
+#include "Settings.h"
 #include "XUtils.h"
 
 
@@ -34,6 +35,7 @@ static uint32_t cached_rxp_diff;
 static double cached_txb_diff;
 static char cached_txb_diff_str[6];
 static uint32_t cached_txp_diff;
+static const char* cached_unit_suffix = "iB/s";
 
 static void NetworkIOMeter_updateValues(Meter* this) {
    const Machine* host = this->host;
@@ -66,6 +68,7 @@ static void NetworkIOMeter_updateValues(Meter* this) {
       static uint64_t cached_txp_total;
 
       if (status != RATESTATUS_INIT) {
+         const bool decimal = host->settings->decimalUnits;
          uint64_t diff;
 
          if (data.bytesReceived > cached_rxb_total) {
@@ -75,7 +78,7 @@ static void NetworkIOMeter_updateValues(Meter* this) {
          } else {
             cached_rxb_diff = 0;
          }
-         Meter_humanUnit(cached_rxb_diff_str, cached_rxb_diff / ONE_K, sizeof(cached_rxb_diff_str));
+         cached_unit_suffix = Meter_ioRateUnit(cached_rxb_diff_str, sizeof(cached_rxb_diff_str), cached_rxb_diff, decimal);
 
          if (data.packetsReceived > cached_rxp_total) {
             diff = data.packetsReceived - cached_rxp_total;
@@ -92,7 +95,7 @@ static void NetworkIOMeter_updateValues(Meter* this) {
          } else {
             cached_txb_diff = 0;
          }
-         Meter_humanUnit(cached_txb_diff_str, cached_txb_diff / ONE_K, sizeof(cached_txb_diff_str));
+         Meter_ioRateUnit(cached_txb_diff_str, sizeof(cached_txb_diff_str), cached_txb_diff, decimal);
 
          if (data.packetsTransmitted > cached_txp_total) {
             diff = data.packetsTransmitted - cached_txp_total;
@@ -125,8 +128,8 @@ static void NetworkIOMeter_updateValues(Meter* this) {
       return;
    }
 
-   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "rx:%siB/s tx:%siB/s (%u/%upps)",
-      cached_rxb_diff_str, cached_txb_diff_str, cached_rxp_diff, cached_txp_diff);
+   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "rx:%s%s tx:%s%s (%u/%upps)",
+      cached_rxb_diff_str, cached_unit_suffix, cached_txb_diff_str, cached_unit_suffix, cached_rxp_diff, cached_txp_diff);
 }
 
 static void NetworkIOMeter_display(ATTR_UNUSED const Object* cast, RichString* out) {
@@ -148,11 +151,11 @@ static void NetworkIOMeter_display(ATTR_UNUSED const Object* cast, RichString* o
 
    RichString_writeAscii(out, CRT_colors[METER_TEXT], "rx: ");
    RichString_appendAscii(out, CRT_colors[METER_VALUE_IOREAD], cached_rxb_diff_str);
-   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOREAD], "iB/s");
+   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOREAD], cached_unit_suffix);
 
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " tx: ");
    RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], cached_txb_diff_str);
-   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], "iB/s");
+   RichString_appendAscii(out, CRT_colors[METER_VALUE_IOWRITE], cached_unit_suffix);
 
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " (");
    int len = xSnprintf(buffer, sizeof(buffer), "%u", (unsigned int)cached_rxp_diff);

--- a/Row.c
+++ b/Row.c
@@ -474,28 +474,27 @@ void Row_printRate(RichString* str, double rate, bool coloring) {
 
    if (!isNonnegative(rate)) {
       RichString_appendAscii(str, shadowColor, "        N/A ");
-   } else if (rate < 0.005) {
-      int len = snprintf(buffer, sizeof(buffer), "%7.2f B/s ", rate);
-      RichString_appendnAscii(str, shadowColor, buffer, len);
-   } else if (rate < ONE_K) {
-      int len = snprintf(buffer, sizeof(buffer), "%7.2f B/s ", rate);
-      RichString_appendnAscii(str, baseColor, buffer, len);
-   } else if (rate < ONE_M) {
-      int len = snprintf(buffer, sizeof(buffer), "%7.2f K/s ", rate / ONE_K);
-      RichString_appendnAscii(str, baseColor, buffer, len);
-   } else if (rate < ONE_G) {
-      int len = snprintf(buffer, sizeof(buffer), "%7.2f M/s ", rate / ONE_M);
-      RichString_appendnAscii(str, megabytesColor, buffer, len);
-   } else if (rate < ONE_T) {
-      int len = snprintf(buffer, sizeof(buffer), "%7.2f G/s ", rate / ONE_G);
-      RichString_appendnAscii(str, largeNumberColor, buffer, len);
-   } else if (rate < ONE_P) {
-      int len = snprintf(buffer, sizeof(buffer), "%7.2f T/s ", rate / ONE_T);
-      RichString_appendnAscii(str, largeNumberColor, buffer, len);
-   } else {
-      int len = snprintf(buffer, sizeof(buffer), "%7.2f P/s ", rate / ONE_P);
-      RichString_appendnAscii(str, largeNumberColor, buffer, len);
+      return;
    }
+
+   size_t i = 0;
+   double scaled = rate;
+   while (scaled >= ONE_K && i < ARRAYSIZE(unitPrefixes)) {
+      scaled /= ONE_K;
+      i++;
+   }
+
+   int color = baseColor;
+   if (rate < 0.005)
+      color = shadowColor;
+   else if (i == 2)
+      color = megabytesColor;
+   else if (i >= 3)
+      color = largeNumberColor;
+
+   char prefix = (i == 0) ? 'B' : unitPrefixes[i - 1];
+   int len = xSnprintf(buffer, sizeof(buffer), "%7.2f %c/s ", scaled, prefix);
+   RichString_appendnAscii(str, color, buffer, len);
 }
 
 void Row_printLeftAlignedField(RichString* str, int attr, const char* content, unsigned int width) {

--- a/Row.c
+++ b/Row.c
@@ -459,7 +459,7 @@ void Row_printNanoseconds(RichString* str, unsigned long long totalNanoseconds, 
    Row_printTime(str, totalHundredths, coloring);
 }
 
-void Row_printRate(RichString* str, double rate, bool coloring) {
+void Row_printRate(RichString* str, double rate, bool coloring, bool decimal) {
    char buffer[16];
 
    int largeNumberColor = CRT_colors[LARGE_NUMBER];
@@ -477,10 +477,11 @@ void Row_printRate(RichString* str, double rate, bool coloring) {
       return;
    }
 
+   const double base = decimal ? ONE_DECIMAL_K : ONE_K;
    size_t i = 0;
    double scaled = rate;
-   while (scaled >= ONE_K && i < ARRAYSIZE(unitPrefixes)) {
-      scaled /= ONE_K;
+   while (scaled >= base && i < ARRAYSIZE(unitPrefixes)) {
+      scaled /= base;
       i++;
    }
 

--- a/Row.h
+++ b/Row.h
@@ -157,8 +157,8 @@ void Row_printTime(RichString* str, unsigned long long totalHundredths, bool col
 /* Takes time in nanoseconds. Prints 9 columns. */
 void Row_printNanoseconds(RichString* str, unsigned long long totalNanoseconds, bool coloring);
 
-/* Takes rate in bare unit (base 1024) per second. Prints 12 columns. */
-void Row_printRate(RichString* str, double rate, bool coloring);
+/* Takes rate in bytes per second. Uses base 1000 (SI) when 'decimal', else base 1024 (IEC). Prints 12 columns. */
+void Row_printRate(RichString* str, double rate, bool coloring, bool decimal);
 
 int Row_printPercentage(float val, char* buffer, size_t n, uint8_t width, int* attr);
 

--- a/Settings.c
+++ b/Settings.c
@@ -523,6 +523,8 @@ static bool Settings_read(Settings* this, const char* fileName, const Machine* h
          didReadMeters = true;
       } else if (String_eq(option[0], "hide_function_bar")) {
          this->hideFunctionBar = atoi(option[1]);
+      } else if (String_eq(option[0], "decimal_units")) {
+         this->decimalUnits = !!atoi(option[1]);
       #ifdef HAVE_LIBHWLOC
       } else if (String_eq(option[0], "topology_affinity")) {
          this->topologyAffinity = !!atoi(option[1]);
@@ -723,6 +725,7 @@ int Settings_write(const Settings* this, bool onCrash) {
    #endif
    printSettingInteger("delay", (int) this->delay);
    printSettingInteger("hide_function_bar", (int) this->hideFunctionBar);
+   printSettingInteger("decimal_units", this->decimalUnits);
    #ifdef HAVE_LIBHWLOC
    printSettingInteger("topology_affinity", this->topologyAffinity);
    #endif
@@ -873,6 +876,7 @@ Settings* Settings_new(const Machine* host, Hashtable* dynamicMeters, Hashtable*
       free_and_xStrdup(&this->filename, this->initialFilename);
 
    this->colorScheme = 0;
+   this->decimalUnits = false;
 #ifdef HAVE_GETMOUSE
    this->enableMouse = true;
 #endif

--- a/Settings.c
+++ b/Settings.c
@@ -574,6 +574,8 @@ static bool Settings_read(Settings* this, const char* fileName, const Machine* h
          }
       } else if (String_eq(option[0], "hide_function_bar")) {
          this->hideFunctionBar = atoi(option[1]);
+      } else if (String_eq(option[0], "decimal_units")) {
+         this->decimalUnits = !!atoi(option[1]);
       #ifdef HAVE_LIBHWLOC
       } else if (String_eq(option[0], "topology_affinity")) {
          this->topologyAffinity = !!atoi(option[1]);
@@ -841,6 +843,7 @@ int Settings_write(const Settings* this, bool onCrash) {
    #endif
    printSettingInteger("delay", (int) this->delay);
    printSettingInteger("hide_function_bar", (int) this->hideFunctionBar);
+   printSettingInteger("decimal_units", this->decimalUnits);
    #ifdef HAVE_LIBHWLOC
    printSettingInteger("topology_affinity", this->topologyAffinity);
    #endif
@@ -993,6 +996,7 @@ Settings* Settings_new(const Machine* host, Hashtable* dynamicMeters, Hashtable*
       free_and_xStrdup(&this->filename, this->initialFilename);
 
    this->colorScheme = 0;
+   this->decimalUnits = false;
 #ifdef HAVE_GETMOUSE
    this->enableMouse = true;
 #endif

--- a/Settings.h
+++ b/Settings.h
@@ -107,6 +107,7 @@ typedef struct Settings_ {
    bool enableMouse;
    #endif
    int hideFunctionBar;  // 0 - off, 1 - on ESC until next input, 2 - permanently
+   bool decimalUnits;    // I/O rates: false = IEC binary (KiB/s, ...), true = SI decimal (KB/s, ...)
    #ifdef HAVE_LIBHWLOC
    bool topologyAffinity;
    #endif

--- a/Settings.h
+++ b/Settings.h
@@ -109,6 +109,7 @@ typedef struct Settings_ {
    bool enableMouse;
    #endif
    int hideFunctionBar;  // 0 - off, 1 - on ESC until next input, 2 - permanently
+   bool decimalUnits;    // I/O rates: false = IEC binary (KiB/s, ...), true = SI decimal (KB/s, ...)
    #ifdef HAVE_LIBHWLOC
    bool topologyAffinity;
    #endif

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -274,9 +274,9 @@ static void LinuxProcess_rowWriteField(const Row* super, RichString* str, Proces
    case RBYTES: Row_printBytes(str, lp->io_read_bytes, coloring); return;
    case WBYTES: Row_printBytes(str, lp->io_write_bytes, coloring); return;
    case CNCLWB: Row_printBytes(str, lp->io_cancelled_write_bytes, coloring); return;
-   case IO_READ_RATE:  Row_printRate(str, lp->io_rate_read_bps, coloring); return;
-   case IO_WRITE_RATE: Row_printRate(str, lp->io_rate_write_bps, coloring); return;
-   case IO_RATE: Row_printRate(str, LinuxProcess_totalIORate(lp), coloring); return;
+   case IO_READ_RATE:  Row_printRate(str, lp->io_rate_read_bps, coloring, host->settings->decimalUnits); return;
+   case IO_WRITE_RATE: Row_printRate(str, lp->io_rate_write_bps, coloring, host->settings->decimalUnits); return;
+   case IO_RATE: Row_printRate(str, LinuxProcess_totalIORate(lp), coloring, host->settings->decimalUnits); return;
    #ifdef HAVE_OPENVZ
    case CTID: xSnprintf(buffer, n, "%-8s ", lp->ctid ? lp->ctid : ""); break;
    case VPID: xSnprintf(buffer, n, "%*d ", Process_pidDigits, lp->vpid); break;

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -267,9 +267,9 @@ static void LinuxProcess_rowWriteField(const Row* super, RichString* str, Proces
    case RBYTES: Row_printBytes(str, lp->io_read_bytes, coloring); return;
    case WBYTES: Row_printBytes(str, lp->io_write_bytes, coloring); return;
    case CNCLWB: Row_printBytes(str, lp->io_cancelled_write_bytes, coloring); return;
-   case IO_READ_RATE:  Row_printRate(str, lp->io_rate_read_bps, coloring); return;
-   case IO_WRITE_RATE: Row_printRate(str, lp->io_rate_write_bps, coloring); return;
-   case IO_RATE: Row_printRate(str, LinuxProcess_totalIORate(lp), coloring); return;
+   case IO_READ_RATE:  Row_printRate(str, lp->io_rate_read_bps, coloring, host->settings->decimalUnits); return;
+   case IO_WRITE_RATE: Row_printRate(str, lp->io_rate_write_bps, coloring, host->settings->decimalUnits); return;
+   case IO_RATE: Row_printRate(str, LinuxProcess_totalIORate(lp), coloring, host->settings->decimalUnits); return;
    case CGROUP:
       xSnprintf(buffer, n, "%-*.*s ", Row_fieldWidths[CGROUP], Row_fieldWidths[CGROUP], lp->cgroup ? lp->cgroup : "N/A");
       RichString_appendWide(str, attr, buffer);

--- a/pcp/PCPDynamicColumn.c
+++ b/pcp/PCPDynamicColumn.c
@@ -444,7 +444,7 @@ void PCPDynamicColumn_writeAtomValue(PCPDynamicColumn* column, RichString* str, 
    bool coloring = settings->highlightMegabytes;
    pmUnits units = desc->units;
    if (units.dimSpace && units.dimTime)
-      Row_printRate(str, value, coloring);
+      Row_printRate(str, value, coloring, settings->decimalUnits);
    else if (units.dimSpace)
       Row_printBytes(str, value, coloring);
    else if (units.dimCount)

--- a/pcp/PCPProcess.c
+++ b/pcp/PCPProcess.c
@@ -161,9 +161,9 @@ static void PCPProcess_rowWriteField(const Row* super, RichString* str, ProcessF
    case RBYTES: Row_printBytes(str, pp->io_read_bytes, coloring); return;
    case WBYTES: Row_printBytes(str, pp->io_write_bytes, coloring); return;
    case CNCLWB: Row_printBytes(str, pp->io_cancelled_write_bytes, coloring); return;
-   case IO_READ_RATE:  Row_printRate(str, pp->io_rate_read_bps, coloring); return;
-   case IO_WRITE_RATE: Row_printRate(str, pp->io_rate_write_bps, coloring); return;
-   case IO_RATE: Row_printRate(str, PCPProcess_totalIORate(pp), coloring); return;
+   case IO_READ_RATE:  Row_printRate(str, pp->io_rate_read_bps, coloring, super->host->settings->decimalUnits); return;
+   case IO_WRITE_RATE: Row_printRate(str, pp->io_rate_write_bps, coloring, super->host->settings->decimalUnits); return;
+   case IO_RATE: Row_printRate(str, PCPProcess_totalIORate(pp), coloring, super->host->settings->decimalUnits); return;
    case CGROUP: xSnprintf(buffer, n, "%-35.35s ", pp->cgroup ? pp->cgroup : "N/A"); break;
    case CCGROUP: xSnprintf(buffer, n, "%-35.35s ", pp->cgroup_short ? pp->cgroup_short : (pp->cgroup ? pp->cgroup : "N/A")); break;
    case CONTAINER: xSnprintf(buffer, n, "%-35.35s ", pp->container_short ? pp->container_short : "N/A"); break;


### PR DESCRIPTION
when displaying network or disk io meters allow to choose whether to use IEC or SI unit prefixes
