### PR TITLE
Fix building htop for TCC compiler and experiments for Gentoo users

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -349,10 +349,10 @@ AC_LINK_IFELSE(
 )
 
 AC_MSG_CHECKING(for __builtin_ctz)
-AC_COMPILE_IFELSE(
+AC_LINK_IFELSE(
    [AC_LANG_PROGRAM(
       [],
-      [[__builtin_ctz(1); /* Supported in GCC 3.4 or later */]]
+      [[volatile int test_ctz = __builtin_ctz(1); (void)test_ctz; /* Supported in GCC 3.4 or later */]]
    )],
    AC_DEFINE([HAVE_BUILTIN_CTZ], 1, [Define to 1 if the compiler supports '__builtin_ctz' function.])
    AC_MSG_RESULT(yes),


### PR DESCRIPTION
My experiments on 2 CPUs Xeon E5-2699v3 (72 threads):

Wow! I am surprised by the compilation speed on TCC, as well as the resource consumption on monitoring
- TCC 3s compilation
- Clang 12s compilation
- GCC 15s compialtion

Building with -DNDEBUG macro by default.

I think Gentoo users will idolize Fabrice Bellard.

Install `tcc` compiler easy `apt install tcc`

Wiki: https://en.wikipedia.org/wiki/Tiny_C_Compiler
Official site: https://bellard.org/tcc/

<img width="1656" height="771" alt="tcc_htop" src="https://github.com/user-attachments/assets/bb90ad56-540f-47af-8077-013582820b26" />
<img width="1623" height="712" alt="clang_htop" src="https://github.com/user-attachments/assets/aaa6a4d8-12f3-4c6f-8087-8f2607d42a0c" />
<img width="1614" height="811" alt="gcc_htop" src="https://github.com/user-attachments/assets/efeadd8f-f60f-4190-93fa-195a6ecebe6b" />
