### PR TITLE
Fix drawTab bounds handling and improve rendering safety

### DIFF
--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -168,27 +168,57 @@ static void checkRecalculation(ScreenManager* this, double* oldTime, int* sortTi
    *rescan = false;
 }
 
-static inline bool drawTab(const int* y, int* x, int l, const char* name, bool cur) {
-   assert(*x >= 0);
-   assert(*x < l);
+static inline int getBorderColor(bool cur) {
+   return CRT_colors[cur ? SCREENS_CUR_BORDER : SCREENS_OTH_BORDER];
+}
 
-   attrset(CRT_colors[cur ? SCREENS_CUR_BORDER : SCREENS_OTH_BORDER]);
-   mvaddch(*y, *x, '[');
+static inline int getTextColor(bool cur) {
+   return CRT_colors[cur ? SCREENS_CUR_TEXT : SCREENS_OTH_TEXT];
+}
+
+static inline bool drawTab(int y, int* x, int maxWidth, const char* name, bool cur) {
+
+   assert( x != NULL);
+   assert(name != NULL); 
+   assert(*x >= 0 && *x < maxWidth);
+
+   int remainingWidth = maxWidth - *x;
+
+   //drwa '['
+   attrset(getBorderColor(cur));
+   mvaddch(y, *x, '[');
    (*x)++;
-   if (*x >= l)
-      return false;
-   int nameWidth = (int)strnlen(name, l - *x);
-   attrset(CRT_colors[cur ? SCREENS_CUR_TEXT : SCREENS_OTH_TEXT]);
-   mvaddnstr(*y, *x, name, nameWidth);
+   remainingWidth--;
+   if (remainingWidth <= 0) {
+      return false; 
+   }
+
+   //draw text with safety
+   int nameWidth = (int)strnlen(name, remainingWidth);
+   attrset(getTextColor(cur));
+   mvaddnstr(y, *x, name, nameWidth);
    *x += nameWidth;
-   if (*x >= l)
+   remainingWidth -= nameWidth;
+   if (remainingWidth <= 0) {
       return false;
-   attrset(CRT_colors[cur ? SCREENS_CUR_BORDER : SCREENS_OTH_BORDER]);
-   mvaddch(*y, *x, ']');
-   *x += 1 + SCREEN_TAB_COLUMN_GAP;
-   if (*x >= l)
+   } 
+
+   //draw ']'
+   attrset(getBorderColor(cur));
+   mvaddch(y, *x, ']');
+   (*x)++;
+   remainingWidth--;
+   if (remainingWidth <= 0){ 
       return false;
-   return true;
+   }
+
+   //add gap, clamped so *x never exceeds maxWidth on exit
+   int gap =  SCREEN_TAB_COLUMN_GAP; 
+   int advance = (gap < remainingWidth) ? gap : remainingWidth;
+   *x += advance;
+   remainingWidth -= advance;
+
+   return (remainingWidth > 0);
 }
 
 static void ScreenManager_drawScreenTabs(ScreenManager* this) {


### PR DESCRIPTION
This change improves the safety and clarity of drawTab() while preserving its behavior.

Key changes:

- Reworked bounds handling using a `remainingWidth` variable instead of repeated `*x >= l` checks
  - Simplifies reasoning about available space
  - Ensures no writes occur past the screen width
  
- Prevent potential overflow when applying `SCREEN_TAB_COLUMN_GAP`
  - The gap is now clamped to remaining width
  - Previously, `*x += 1 + gap` could advance beyond the limit

- Removed unnecessary pointer usage for `y`
  - `y` is not modified, so passing by value simplifies the API

- Extracted color selection into helper functions
  - Reduces duplication and improves readability

- Added basic null checks for `x` and `name`

Behavioral notes:

- Rendering is unchanged in normal cases
- Near the right boundary, tabs are now safely clipped instead of potentially exceeding bounds

This is primarily a correctness and maintainability improvement with no intended visual changes.