### PR TITLE
Switch primary timekeeping from struct timeval to struct timespec

### DIFF
--- a/Machine.h
+++ b/Machine.h
@@ -11,7 +11,7 @@ in the source distribution for its full text.
 #include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <sys/time.h>
+#include <time.h>
 #include <sys/types.h>
 
 #include "Panel.h"
@@ -38,7 +38,7 @@ typedef unsigned long long int memory_t;
 typedef struct Machine_ {
    struct Settings_* settings;
 
-   struct timeval realtime;   /* time of the current sample */
+   struct timespec realtime;  /* time of the current sample */
    uint64_t realtimeMs;       /* current time in milliseconds */
    uint64_t monotonicMs;      /* same, but from monotonic clock */
    uint64_t prevMonotonicMs;  /* time in milliseconds from monotonic clock of previous scan */

--- a/Meter.c
+++ b/Meter.c
@@ -24,6 +24,7 @@ in the source distribution for its full text.
 #include "Row.h"
 #include "Settings.h"
 #include "XUtils.h"
+#include "generic/gettime.h"
 
 
 #ifndef UINT32_WIDTH
@@ -255,10 +256,10 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
 
    // Record new value if necessary
    const Machine* host = this->host;
-   if (!timercmp(&host->realtime, &(data->time), <)) {
+   if (timespec_cmp(&host->realtime, &(data->time)) >= 0) {
       int globalDelay = host->settings->delay;
-      struct timeval delay = { .tv_sec = globalDelay / 10, .tv_usec = (globalDelay % 10) * 100000L };
-      timeradd(&host->realtime, &delay, &(data->time));
+      struct timespec delay = { .tv_sec = globalDelay / 10, .tv_nsec = (globalDelay % 10) * 100000000L };
+      timespec_add(&host->realtime, &delay, &(data->time));
 
       memmove(&data->values[0], &data->values[1], (nValues - 1) * sizeof(*data->values));
 

--- a/Meter.h
+++ b/Meter.h
@@ -10,7 +10,7 @@ in the source distribution for its full text.
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <sys/time.h>
+#include <time.h>
 
 #include "ListItem.h"
 #include "Machine.h"
@@ -104,7 +104,7 @@ typedef struct MeterClass_ {
 #define Meter_isPercentChart(this_)    As_Meter(this_)->isPercentChart
 
 typedef struct GraphData_ {
-   struct timeval time;
+   struct timespec time;
    size_t nValues;
    double* values;
 } GraphData;

--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -123,7 +123,7 @@ static void checkRecalculation(ScreenManager* this, double* oldTime, int* sortTi
    Machine* host = this->host;
 
    Platform_gettime_realtime(&host->realtime, &host->realtimeMs);
-   double newTime = ((double)host->realtime.tv_sec * 10) + ((double)host->realtime.tv_usec / 100000);
+   double newTime = ((double)host->realtime.tv_sec * 10) + ((double)host->realtime.tv_nsec / 100000000L);
 
    *timedOut = (newTime - *oldTime > host->settings->delay);
    *rescan |= *timedOut;

--- a/configure.ac
+++ b/configure.ac
@@ -454,7 +454,7 @@ if test "$my_htop_platform" = darwin; then
 fi
 
 if test "$my_htop_platform" = pcp; then
-   AC_CHECK_FUNCS([pmLookupDescs])
+   AC_CHECK_FUNCS([pmLookupDescs pmtimespecToReal pmtimevalTotimespec])
 fi
 
 if test "$my_htop_platform" = linux && test "x$enable_static" = xyes; then

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -18,6 +18,7 @@ in the source distribution for its full text.
 #include <net/if_types.h>
 #include <net/route.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <mach/port.h>
 #include <net/if.h> // After `sys/socket.h` for struct `sockaddr` (for iOS6 SDK)
 

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -103,7 +103,7 @@ static inline CommandLineStatus Platform_getLongOption(ATTR_UNUSED int opt, ATTR
    return STATUS_ERROR_EXIT;
 }
 
-static inline void Platform_gettime_realtime(struct timeval* tv, uint64_t* msec) {
+static inline void Platform_gettime_realtime(struct timespec* tv, uint64_t* msec) {
    Generic_gettime_realtime(tv, msec);
 }
 

--- a/dragonflybsd/Platform.h
+++ b/dragonflybsd/Platform.h
@@ -93,7 +93,7 @@ static inline CommandLineStatus Platform_getLongOption(ATTR_UNUSED int opt, ATTR
    return STATUS_ERROR_EXIT;
 }
 
-static inline void Platform_gettime_realtime(struct timeval* tv, uint64_t* msec) {
+static inline void Platform_gettime_realtime(struct timespec* tv, uint64_t* msec) {
    Generic_gettime_realtime(tv, msec);
 }
 

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -93,7 +93,7 @@ static inline CommandLineStatus Platform_getLongOption(ATTR_UNUSED int opt, ATTR
    return STATUS_ERROR_EXIT;
 }
 
-static inline void Platform_gettime_realtime(struct timeval* tv, uint64_t* msec) {
+static inline void Platform_gettime_realtime(struct timespec* tv, uint64_t* msec) {
    Generic_gettime_realtime(tv, msec);
 }
 

--- a/generic/gettime.c
+++ b/generic/gettime.c
@@ -10,31 +10,32 @@ in the source distribution for its full text.
 #include "generic/gettime.h"
 
 #include <string.h>
-#include <time.h>
+
+#if !defined(HAVE_CLOCK_GETTIME)
+#include <sys/time.h>
+#endif
 
 
-void Generic_gettime_realtime(struct timeval* tvp, uint64_t* msec) {
+void Generic_gettime_realtime(struct timespec* tsp, uint64_t* msec) {
 
 #if defined(HAVE_CLOCK_GETTIME)
 
-   struct timespec ts;
-   if (clock_gettime(CLOCK_REALTIME, &ts) == 0) {
-      tvp->tv_sec = ts.tv_sec;
-      tvp->tv_usec = (suseconds_t)(ts.tv_nsec / 1000);
-      *msec = ((uint64_t)ts.tv_sec * 1000) + ((uint64_t)ts.tv_nsec / 1000000);
+   if (clock_gettime(CLOCK_REALTIME, tsp) == 0) {
+      *msec = ((uint64_t)tsp->tv_sec * 1000) + ((uint64_t)tsp->tv_nsec / 1000000);
    } else {
-      memset(tvp, 0, sizeof(struct timeval));
+      memset(tsp, 0, sizeof(*tsp));
       *msec = 0;
    }
 
-#else /* lower resolution gettimeofday(2) is always available */
+#else /* lower resolution gettimeofday(2) fallback */
 
    struct timeval tv;
    if (gettimeofday(&tv, NULL) == 0) {
-      *tvp = tv; /* struct copy */
+      tsp->tv_sec = tv.tv_sec;
+      tsp->tv_nsec = (long)tv.tv_usec * 1000L;
       *msec = ((uint64_t)tv.tv_sec * 1000) + ((uint64_t)tv.tv_usec / 1000);
    } else {
-      memset(tvp, 0, sizeof(struct timeval));
+      memset(tsp, 0, sizeof(*tsp));
       *msec = 0;
    }
 
@@ -50,7 +51,7 @@ void Generic_gettime_monotonic(uint64_t* msec) {
    else
       *msec = 0;
 
-#else /* lower resolution gettimeofday() should be always available */
+#else /* lower resolution gettimeofday() fallback */
 
    struct timeval tv;
    if (gettimeofday(&tv, NULL) == 0)

--- a/generic/gettime.h
+++ b/generic/gettime.h
@@ -8,11 +8,28 @@ in the source distribution for its full text.
 */
 
 #include <stdint.h>
-#include <sys/time.h>
+#include <time.h>
 
 
-void Generic_gettime_realtime(struct timeval* tvp, uint64_t* msec);
+void Generic_gettime_realtime(struct timespec* tsp, uint64_t* msec);
 
 void Generic_gettime_monotonic(uint64_t* msec);
+
+static inline int timespec_cmp(const struct timespec* a, const struct timespec* b) {
+   if (a->tv_sec != b->tv_sec)
+      return a->tv_sec < b->tv_sec ? -1 : 1;
+   if (a->tv_nsec != b->tv_nsec)
+      return a->tv_nsec < b->tv_nsec ? -1 : 1;
+   return 0;
+}
+
+static inline void timespec_add(const struct timespec* a, const struct timespec* b, struct timespec* result) {
+   result->tv_sec = a->tv_sec + b->tv_sec;
+   result->tv_nsec = a->tv_nsec + b->tv_nsec;
+   if (result->tv_nsec >= 1000000000L) {
+      result->tv_sec++;
+      result->tv_nsec -= 1000000000L;
+   }
+}
 
 #endif

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -117,7 +117,7 @@ void Platform_longOptionsUsage(const char* name);
 
 CommandLineStatus Platform_getLongOption(int opt, int argc, char** argv);
 
-static inline void Platform_gettime_realtime(struct timeval* tv, uint64_t* msec) {
+static inline void Platform_gettime_realtime(struct timespec* tv, uint64_t* msec) {
    Generic_gettime_realtime(tv, msec);
 }
 

--- a/netbsd/Platform.h
+++ b/netbsd/Platform.h
@@ -97,7 +97,7 @@ static inline CommandLineStatus Platform_getLongOption(ATTR_UNUSED int opt, ATTR
    return STATUS_ERROR_EXIT;
 }
 
-static inline void Platform_gettime_realtime(struct timeval* tv, uint64_t* msec) {
+static inline void Platform_gettime_realtime(struct timespec* tv, uint64_t* msec) {
    Generic_gettime_realtime(tv, msec);
 }
 

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -91,7 +91,7 @@ static inline CommandLineStatus Platform_getLongOption(ATTR_UNUSED int opt, ATTR
    return STATUS_ERROR_EXIT;
 }
 
-static inline void Platform_gettime_realtime(struct timeval* tv, uint64_t* msec) {
+static inline void Platform_gettime_realtime(struct timespec* tv, uint64_t* msec) {
    Generic_gettime_realtime(tv, msec);
 }
 

--- a/pcp/Metric.c
+++ b/pcp/Metric.c
@@ -219,7 +219,7 @@ void Metric_enableThreads(void) {
    pmFreeResult(result);
 }
 
-bool Metric_fetch(struct timeval* timestamp) {
+bool Metric_fetch(struct timespec* timestamp) {
    if (pcp->result) {
       pmFreeResult(pcp->result);
       pcp->result = NULL;
@@ -243,9 +243,9 @@ bool Metric_fetch(struct timeval* timestamp) {
    }
    if (timestamp) {
 #if PMAPI_VERSION >= 3
-      pmtimespecTotimeval(&pcp->result->timestamp, timestamp);
-#else
       *timestamp = pcp->result->timestamp;
+#else
+      pmtimevalTotimespec(&pcp->result->timestamp, timestamp);
 #endif
    }
    return true;

--- a/pcp/Metric.h
+++ b/pcp/Metric.h
@@ -176,7 +176,7 @@ bool Metric_enabled(Metric metric);
 
 void Metric_enableThreads(void);
 
-bool Metric_fetch(struct timeval* timestamp);
+bool Metric_fetch(struct timespec* timestamp);
 
 bool Metric_iterate(Metric metric, int* instp, int* offsetp, size_t entrylen);
 

--- a/pcp/PCPMachine.c
+++ b/pcp/PCPMachine.c
@@ -16,7 +16,7 @@ in the source distribution for its full text.
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
+#include <time.h>
 
 #include "Machine.h"
 #include "Macros.h"
@@ -364,12 +364,12 @@ void Machine_scan(Machine* super) {
    Metric_enable(PCP_PROC_SMAPS_SWAP, host->smaps_flag);
    Metric_enable(PCP_PROC_SMAPS_SWAPPSS, host->smaps_flag);
 
-   struct timeval timestamp;
+   struct timespec timestamp;
    if (Metric_fetch(&timestamp) != true)
       return;
 
    double sample = host->timestamp;
-   host->timestamp = pmtimevalToReal(&timestamp);
+   host->timestamp = pmtimespecToReal(&timestamp);
    host->period = (host->timestamp - sample) * 100;
 
    PCPMachine_scan(host);
@@ -381,9 +381,9 @@ Machine* Machine_new(UsersTable* usersTable, uid_t userId) {
 
    Machine_init(super, usersTable, userId);
 
-   struct timeval timestamp;
-   gettimeofday(&timestamp, NULL);
-   this->timestamp = pmtimevalToReal(&timestamp);
+   struct timespec timestamp;
+   pmtimespecNow(&timestamp);
+   this->timestamp = pmtimespecToReal(&timestamp);
 
    this->sys = SYSTEM_NAME_UNKNOWN;
    PCPMachine_updateSystemName(this);

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -295,6 +295,19 @@ static const char* Platform_metricNames[] = {
 
 static void Platform_setRelease(void);
 
+#ifndef HAVE_PMTIMEVALTOTIMESPEC
+void pmtimevalTotimespec(struct timeval* tv, struct timespec* ts) {
+   ts->tv_sec = tv->tv_sec;
+   ts->tv_nsec = tv->tv_usec * 1000;
+}
+#endif
+
+#ifndef HAVE_PMTIMESPECTOREAL
+double pmtimespecToReal(const struct timespec* ts) {
+   return (double)ts->tv_sec + ((double)ts->tv_nsec / 1e9);
+}
+#endif
+
 #ifndef HAVE_PMLOOKUPDESCS
 /*
  * pmLookupDescs(3) exists in latest versions of libpcp (5.3.6+),
@@ -383,12 +396,12 @@ bool Platform_init(void) {
    pcp->descs = xCalloc(PCP_METRIC_COUNT, sizeof(pmDesc));
 
    if (opts.context == PM_CONTEXT_ARCHIVE) {
-      gettimeofday(&pcp->offset, NULL);
+      pmtimespecNow(&pcp->offset);
 #if PMAPI_VERSION >= 3
-      struct timeval start = { opts.start.tv_sec, (suseconds_t)(opts.start.tv_nsec / 1000) };
-      pmtimevalDec(&pcp->offset, &start);
+      pmtimespecDec(&pcp->offset, &opts.start);
 #else
-      pmtimevalDec(&pcp->offset, &opts.start);
+      struct timespec start = { .tv_sec = opts.start.tv_sec, .tv_nsec = 1000L * opts.start.tv_usec };
+      pmtimespecDec(&pcp->offset, &start);
 #endif
    }
 
@@ -905,14 +918,14 @@ CommandLineStatus Platform_getLongOption(int opt, ATTR_UNUSED int argc, char** a
    return STATUS_ERROR_EXIT;
 }
 
-void Platform_gettime_realtime(struct timeval* tv, uint64_t* msec) {
-   if (gettimeofday(tv, NULL) == 0) {
+void Platform_gettime_realtime(struct timespec* tv, uint64_t* msec) {
+   if (pmtimespecNow(tv) == 0) {
       /* shift by start offset to stay in lock-step with realtime (archives) */
-      if (pcp->offset.tv_sec || pcp->offset.tv_usec)
-         pmtimevalDec(tv, &pcp->offset);
-      *msec = ((uint64_t)tv->tv_sec * 1000) + ((uint64_t)tv->tv_usec / 1000);
+      if (pcp->offset.tv_sec || pcp->offset.tv_nsec)
+         pmtimespecDec(tv, &pcp->offset);
+      *msec = ((uint64_t)tv->tv_sec * 1000) + ((uint64_t)tv->tv_nsec / 1000000);
    } else {
-      memset(tv, 0, sizeof(struct timeval));
+      memset(tv, 0, sizeof(struct timespec));
       *msec = 0;
    }
 }

--- a/pcp/Platform.h
+++ b/pcp/Platform.h
@@ -54,12 +54,20 @@ typedef struct Platform_ {
    PCPDynamicMeters meters;   /* dynamic meters via configuration files */
    PCPDynamicColumns columns; /* dynamic columns via configuration files */
    PCPDynamicScreens screens; /* dynamic screens via configuration files */
-   struct timeval offset;     /* time offset used in archive mode only */
+   struct timespec offset;    /* time offset used in archive mode only */
    long long btime;           /* boottime in seconds since the epoch */
    char* release;             /* uname and distro from this context */
    int pidmax;                /* maximum platform process identifier */
    unsigned int ncpu;         /* maximum processor count configured */
 } Platform;
+
+/* older pcp/pmapi.h versions lack these libpcp declarations */
+#ifndef HAVE_PMTIMEVALTOTIMESPEC
+void pmtimevalTotimespec(struct timeval *, struct timespec *);
+#endif
+#ifndef HAVE_PMTIMESPECTOREAL
+double pmtimespecToReal(const struct timespec *);
+#endif
 
 extern const ScreenDefaults Platform_defaultScreens[];
 
@@ -142,7 +150,7 @@ size_t Platform_addMetric(Metric id, const char* name);
 
 void Platform_getFileDescriptors(double* used, double* max);
 
-void Platform_gettime_realtime(struct timeval* tv, uint64_t* msec);
+void Platform_gettime_realtime(struct timespec* tv, uint64_t* msec);
 
 void Platform_gettime_monotonic(uint64_t* msec);
 

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -119,7 +119,7 @@ static inline CommandLineStatus Platform_getLongOption(ATTR_UNUSED int opt, ATTR
    return STATUS_ERROR_EXIT;
 }
 
-static inline void Platform_gettime_realtime(struct timeval* tv, uint64_t* msec) {
+static inline void Platform_gettime_realtime(struct timespec* tv, uint64_t* msec) {
    Generic_gettime_realtime(tv, msec);
 }
 

--- a/unsupported/Platform.h
+++ b/unsupported/Platform.h
@@ -84,7 +84,7 @@ static inline CommandLineStatus Platform_getLongOption(ATTR_UNUSED int opt, ATTR
    return STATUS_ERROR_EXIT;
 }
 
-static inline void Platform_gettime_realtime(struct timeval* tv, uint64_t* msec) {
+static inline void Platform_gettime_realtime(struct timespec* tv, uint64_t* msec) {
    Generic_gettime_realtime(tv, msec);
 }
 


### PR DESCRIPTION
The generic gettime implementation already calls clock_gettime() with struct timespec, then converts down to struct timeval — losing nanosecond precision.  This eliminates that wasteful conversion and modernizes the internal time API to use nanosecond precision throughout (struct timespec) instead of microsecond (struct timeval).

Core changes:
- Machine.realtime: struct timeval → struct timespec
- GraphData.time: struct timeval → struct timespec
- Generic_gettime_realtime: now populates struct timespec directly
- timespec_cmp() and timespec_add() helpers in generic/gettime.h

System API boundaries retained as struct timeval:
- BSD platform uptime (gettimeofday + kernel sysctl boottime)
- TraceScreen.c select() timeout
- generic/gettime.c gettimeofday() fallback (no clock_gettime)
- Kernel structs (BSD kinfo_proc boot time, dragonfly busy_time)