### PR TITLE
build: Simplify __builtin_ctz check code

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -352,7 +352,10 @@ AC_MSG_CHECKING(for __builtin_ctz)
 AC_LINK_IFELSE(
    [AC_LANG_PROGRAM(
       [],
-      [[volatile int test_ctz = __builtin_ctz(1); (void)test_ctz; /* Supported in GCC 3.4 or later */]]
+      [[
+         /* Supported in GCC 3.4 or later */
+         return __builtin_ctz(1U); /* Should be 0 (exit success) */
+      ]]
    )],
    AC_DEFINE([HAVE_BUILTIN_CTZ], 1, [Define to 1 if the compiler supports '__builtin_ctz' function.])
    AC_MSG_RESULT(yes),


### PR DESCRIPTION
Follow-up of #1978.

@GermanAizek I believe this check code also works with TCC without a false positive, but I would like you to help me test it out.