### PR TITLE
linux: fix core ID normalization

### DIFF
--- a/linux/LinuxMachine.c
+++ b/linux/LinuxMachine.c
@@ -762,7 +762,7 @@ static void LinuxMachine_computeThreadIndices(LinuxMachine* this) {
 
    /* Now compute a normalized physical core index for each CPU.
       On many systems, this index will match the following:
-        physicalID*(maxPhysicalID+1)+coreID
+        physicalID*(maxCoreID+1)+coreID
       But there are some systems where this is not true, either
       because CoreIDs are not contiguous or because cpus are
       enumerated in an alternative order, or both. */

--- a/linux/LinuxMachine.c
+++ b/linux/LinuxMachine.c
@@ -766,11 +766,15 @@ static void LinuxMachine_computeThreadIndices(LinuxMachine* this) {
       But there are some systems where this is not true, either
       because CoreIDs are not contiguous or because cpus are
       enumerated in an alternative order, or both. */
+   int maxCoreIndex = 0;
    for (size_t i = 1; i <= super->existingCPUs; i++) {
-      cpus[i].coreIndex = 0;
+      cpus[i].coreIndex = maxCoreIndex++;
       for (size_t j = i - 1; j >= 1; j--) {
-         if (cpus[i].threadIndex == cpus[j].threadIndex) {
-            cpus[i].coreIndex = cpus[j].coreIndex + 1;
+         if (cpus[i].physicalID == cpus[j].physicalID &&
+             cpus[i].coreID == cpus[j].coreID) {
+            assert(cpus[i].threadIndex != cpus[j].threadIndex);
+            cpus[i].coreIndex = cpus[j].coreIndex;
+            maxCoreIndex--;
             break;
          }
       }


### PR DESCRIPTION
On systems where CPU IDs are assigned irregularly (neither sequentially
nor regularly staggered), such as Meteor Lake-H laptops with preferred
cores where e.g.

- core 0 is CPUs 0 and 5
- core 1 is CPUs 1 and 2
- core 2 is CPUs 3 and 4
- core 3 is CPUs 6 and 7
- etc

<img width="2972" height="1220" alt="Image" src="https://github.com/user-attachments/assets/eadb4671-a9c5-49fe-86ed-4e5881e43ba1" />

Under those conditions, the existing core ID normalization algorithm
added in 772da756d6f69f23951e28b7c32c1261ead0acf4 produces bogus values:

    LinuxMachine_fetchCPUTopologyFromCPUinfo: cpuid=0, coreid=16 <--
    LinuxMachine_fetchCPUTopologyFromCPUinfo: cpuid=1, coreid=8
    LinuxMachine_fetchCPUTopologyFromCPUinfo: cpuid=2, coreid=8
    LinuxMachine_fetchCPUTopologyFromCPUinfo: cpuid=3, coreid=12
    LinuxMachine_fetchCPUTopologyFromCPUinfo: cpuid=4, coreid=12
    LinuxMachine_fetchCPUTopologyFromCPUinfo: cpuid=5, coreid=16 <--
    ...
    CPUMeter_init[SMT=on](cpu=0): core=0, thread=0, caption=0a <--
    CPUMeter_init[SMT=on](cpu=1): core=1, thread=0, caption=1a
    CPUMeter_init[SMT=on](cpu=3): core=2, thread=0, caption=2a
    ...
    CPUMeter_init[SMT=on](cpu=5): core=2, thread=1, caption=2b <--
    CPUMeter_init[SMT=on](cpu=2): core=0, thread=1, caption=0b
    CPUMeter_init[SMT=on](cpu=4): core=1, thread=1, caption=1b
    ...

Use a different algorithm to produce consistent mappings in presence
of irregular topologies:

    LinuxMachine_fetchCPUTopologyFromCPUinfo: cpuid=0, coreid=16 <--
    LinuxMachine_fetchCPUTopologyFromCPUinfo: cpuid=1, coreid=8
    LinuxMachine_fetchCPUTopologyFromCPUinfo: cpuid=2, coreid=8
    LinuxMachine_fetchCPUTopologyFromCPUinfo: cpuid=3, coreid=12
    LinuxMachine_fetchCPUTopologyFromCPUinfo: cpuid=4, coreid=12
    LinuxMachine_fetchCPUTopologyFromCPUinfo: cpuid=5, coreid=16 <--
    ...
    CPUMeter_init[SMT=on](cpu=0): core=0, thread=0, caption=0a <--
    CPUMeter_init[SMT=on](cpu=1): core=1, thread=0, caption=1a
    CPUMeter_init[SMT=on](cpu=3): core=2, thread=0, caption=2a
    ...
    CPUMeter_init[SMT=on](cpu=5): core=0, thread=1, caption=0b <--
    CPUMeter_init[SMT=on](cpu=2): core=1, thread=1, caption=1b
    CPUMeter_init[SMT=on](cpu=4): core=2, thread=1, caption=2b
    ...

Fixes #1987.