### PR TITLE
Prevent another integer overflow in drawScreenTab()

### DIFF
--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -185,9 +185,11 @@ static inline bool drawTab(const int* y, int* x, int l, const char* name, bool c
       return false;
    attrset(CRT_colors[cur ? SCREENS_CUR_BORDER : SCREENS_OTH_BORDER]);
    mvaddch(*y, *x, ']');
-   *x += 1 + SCREEN_TAB_COLUMN_GAP;
-   if (*x >= l)
+   if (*x >= l - (1 + SCREEN_TAB_COLUMN_GAP)) {
+      *x = l;
       return false;
+   }
+   *x += 1 + SCREEN_TAB_COLUMN_GAP;
    return true;
 }
 


### PR DESCRIPTION
Specifically there's an integer overflow potential in (x + 1 + SCREEN_TAB_COLUMN_GAP). Fix it with a better clamping logic.

Follow-up of commit e9e80017a180f9f69a3a0805fb856951943951fa

Supersedes #1984.