### PR TITLE
Extend #1967

### DIFF
--- a/Battery.c
+++ b/Battery.c
@@ -63,10 +63,10 @@ void Battery_aggregate(const BatteryRaw* raws, size_t n, BatteryInfo* out) {
 
       /* Derive missing now-counter from FULL * level / 100 when the kernel
        * exposes only a percent reading. Firmware sometimes overshoots 100%
-       * by a fraction during calibration; clamp before using as a fraction
-       * so the per-battery MINIMIUM(now, full) below still produces a
-       * sensible reading rather than dropping the contribution. */
-      if (bat.level >= 0) {
+       * by a fraction during calibration; accept the small overshoot but
+       * reject obvious sentinel values (e.g. 255 for "unknown") that would
+       * otherwise be clamped to a fake full reading. */
+      if (bat.level >= 0 && bat.level <= 105) {
          double levelClamped = CLAMP(bat.level, 0.0, 100.0);
          if (bat.energyFull > 0 && !(bat.energyNow >= 0))
             bat.energyNow = bat.energyFull * (levelClamped / 100.0);
@@ -98,7 +98,7 @@ void Battery_aggregate(const BatteryRaw* raws, size_t n, BatteryInfo* out) {
          chargeContrib++;
       }
 
-      if (bat.level >= 0) {
+      if (bat.level >= 0 && bat.level <= 105) {
          sumLevel += CLAMP(bat.level, 0.0, 100.0);
          levelContrib++;
       }

--- a/Battery.c
+++ b/Battery.c
@@ -62,12 +62,16 @@ void Battery_aggregate(const BatteryRaw* raws, size_t n, BatteryInfo* out) {
       BatteryRaw bat = raws[i];
 
       /* Derive missing now-counter from FULL * level / 100 when the kernel
-       * exposes only a percent reading. */
-      if (bat.level >= 0 && bat.level <= 100) {
+       * exposes only a percent reading. Firmware sometimes overshoots 100%
+       * by a fraction during calibration; clamp before using as a fraction
+       * so the per-battery MINIMIUM(now, full) below still produces a
+       * sensible reading rather than dropping the contribution. */
+      if (bat.level >= 0) {
+         double levelClamped = CLAMP(bat.level, 0.0, 100.0);
          if (bat.energyFull > 0 && !(bat.energyNow >= 0))
-            bat.energyNow = bat.energyFull * (bat.level / 100.0);
+            bat.energyNow = bat.energyFull * (levelClamped / 100.0);
          if (bat.chargeFull > 0 && !(bat.chargeNow >= 0))
-            bat.chargeNow = bat.chargeFull * (bat.level / 100.0);
+            bat.chargeNow = bat.chargeFull * (levelClamped / 100.0);
       }
 
       /* Derive energy from charge * voltage when energy is missing on this
@@ -94,8 +98,8 @@ void Battery_aggregate(const BatteryRaw* raws, size_t n, BatteryInfo* out) {
          chargeContrib++;
       }
 
-      if (bat.level >= 0 && bat.level <= 100) {
-         sumLevel += bat.level;
+      if (bat.level >= 0) {
+         sumLevel += CLAMP(bat.level, 0.0, 100.0);
          levelContrib++;
       }
 

--- a/Battery.c
+++ b/Battery.c
@@ -1,0 +1,139 @@
+/*
+htop - Battery.c
+(C) 2026 htop dev team
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include "config.h" // IWYU pragma: keep
+
+#include "Battery.h"
+
+#include <math.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "BatteryMeter.h"
+#include "Macros.h"
+
+
+/* Reference voltage for energy<->charge conversion. Design preferred so
+ * that ENERGY_FULL on an aged pack stays comparable to historical readings;
+ * VOLTAGE_NOW is the live fallback. */
+static double referenceVoltage(const BatteryRaw* bat) {
+   if (bat->voltageDesign > 0)
+      return bat->voltageDesign;
+   if (bat->voltageNow > 0)
+      return bat->voltageNow;
+   return NAN;
+}
+
+/* Voltage to use when computing P = I * V from instantaneous current.
+ * Live voltage gives the most accurate instantaneous power; design is the
+ * fallback when the kernel exposes only nominal voltage. */
+static double instantaneousVoltage(const BatteryRaw* bat) {
+   if (bat->voltageNow > 0)
+      return bat->voltageNow;
+   if (bat->voltageDesign > 0)
+      return bat->voltageDesign;
+   return NAN;
+}
+
+void Battery_aggregate(const BatteryRaw* raws, size_t n, BatteryInfo* out) {
+   out->percent = NAN;
+   out->powerCurr = NAN;
+   out->energyCurr = NAN;
+   out->energyFull = NAN;
+
+   if (n == 0)
+      return;
+
+   double sumEnergyNow = 0, sumEnergyFull = 0;
+   double sumChargeNow = 0, sumChargeFull = 0;
+   double sumLevel = 0;
+   double sumPower = 0;
+
+   size_t energyContrib = 0;
+   size_t chargeContrib = 0;
+   size_t levelContrib = 0;
+   size_t powerContrib = 0;
+
+   for (size_t i = 0; i < n; i++) {
+      BatteryRaw bat = raws[i];
+
+      /* Derive missing now-counter from FULL * level / 100 when the kernel
+       * exposes only a percent reading. */
+      if (bat.level >= 0 && bat.level <= 100) {
+         if (bat.energyFull > 0 && !(bat.energyNow >= 0))
+            bat.energyNow = bat.energyFull * (bat.level / 100.0);
+         if (bat.chargeFull > 0 && !(bat.chargeNow >= 0))
+            bat.chargeNow = bat.chargeFull * (bat.level / 100.0);
+      }
+
+      /* Derive energy from charge * voltage when energy is missing on this
+       * unit but charge + a usable voltage are available. Done per-unit so
+       * mixed packs (one energy-reporting, one charge-reporting) still
+       * aggregate on a single dimension. */
+      double refV = referenceVoltage(&bat);
+      if (refV > 0
+            && !(bat.energyFull > 0 && bat.energyNow >= 0)
+            && bat.chargeFull > 0 && bat.chargeNow >= 0) {
+         bat.energyFull = bat.chargeFull * refV;
+         bat.energyNow  = bat.chargeNow  * refV;
+      }
+
+      if (bat.energyFull > 0 && bat.energyNow >= 0) {
+         sumEnergyFull += bat.energyFull;
+         sumEnergyNow  += MINIMUM(bat.energyNow, bat.energyFull);
+         energyContrib++;
+      }
+
+      if (bat.chargeFull > 0 && bat.chargeNow >= 0) {
+         sumChargeFull += bat.chargeFull;
+         sumChargeNow  += MINIMUM(bat.chargeNow, bat.chargeFull);
+         chargeContrib++;
+      }
+
+      if (bat.level >= 0 && bat.level <= 100) {
+         sumLevel += bat.level;
+         levelContrib++;
+      }
+
+      /* Derive power from current * voltage when power is missing.
+       * Zero current implies zero power even when voltage is unknown. */
+      if (!isfinite(bat.power) && isfinite(bat.current)) {
+         double pV = instantaneousVoltage(&bat);
+         if (pV > 0)
+            bat.power = bat.current * pV;
+         else if (fpclassify(bat.current) == FP_ZERO)
+            bat.power = 0;
+      }
+
+      if (isfinite(bat.power)) {
+         sumPower += bat.power;
+         powerContrib++;
+      }
+   }
+
+   /* All-or-nothing completeness: every present battery must contribute
+    * on the same dimension or the aggregate stays NaN. Mixing partial
+    * energy+charge sums is dimensionally invalid. */
+   bool energyComplete = (energyContrib == n);
+   bool chargeComplete = (chargeContrib == n);
+   bool levelComplete  = (levelContrib  == n);
+   bool powerComplete  = (powerContrib  == n);
+
+   if (energyComplete && sumEnergyFull > 0) {
+      out->energyCurr = sumEnergyNow;
+      out->energyFull = sumEnergyFull;
+      out->percent    = CLAMP((sumEnergyNow / sumEnergyFull) * 100.0, 0.0, 100.0);
+   } else if (chargeComplete && sumChargeFull > 0) {
+      out->percent    = CLAMP((sumChargeNow / sumChargeFull) * 100.0, 0.0, 100.0);
+   } else if (levelComplete) {
+      out->percent    = CLAMP(sumLevel / (double) n, 0.0, 100.0);
+   }
+
+   if (powerComplete) {
+      out->powerCurr = sumPower;
+   }
+}

--- a/Battery.c
+++ b/Battery.c
@@ -57,6 +57,7 @@ void Battery_aggregate(const BatteryRaw* raws, size_t n, BatteryInfo* out) {
    size_t chargeContrib = 0;
    size_t levelContrib = 0;
    size_t powerContrib = 0;
+   size_t capacityAttempts = 0;
 
    for (size_t i = 0; i < n; i++) {
       BatteryRaw bat = raws[i];
@@ -85,6 +86,9 @@ void Battery_aggregate(const BatteryRaw* raws, size_t n, BatteryInfo* out) {
          bat.energyFull = bat.chargeFull * refV;
          bat.energyNow  = bat.chargeNow  * refV;
       }
+
+      if (isfinite(bat.energyFull) || isfinite(bat.chargeFull))
+         capacityAttempts++;
 
       if (bat.energyFull > 0 && bat.energyNow >= 0) {
          sumEnergyFull += bat.energyFull;
@@ -133,7 +137,12 @@ void Battery_aggregate(const BatteryRaw* raws, size_t n, BatteryInfo* out) {
       out->percent    = CLAMP((sumEnergyNow / sumEnergyFull) * 100.0, 0.0, 100.0);
    } else if (chargeComplete && sumChargeFull > 0) {
       out->percent    = CLAMP((sumChargeNow / sumChargeFull) * 100.0, 0.0, 100.0);
-   } else if (levelComplete) {
+   } else if (levelComplete && capacityAttempts == 0) {
+      /* Level fallback applies only when no battery has any FULL counter
+       * to attempt -- e.g. PCP denki and Darwin IOPS.  When a capacity
+       * axis was attempted but failed (Linux FULL=0 on a present pack),
+       * the all-or-nothing intent is to keep percent unknown rather than
+       * publish an unweighted level average. */
       out->percent    = CLAMP(sumLevel / (double) n, 0.0, 100.0);
    }
 

--- a/Battery.h
+++ b/Battery.h
@@ -1,0 +1,47 @@
+#ifndef HEADER_Battery
+#define HEADER_Battery
+/*
+htop - Battery.h
+(C) 2026 htop dev team
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include <stddef.h>
+
+#include "BatteryMeter.h"
+
+
+/* Per-battery measurement, normalized to canonical SI units.
+ *
+ * NaN means "unknown" for every measurement field; platforms set NaN
+ * when the kernel/firmware does not expose the value, or expresses it
+ * with a sentinel (-1, 0xFFFF..., FUNKNOWN, "invalid", etc.).
+ *
+ * `current` and `power` follow htop's sign convention:
+ *   positive = discharging, negative = charging.
+ *
+ * Platforms whose firmware reports unsigned magnitude must combine it
+ * with a charge-state flag at parse time before populating these fields. */
+typedef struct BatteryRaw_ {
+   double level;            /* 0..100 percent, NaN if unknown */
+   double energyFull;       /* Wh,  NaN if unknown */
+   double energyNow;        /* Wh,  NaN if unknown */
+   double chargeFull;       /* Ah,  NaN if unknown */
+   double chargeNow;        /* Ah,  NaN if unknown */
+   double voltageNow;       /* V,   NaN if unknown */
+   double voltageDesign;    /* V,   NaN if unknown */
+   double current;          /* A,   NaN if unknown; +discharge, -charge */
+   double power;            /* W,   NaN if unknown; +discharge, -charge */
+} BatteryRaw;
+
+/* Aggregate per-battery samples into a system-level reading.
+ *
+ * Inputs must contain only present, non-peripheral system batteries;
+ * platform code is responsible for filtering before the call.
+ *
+ * Capacity contributions are all-or-nothing per dimension: a missing
+ * field on any battery suppresses the corresponding output. */
+void Battery_aggregate(const BatteryRaw* raws, size_t n, BatteryInfo* out);
+
+#endif

--- a/BatteryMeter.c
+++ b/BatteryMeter.c
@@ -25,21 +25,23 @@ static const int BatteryMeter_attributes[] = {
 };
 
 static void BatteryMeter_updateValues(Meter* this) {
-   ACPresence isOnAC;
-   double percent;
+   BatteryInfo info = {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
 
-   Platform_getBattery(&percent, &isOnAC);
+   Platform_getBattery(&info);
 
-   if (!isNonnegative(percent)) {
+   if (!isNonnegative(info.percent)) {
       this->values[0] = NAN;
       xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "N/A");
       return;
    }
 
-   this->values[0] = percent;
+   this->values[0] = info.percent;
 
    const char* text;
-   switch (isOnAC) {
+   switch (info.ac) {
       case AC_PRESENT:
          text = this->mode == TEXT_METERMODE ? " (Running on A/C)" : "(A/C)";
          break;
@@ -52,7 +54,7 @@ static void BatteryMeter_updateValues(Meter* this) {
          break;
    }
 
-   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%.1f%%%s", percent, text);
+   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%.1f%%%s", info.percent, text);
 }
 
 const MeterClass BatteryMeter_class = {

--- a/BatteryMeter.c
+++ b/BatteryMeter.c
@@ -28,6 +28,7 @@ static void BatteryMeter_updateValues(Meter* this) {
    BatteryInfo info = {
       .ac = AC_ERROR,
       .percent = NAN,
+      .powerCurr = NAN,
       .energyCurr = NAN,
       .energyFull = NAN,
    };

--- a/BatteryMeter.c
+++ b/BatteryMeter.c
@@ -28,6 +28,8 @@ static void BatteryMeter_updateValues(Meter* this) {
    BatteryInfo info = {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 
    Platform_getBattery(&info);

--- a/BatteryMeter.h
+++ b/BatteryMeter.h
@@ -22,6 +22,8 @@ typedef struct BatteryInfo_ {
    ACPresence ac;
 
    double percent;          /* [0..100], NAN if unknown */
+   double energyCurr;       /* Wh, NAN if unknown */
+   double energyFull;       /* Wh, NAN if unknown */
 } BatteryInfo;
 
 extern const MeterClass BatteryMeter_class;

--- a/BatteryMeter.h
+++ b/BatteryMeter.h
@@ -18,6 +18,12 @@ typedef enum ACPresence_ {
    AC_ERROR
 } ACPresence;
 
+typedef struct BatteryInfo_ {
+   ACPresence ac;
+
+   double percent;          /* [0..100], NAN if unknown */
+} BatteryInfo;
+
 extern const MeterClass BatteryMeter_class;
 
 #endif

--- a/BatteryMeter.h
+++ b/BatteryMeter.h
@@ -22,6 +22,7 @@ typedef struct BatteryInfo_ {
    ACPresence ac;
 
    double percent;          /* [0..100], NAN if unknown */
+   double powerCurr;        /* instantaneous power in W, NAN if unknown */
    double energyCurr;       /* Wh, NAN if unknown */
    double energyFull;       /* Wh, NAN if unknown */
 } BatteryInfo;

--- a/BatteryMeter.h
+++ b/BatteryMeter.h
@@ -22,13 +22,9 @@ typedef struct BatteryInfo_ {
    ACPresence ac;
 
    double percent;          /* [0..100], NAN if unknown */
-   double powerCurr;        /* instantaneous power in W, NAN if unknown.
-                             * Sign convention: positive while discharging
-                             * (drawing from the battery), negative while
-                             * charging.  Platforms that cannot determine the
-                             * direction (e.g. PCP/denki, which exposes only a
-                             * magnitude) publish a non-negative best-effort
-                             * reading. */
+   double powerCurr;        /* W, NAN if unknown. positive=discharging,
+                             * negative=charging. Platforms without
+                             * direction publish non-negative magnitude. */
    double energyCurr;       /* Wh, NAN if unknown */
    double energyFull;       /* Wh, NAN if unknown */
 } BatteryInfo;

--- a/BatteryMeter.h
+++ b/BatteryMeter.h
@@ -22,7 +22,13 @@ typedef struct BatteryInfo_ {
    ACPresence ac;
 
    double percent;          /* [0..100], NAN if unknown */
-   double powerCurr;        /* instantaneous power in W, NAN if unknown */
+   double powerCurr;        /* instantaneous power in W, NAN if unknown.
+                             * Sign convention: positive while discharging
+                             * (drawing from the battery), negative while
+                             * charging.  Platforms that cannot determine the
+                             * direction (e.g. PCP/denki, which exposes only a
+                             * magnitude) publish a non-negative best-effort
+                             * reading. */
    double energyCurr;       /* Wh, NAN if unknown */
    double energyFull;       /* Wh, NAN if unknown */
 } BatteryInfo;

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,6 +33,7 @@ myhtopsources = \
 	AffinityPanel.c \
 	AvailableColumnsPanel.c \
 	AvailableMetersPanel.c \
+	Battery.c \
 	BatteryMeter.c \
 	CategoriesPanel.c \
 	ColorsPanel.c \
@@ -98,6 +99,7 @@ myhtopheaders = \
 	AffinityPanel.h \
 	AvailableColumnsPanel.h \
 	AvailableMetersPanel.h \
+	Battery.h \
 	BatteryMeter.h \
 	CPUMeter.h \
 	CRT.h \

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -682,9 +682,11 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    return true;
 }
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC) {
-   *percent = NAN;
-   *isOnAC = AC_ERROR;
+void Platform_getBattery(BatteryInfo* info) {
+   *info = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
 
    CFArrayRef list = NULL;
 
@@ -715,8 +717,8 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
       /* Determine the AC state */
       CFStringRef power_state = CFDictionaryGetValue(power_source, CFSTR(kIOPSPowerSourceStateKey));
 
-      if (*isOnAC != AC_PRESENT)
-         *isOnAC = (kCFCompareEqualTo == CFStringCompare(power_state, CFSTR(kIOPSACPowerValue), 0)) ? AC_PRESENT : AC_ABSENT;
+      if (info->ac != AC_PRESENT)
+         info->ac = (kCFCompareEqualTo == CFStringCompare(power_state, CFSTR(kIOPSACPowerValue), 0)) ? AC_PRESENT : AC_ABSENT;
 
       /* Get the percentage remaining */
       double tmp;
@@ -727,7 +729,7 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
    }
 
    if (cap_max > 0.0)
-      *percent = 100.0 * cap_current / cap_max;
+      info->percent = 100.0 * cap_current / cap_max;
 
 cleanup:
    if (list)

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -736,6 +736,29 @@ void Platform_getBattery(BatteryInfo* info) {
       info->energyFull = cap_max;
    }
 
+   io_service_t batt = IOServiceGetMatchingService(iokit_port, IOServiceMatching("AppleSmartBattery"));
+   if (batt) {
+      CFNumberRef ampRef = IORegistryEntryCreateCFProperty(batt, CFSTR("Amperage"), kCFAllocatorDefault, 0);
+      CFNumberRef voltRef = IORegistryEntryCreateCFProperty(batt, CFSTR("Voltage"), kCFAllocatorDefault, 0);
+
+      if (ampRef && voltRef) {
+         double ampMA = 0.0;
+         CFNumberGetValue(ampRef, kCFNumberDoubleType, &ampMA);
+
+         double voltMV = 0.0;
+         CFNumberGetValue(voltRef, kCFNumberDoubleType, &voltMV);
+
+         info->powerCurr = ampMA * voltMV / 1e6;
+      }
+
+      if (ampRef)
+         CFRelease(ampRef);
+      if (voltRef)
+         CFRelease(voltRef);
+
+      IOObjectRelease(batt);
+   }
+
 cleanup:
    if (list)
       CFRelease(list);

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -686,6 +686,7 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .powerCurr = NAN,
       .energyCurr = NAN,
       .energyFull = NAN,
    };

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -686,6 +686,8 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 
    CFArrayRef list = NULL;
@@ -728,8 +730,11 @@ void Platform_getBattery(BatteryInfo* info) {
       cap_max += tmp;
    }
 
-   if (cap_max > 0.0)
+   if (cap_max > 0.0) {
       info->percent = 100.0 * cap_current / cap_max;
+      info->energyCurr = cap_current;
+      info->energyFull = cap_max;
+   }
 
 cleanup:
    if (list)

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -683,14 +683,14 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    return true;
 }
 
-#define IOPS_MAX_BATTERIES 32
-
 /* Walk IOPS power sources, populate per-source BatteryRaw entries with
  * the IOPS unitless capacity (treated as energy: percent = sum/sum*100
  * stays correct under the aggregator's energy axis). Sets info->ac as a
- * side effect. Returns the number of internal-type sources captured, or
- * SIZE_MAX if more sources were present than the buffer holds. */
-static size_t parseIOPS(BatteryInfo* info, BatteryRaw* raws, size_t cap) {
+ * side effect. Caller frees raws via free(). Returns the number of
+ * internal-type sources captured. */
+static size_t parseIOPS(BatteryInfo* info, BatteryRaw** rawsOut) {
+   *rawsOut = NULL;
+
    CFTypeRef power_sources = IOPSCopyPowerSourcesInfo();
    if (!power_sources)
       return 0;
@@ -701,9 +701,10 @@ static size_t parseIOPS(BatteryInfo* info, BatteryRaw* raws, size_t cap) {
       return 0;
    }
 
-   size_t nbat = 0;
    size_t len = CFArrayGetCount(list);
-   bool overflow = false;
+   /* Sized to the IOPS list count; only internal-type sources will be kept. */
+   BatteryRaw* raws = (len > 0) ? xMalloc(len * sizeof(BatteryRaw)) : NULL;
+   size_t nbat = 0;
    for (size_t i = 0; i < len; ++i) {
       CFDictionaryRef power_source = IOPSGetPowerSourceDescription(power_sources, CFArrayGetValueAtIndex(list, i)); /* GET rule */
       if (!power_source)
@@ -716,11 +717,6 @@ static size_t parseIOPS(BatteryInfo* info, BatteryRaw* raws, size_t cap) {
       CFStringRef power_state = CFDictionaryGetValue(power_source, CFSTR(kIOPSPowerSourceStateKey));
       if (info->ac != AC_PRESENT)
          info->ac = (kCFCompareEqualTo == CFStringCompare(power_state, CFSTR(kIOPSACPowerValue), 0)) ? AC_PRESENT : AC_ABSENT;
-
-      if (nbat >= cap) {
-         overflow = true;
-         continue;
-      }
 
       raws[nbat] = (BatteryRaw){
          .level = NAN,
@@ -747,7 +743,13 @@ static size_t parseIOPS(BatteryInfo* info, BatteryRaw* raws, size_t cap) {
 
    CFRelease(list);
    CFRelease(power_sources);
-   return overflow ? SIZE_MAX : nbat;
+
+   if (nbat == 0 && raws != NULL) {
+      free(raws);
+      raws = NULL;
+   }
+   *rawsOut = raws;
+   return nbat;
 }
 
 /* AppleSmartBattery exposes a single system-wide rate (not per-source);
@@ -787,14 +789,10 @@ void Platform_getBattery(BatteryInfo* info) {
       .energyFull = NAN,
    };
 
-   BatteryRaw raws[IOPS_MAX_BATTERIES];
-   size_t nbat = parseIOPS(info, raws, IOPS_MAX_BATTERIES);
-
-   /* SIZE_MAX from parseIOPS signals overflow: more internal sources
-    * than the buffer holds. Refuse partial aggregation; ac was already
-    * recorded as a side effect. */
-   if (nbat != SIZE_MAX)
-      Battery_aggregate(raws, nbat, info);
+   BatteryRaw* raws = NULL;
+   size_t nbat = parseIOPS(info, &raws);
+   Battery_aggregate(raws, nbat, info);
+   free(raws);
 
    /* IOPS capacity is unitless; energyCurr/energyFull are not real Wh. */
    info->energyCurr = NAN;

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -752,7 +752,9 @@ void Platform_getBattery(BatteryInfo* info) {
          double voltMV = 0.0;
          CFNumberGetValue(voltRef, kCFNumberDoubleType, &voltMV);
 
-         info->powerCurr = ampMA * voltMV / 1e6;
+         /* IOKit's Amperage is positive while charging; htop's BatteryInfo
+          * convention is positive while discharging.  Negate to match. */
+         info->powerCurr = -(ampMA * voltMV) / 1e6;
       }
 
       if (ampRef)

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -733,8 +733,11 @@ void Platform_getBattery(BatteryInfo* info) {
 
    if (cap_max > 0.0) {
       info->percent = 100.0 * cap_current / cap_max;
-      info->energyCurr = cap_current;
-      info->energyFull = cap_max;
+      /* IOPS capacity keys (kIOPSCurrentCapacityKey/kIOPSMaxCapacityKey) are
+       * unitless (typically a 0-100 percentage) and cannot be assigned to
+       * energyCurr/energyFull, which the BatteryInfo contract specifies as
+       * Watt-hours.  Leave the energy fields as NaN; we have no reliable way
+       * to derive Wh from AppleSmartBattery without a nominal voltage. */
    }
 
    io_service_t batt = IOServiceGetMatchingService(iokit_port, IOServiceMatching("AppleSmartBattery"));

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -50,6 +50,7 @@ in the source distribution for its full text.
 #include "SysArchMeter.h"
 #include "TasksMeter.h"
 #include "UptimeMeter.h"
+#include "XUtils.h"
 #include "darwin/DarwinMachine.h"
 #include "darwin/PlatformHelpers.h"
 #include "generic/fdstat_sysctl.h"

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -732,15 +732,10 @@ void Platform_getBattery(BatteryInfo* info) {
    }
 
    if (cap_max > 0.0) {
-      /* Clamp to the documented [0..100] BatteryInfo contract: IOPS can
-       * (rarely) report cap_current > cap_max on quirky firmware. */
+      /* Clamp to [0..100]; IOPS may report cap_current > cap_max. */
       double pct = 100.0 * cap_current / cap_max;
       info->percent = pct > 100.0 ? 100.0 : (pct < 0.0 ? 0.0 : pct);
-      /* IOPS capacity keys (kIOPSCurrentCapacityKey/kIOPSMaxCapacityKey) are
-       * unitless (typically a 0-100 percentage) and cannot be assigned to
-       * energyCurr/energyFull, which the BatteryInfo contract specifies as
-       * Watt-hours.  Leave the energy fields as NaN; we have no reliable way
-       * to derive Wh from AppleSmartBattery without a nominal voltage. */
+      /* IOPS capacity is unitless; energyCurr/energyFull stay NaN. */
    }
 
    io_service_t batt = IOServiceGetMatchingService(iokit_port, IOServiceMatching("AppleSmartBattery"));
@@ -755,13 +750,7 @@ void Platform_getBattery(BatteryInfo* info) {
          double voltMV = 0.0;
          CFNumberGetValue(voltRef, kCFNumberDoubleType, &voltMV);
 
-         /* IOKit's Amperage is positive while charging; htop's BatteryInfo
-          * convention is positive while discharging.  Negate to match.
-          *
-          * Guard voltMV > 0: AppleSmartBattery exposes the Voltage key even
-          * when it has no current reading (returning 0). Without the guard we
-          * would publish 0 W as a known-good power reading instead of leaving
-          * powerCurr NaN. */
+         /* IOKit Amperage sign is reversed; htop wants positive=discharging. */
          if (voltMV > 0.0)
             info->powerCurr = -(ampMA * voltMV) / 1e6;
       }

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -34,6 +34,7 @@ in the source distribution for its full text.
 #include <IOKit/ps/IOPSKeys.h>
 #include <IOKit/storage/IOBlockStorageDriver.h>
 
+#include "Battery.h"
 #include "CPUMeter.h"
 #include "CRT.h"
 #include "DateTimeMeter.h"
@@ -682,6 +683,94 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    return true;
 }
 
+#define IOPS_MAX_BATTERIES 32
+
+/* Walk IOPS power sources, populate per-source BatteryRaw entries with
+ * the IOPS unitless capacity (treated as energy: percent = sum/sum*100
+ * stays correct under the aggregator's energy axis). Sets info->ac as a
+ * side effect. Returns the number of internal-type sources captured. */
+static size_t parseIOPS(BatteryInfo* info, BatteryRaw* raws, size_t cap) {
+   CFTypeRef power_sources = IOPSCopyPowerSourcesInfo();
+   if (!power_sources)
+      return 0;
+
+   CFArrayRef list = IOPSCopyPowerSourcesList(power_sources);
+   if (!list) {
+      CFRelease(power_sources);
+      return 0;
+   }
+
+   size_t nbat = 0;
+   size_t len = CFArrayGetCount(list);
+   for (size_t i = 0; i < len && nbat < cap; ++i) {
+      CFDictionaryRef power_source = IOPSGetPowerSourceDescription(power_sources, CFArrayGetValueAtIndex(list, i)); /* GET rule */
+      if (!power_source)
+         continue;
+
+      CFStringRef power_type = CFDictionaryGetValue(power_source, CFSTR(kIOPSTransportTypeKey)); /* GET rule */
+      if (kCFCompareEqualTo != CFStringCompare(power_type, CFSTR(kIOPSInternalType), 0))
+         continue;
+
+      CFStringRef power_state = CFDictionaryGetValue(power_source, CFSTR(kIOPSPowerSourceStateKey));
+      if (info->ac != AC_PRESENT)
+         info->ac = (kCFCompareEqualTo == CFStringCompare(power_state, CFSTR(kIOPSACPowerValue), 0)) ? AC_PRESENT : AC_ABSENT;
+
+      raws[nbat] = (BatteryRaw){
+         .level = NAN,
+         .energyFull = NAN, .energyNow = NAN,
+         .chargeFull = NAN, .chargeNow = NAN,
+         .voltageNow = NAN, .voltageDesign = NAN,
+         .current = NAN, .power = NAN,
+      };
+
+      double cur = 0.0, max = 0.0;
+      if (CFNumberGetValue(CFDictionaryGetValue(power_source, CFSTR(kIOPSCurrentCapacityKey)), kCFNumberDoubleType, &cur)
+            && CFNumberGetValue(CFDictionaryGetValue(power_source, CFSTR(kIOPSMaxCapacityKey)), kCFNumberDoubleType, &max)
+            && max > 0.0) {
+         /* IOPS values are unitless; storing them on the energy axis lets
+          * the aggregator compute a correctly capacity-weighted percent
+          * across multiple sources. energyCurr / energyFull on BatteryInfo
+          * will be the same unitless sum, which BatteryMeter ignores. */
+         raws[nbat].energyFull = max;
+         raws[nbat].energyNow = cur;
+      }
+
+      nbat++;
+   }
+
+   CFRelease(list);
+   CFRelease(power_sources);
+   return nbat;
+}
+
+/* AppleSmartBattery exposes a single system-wide rate (not per-source);
+ * read it independently of the IOPS per-battery loop so multi-battery
+ * Macs do not lose powerCurr to the aggregator's all-or-nothing gate.
+ * IOKit Amperage sign is reversed from htop's (+ = charging on IOKit,
+ * + = discharging on htop). */
+static void parseSmartBatteryPower(BatteryInfo* info) {
+   io_service_t batt = IOServiceGetMatchingService(iokit_port, IOServiceMatching("AppleSmartBattery"));
+   if (!batt)
+      return;
+
+   CFNumberRef ampRef = IORegistryEntryCreateCFProperty(batt, CFSTR("Amperage"), kCFAllocatorDefault, 0);
+   CFNumberRef voltRef = IORegistryEntryCreateCFProperty(batt, CFSTR("Voltage"), kCFAllocatorDefault, 0);
+
+   double ampMA = 0.0, voltMV = 0.0;
+   if (ampRef && voltRef
+         && CFNumberGetValue(ampRef, kCFNumberDoubleType, &ampMA)
+         && CFNumberGetValue(voltRef, kCFNumberDoubleType, &voltMV)
+         && voltMV > 0.0) {
+      info->powerCurr = -(ampMA * voltMV) / 1e6;
+   }
+
+   if (ampRef)
+      CFRelease(ampRef);
+   if (voltRef)
+      CFRelease(voltRef);
+   IOObjectRelease(batt);
+}
+
 void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
@@ -691,84 +780,15 @@ void Platform_getBattery(BatteryInfo* info) {
       .energyFull = NAN,
    };
 
-   CFArrayRef list = NULL;
+   BatteryRaw raws[IOPS_MAX_BATTERIES];
+   size_t nbat = parseIOPS(info, raws, IOPS_MAX_BATTERIES);
+   Battery_aggregate(raws, nbat, info);
 
-   CFTypeRef power_sources = IOPSCopyPowerSourcesInfo();
-   if (!power_sources)
-      goto cleanup;
+   /* IOPS capacity is unitless; energyCurr/energyFull are not real Wh. */
+   info->energyCurr = NAN;
+   info->energyFull = NAN;
 
-   list = IOPSCopyPowerSourcesList(power_sources);
-   if (!list)
-      goto cleanup;
-
-   double cap_current = 0.0;
-   double cap_max = 0.0;
-
-   /* Get the battery */
-   size_t len = CFArrayGetCount(list);
-   for (size_t i = 0; i < len; ++i) {
-      CFDictionaryRef power_source = IOPSGetPowerSourceDescription(power_sources, CFArrayGetValueAtIndex(list, i)); /* GET rule */
-
-      if (!power_source)
-         continue;
-
-      CFStringRef power_type = CFDictionaryGetValue(power_source, CFSTR(kIOPSTransportTypeKey)); /* GET rule */
-
-      if (kCFCompareEqualTo != CFStringCompare(power_type, CFSTR(kIOPSInternalType), 0))
-         continue;
-
-      /* Determine the AC state */
-      CFStringRef power_state = CFDictionaryGetValue(power_source, CFSTR(kIOPSPowerSourceStateKey));
-
-      if (info->ac != AC_PRESENT)
-         info->ac = (kCFCompareEqualTo == CFStringCompare(power_state, CFSTR(kIOPSACPowerValue), 0)) ? AC_PRESENT : AC_ABSENT;
-
-      /* Get the percentage remaining */
-      double tmp;
-      CFNumberGetValue(CFDictionaryGetValue(power_source, CFSTR(kIOPSCurrentCapacityKey)), kCFNumberDoubleType, &tmp);
-      cap_current += tmp;
-      CFNumberGetValue(CFDictionaryGetValue(power_source, CFSTR(kIOPSMaxCapacityKey)), kCFNumberDoubleType, &tmp);
-      cap_max += tmp;
-   }
-
-   if (cap_max > 0.0) {
-      /* Clamp to [0..100]; IOPS may report cap_current > cap_max. */
-      double pct = 100.0 * cap_current / cap_max;
-      info->percent = pct > 100.0 ? 100.0 : (pct < 0.0 ? 0.0 : pct);
-      /* IOPS capacity is unitless; energyCurr/energyFull stay NaN. */
-   }
-
-   io_service_t batt = IOServiceGetMatchingService(iokit_port, IOServiceMatching("AppleSmartBattery"));
-   if (batt) {
-      CFNumberRef ampRef = IORegistryEntryCreateCFProperty(batt, CFSTR("Amperage"), kCFAllocatorDefault, 0);
-      CFNumberRef voltRef = IORegistryEntryCreateCFProperty(batt, CFSTR("Voltage"), kCFAllocatorDefault, 0);
-
-      if (ampRef && voltRef) {
-         double ampMA = 0.0;
-         CFNumberGetValue(ampRef, kCFNumberDoubleType, &ampMA);
-
-         double voltMV = 0.0;
-         CFNumberGetValue(voltRef, kCFNumberDoubleType, &voltMV);
-
-         /* IOKit Amperage sign is reversed; htop wants positive=discharging. */
-         if (voltMV > 0.0)
-            info->powerCurr = -(ampMA * voltMV) / 1e6;
-      }
-
-      if (ampRef)
-         CFRelease(ampRef);
-      if (voltRef)
-         CFRelease(voltRef);
-
-      IOObjectRelease(batt);
-   }
-
-cleanup:
-   if (list)
-      CFRelease(list);
-
-   if (power_sources)
-      CFRelease(power_sources);
+   parseSmartBatteryPower(info);
 }
 
 void Platform_gettime_monotonic(uint64_t* msec) {

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -702,8 +702,9 @@ static size_t parseIOPS(BatteryInfo* info, BatteryRaw** rawsOut) {
    }
 
    size_t len = CFArrayGetCount(list);
-   /* Sized to the IOPS list count; only internal-type sources will be kept. */
-   BatteryRaw* raws = (len > 0) ? xMalloc(len * sizeof(BatteryRaw)) : NULL;
+   /* Sized to the IOPS list count; only internal-type sources will be kept.
+    * xMallocArray traps on size_t overflow if IOPS reports a bogus count. */
+   BatteryRaw* raws = (len > 0) ? xMallocArray(len, sizeof(BatteryRaw)) : NULL;
    size_t nbat = 0;
    for (size_t i = 0; i < len; ++i) {
       CFDictionaryRef power_source = IOPSGetPowerSourceDescription(power_sources, CFArrayGetValueAtIndex(list, i)); /* GET rule */

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -753,8 +753,14 @@ void Platform_getBattery(BatteryInfo* info) {
          CFNumberGetValue(voltRef, kCFNumberDoubleType, &voltMV);
 
          /* IOKit's Amperage is positive while charging; htop's BatteryInfo
-          * convention is positive while discharging.  Negate to match. */
-         info->powerCurr = -(ampMA * voltMV) / 1e6;
+          * convention is positive while discharging.  Negate to match.
+          *
+          * Guard voltMV > 0: AppleSmartBattery exposes the Voltage key even
+          * when it has no current reading (returning 0). Without the guard we
+          * would publish 0 W as a known-good power reading instead of leaving
+          * powerCurr NaN. */
+         if (voltMV > 0.0)
+            info->powerCurr = -(ampMA * voltMV) / 1e6;
       }
 
       if (ampRef)

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -732,7 +732,10 @@ void Platform_getBattery(BatteryInfo* info) {
    }
 
    if (cap_max > 0.0) {
-      info->percent = 100.0 * cap_current / cap_max;
+      /* Clamp to the documented [0..100] BatteryInfo contract: IOPS can
+       * (rarely) report cap_current > cap_max on quirky firmware. */
+      double pct = 100.0 * cap_current / cap_max;
+      info->percent = pct > 100.0 ? 100.0 : (pct < 0.0 ? 0.0 : pct);
       /* IOPS capacity keys (kIOPSCurrentCapacityKey/kIOPSMaxCapacityKey) are
        * unitless (typically a 0-100 percentage) and cannot be assigned to
        * energyCurr/energyFull, which the BatteryInfo contract specifies as

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -688,7 +688,8 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
 /* Walk IOPS power sources, populate per-source BatteryRaw entries with
  * the IOPS unitless capacity (treated as energy: percent = sum/sum*100
  * stays correct under the aggregator's energy axis). Sets info->ac as a
- * side effect. Returns the number of internal-type sources captured. */
+ * side effect. Returns the number of internal-type sources captured, or
+ * SIZE_MAX if more sources were present than the buffer holds. */
 static size_t parseIOPS(BatteryInfo* info, BatteryRaw* raws, size_t cap) {
    CFTypeRef power_sources = IOPSCopyPowerSourcesInfo();
    if (!power_sources)
@@ -702,7 +703,8 @@ static size_t parseIOPS(BatteryInfo* info, BatteryRaw* raws, size_t cap) {
 
    size_t nbat = 0;
    size_t len = CFArrayGetCount(list);
-   for (size_t i = 0; i < len && nbat < cap; ++i) {
+   bool overflow = false;
+   for (size_t i = 0; i < len; ++i) {
       CFDictionaryRef power_source = IOPSGetPowerSourceDescription(power_sources, CFArrayGetValueAtIndex(list, i)); /* GET rule */
       if (!power_source)
          continue;
@@ -714,6 +716,11 @@ static size_t parseIOPS(BatteryInfo* info, BatteryRaw* raws, size_t cap) {
       CFStringRef power_state = CFDictionaryGetValue(power_source, CFSTR(kIOPSPowerSourceStateKey));
       if (info->ac != AC_PRESENT)
          info->ac = (kCFCompareEqualTo == CFStringCompare(power_state, CFSTR(kIOPSACPowerValue), 0)) ? AC_PRESENT : AC_ABSENT;
+
+      if (nbat >= cap) {
+         overflow = true;
+         continue;
+      }
 
       raws[nbat] = (BatteryRaw){
          .level = NAN,
@@ -740,7 +747,7 @@ static size_t parseIOPS(BatteryInfo* info, BatteryRaw* raws, size_t cap) {
 
    CFRelease(list);
    CFRelease(power_sources);
-   return nbat;
+   return overflow ? SIZE_MAX : nbat;
 }
 
 /* AppleSmartBattery exposes a single system-wide rate (not per-source);
@@ -782,7 +789,12 @@ void Platform_getBattery(BatteryInfo* info) {
 
    BatteryRaw raws[IOPS_MAX_BATTERIES];
    size_t nbat = parseIOPS(info, raws, IOPS_MAX_BATTERIES);
-   Battery_aggregate(raws, nbat, info);
+
+   /* SIZE_MAX from parseIOPS signals overflow: more internal sources
+    * than the buffer holds. Refuse partial aggregation; ac was already
+    * recorded as a side effect. */
+   if (nbat != SIZE_MAX)
+      Battery_aggregate(raws, nbat, info);
 
    /* IOPS capacity is unitless; energyCurr/energyFull are not real Wh. */
    info->energyCurr = NAN;

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -83,7 +83,7 @@ bool Platform_getDiskIO(DiskIOData* data);
 
 bool Platform_getNetworkIO(NetworkIOData* data);
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC);
+void Platform_getBattery(BatteryInfo* info);
 
 static inline void Platform_getHostname(char* buffer, size_t size) {
    Generic_hostname(buffer, size);

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -367,6 +367,8 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 
    int life;

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -12,9 +12,13 @@ in the source distribution for its full text.
 
 #include <devstat.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <ifaddrs.h>
 #include <math.h>
 #include <time.h>
+#include <unistd.h>
+#include <dev/acpica/acpiio.h>
+#include <sys/ioctl.h>
 #include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/sysctl.h>
@@ -367,6 +371,7 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .powerCurr = NAN,
       .energyCurr = NAN,
       .energyFull = NAN,
    };
@@ -393,9 +398,11 @@ void Platform_getBattery(BatteryInfo* info) {
 
    bool haveTotalRemain = false;
    bool haveTotalFull = false;
+   bool haveTotalPower = false;
 
    int64_t totalRemain = 0;
    int64_t totalFull = 0;
+   int64_t totalPower = 0;
 
    for (int u = 0; u < units; u++) {
       union acpi_battery_ioctl_arg bifArg = { .unit = u };
@@ -411,9 +418,11 @@ void Platform_getBattery(BatteryInfo* info) {
 
       bool haveBatteryEnergyCurr = false;
       bool haveBatteryEnergyFull = false;
+      bool haveBatteryPower = false;
 
       int64_t batteryEnergyCurr = 0;
       int64_t batteryEnergyFull = 0;
+      int64_t batteryPower = 0;
 
       if (bif->lfcap != ACPI_BATT_UNKNOWN && bst->cap != ACPI_BATT_UNKNOWN) {
          if (bif->units == ACPI_BIF_UNITS_MW) {
@@ -439,6 +448,31 @@ void Platform_getBattery(BatteryInfo* info) {
          totalFull += batteryEnergyFull;
          haveTotalFull = true;
       }
+
+      if (bst->rate == ACPI_BATT_UNKNOWN)
+         continue;
+
+      if (bif->units == ACPI_BIF_UNITS_MW) {
+         batteryPower = (int64_t) bst->rate * 1000;
+         haveBatteryPower = true;
+      } else {
+         uint32_t batteryVoltage = (bst->volt != ACPI_BATT_UNKNOWN) ? bst->volt : bif->dvol;
+
+         if (batteryVoltage != ACPI_BATT_UNKNOWN && batteryVoltage != 0) {
+            batteryPower = (int64_t) bst->rate * batteryVoltage;
+            haveBatteryPower = true;
+         }
+      }
+
+      if (!haveBatteryPower)
+         continue;
+
+      if ((bst->state & ACPI_BATT_STAT_DISCHARG) == 0 &&
+         (bst->state & ACPI_BATT_STAT_CHARGING) != 0)
+         batteryPower = -batteryPower;
+
+      totalPower += batteryPower;
+      haveTotalPower = true;
    }
 
    close(fd);
@@ -450,5 +484,9 @@ void Platform_getBattery(BatteryInfo* info) {
 
       info->energyCurr = (double) totalRemain / 1000000.0;
       info->energyFull = (double) totalFull / 1000000.0;
+   }
+
+   if (haveTotalPower) {
+      info->powerCurr = (double) totalPower / 1000000.0;
    }
 }

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -380,4 +380,75 @@ void Platform_getBattery(BatteryInfo* info) {
    size_t acline_len = sizeof(acline);
    if (sysctlbyname("hw.acpi.acline", &acline, &acline_len, NULL, 0) != -1)
       info->ac = (acline == 0) ? AC_ABSENT : AC_PRESENT;
+
+   int units = 0;
+   int fd = open("/dev/acpi", O_RDONLY | O_CLOEXEC);
+   if (fd == -1)
+      return;
+
+   if (ioctl(fd, ACPIIO_BATT_GET_UNITS, &units) == -1 || units <= 0) {
+      close(fd);
+      return;
+   }
+
+   bool haveTotalRemain = false;
+   bool haveTotalFull = false;
+
+   int64_t totalRemain = 0;
+   int64_t totalFull = 0;
+
+   for (int u = 0; u < units; u++) {
+      union acpi_battery_ioctl_arg bifArg = { .unit = u };
+      if (ioctl(fd, ACPIIO_BATT_GET_BIF, &bifArg) == -1)
+         continue;
+
+      union acpi_battery_ioctl_arg bstArg = { .unit = u };
+      if (ioctl(fd, ACPIIO_BATT_GET_BST, &bstArg) == -1)
+         continue;
+
+      const struct acpi_bif* bif = &bifArg.bif;
+      const struct acpi_bst* bst = &bstArg.bst;
+
+      bool haveBatteryEnergyCurr = false;
+      bool haveBatteryEnergyFull = false;
+
+      int64_t batteryEnergyCurr = 0;
+      int64_t batteryEnergyFull = 0;
+
+      if (bif->lfcap != ACPI_BATT_UNKNOWN && bst->cap != ACPI_BATT_UNKNOWN) {
+         if (bif->units == ACPI_BIF_UNITS_MW) {
+            batteryEnergyCurr = (int64_t) bst->cap * 1000;
+            batteryEnergyFull = (int64_t) bif->lfcap * 1000;
+            haveBatteryEnergyCurr = true;
+            haveBatteryEnergyFull = true;
+         } else {
+            uint32_t batteryVoltage = (bst->volt != ACPI_BATT_UNKNOWN) ? bst->volt : bif->dvol;
+            if (batteryVoltage != ACPI_BATT_UNKNOWN && batteryVoltage != 0) {
+               batteryEnergyCurr = (int64_t) bst->cap * batteryVoltage;
+               batteryEnergyFull = (int64_t) bif->lfcap * batteryVoltage;
+               haveBatteryEnergyCurr = true;
+               haveBatteryEnergyFull = true;
+            }
+         }
+      }
+
+      if (haveBatteryEnergyCurr && haveBatteryEnergyFull && batteryEnergyFull > 0) {
+         totalRemain += batteryEnergyCurr;
+         haveTotalRemain = true;
+
+         totalFull += batteryEnergyFull;
+         haveTotalFull = true;
+      }
+   }
+
+   close(fd);
+
+   if (haveTotalRemain && haveTotalFull && totalFull > 0) {
+      info->percent = ((double) totalRemain * 100.0) / (double) totalFull;
+      if (totalRemain >= totalFull)
+         info->percent = 100;
+
+      info->energyCurr = (double) totalRemain / 1000000.0;
+      info->energyFull = (double) totalFull / 1000000.0;
+   }
 }

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -363,18 +363,19 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    return true;
 }
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC) {
+void Platform_getBattery(BatteryInfo* info) {
+   *info = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
+
    int life;
    size_t life_len = sizeof(life);
-   if (sysctlbyname("hw.acpi.battery.life", &life, &life_len, NULL, 0) == -1)
-      *percent = NAN;
-   else
-      *percent = life;
+   if (sysctlbyname("hw.acpi.battery.life", &life, &life_len, NULL, 0) != -1)
+      info->percent = life;
 
    int acline;
    size_t acline_len = sizeof(acline);
-   if (sysctlbyname("hw.acpi.acline", &acline, &acline_len, NULL, 0) == -1)
-      *isOnAC = AC_ERROR;
-   else
-      *isOnAC = acline == 0 ? AC_ABSENT : AC_PRESENT;
+   if (sysctlbyname("hw.acpi.acline", &acline, &acline_len, NULL, 0) != -1)
+      info->ac = (acline == 0) ? AC_ABSENT : AC_PRESENT;
 }

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -368,8 +368,6 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    return true;
 }
 
-#define ACPI_MAX_BATTERIES 32
-
 /* Read one ACPI battery into canonical SI units. Returns false to skip:
  * NOT_PRESENT bays drop entirely so they don't block the aggregation gate.
  * ioctl failures return true with an empty BatteryRaw so the unit still
@@ -445,15 +443,8 @@ static void getAcpiBatteries(BatteryInfo* info) {
    if (fd == -1)
       return;
 
-   /* Refuse to publish a partial aggregate when the firmware reports
-    * more batteries than the fixed buffer holds; the fallback path
-    * (hw.acpi.battery.life) still runs after this returns. */
-   if (units > ACPI_MAX_BATTERIES) {
-      close(fd);
-      return;
-   }
-
-   BatteryRaw raws[ACPI_MAX_BATTERIES];
+   /* Sized to the firmware-reported unit count; xMalloc never returns NULL. */
+   BatteryRaw* raws = xMalloc((size_t) units * sizeof(BatteryRaw));
    size_t nbat = 0;
    for (int u = 0; u < units; u++) {
       if (parseAcpiBattery(fd, u, &raws[nbat]))
@@ -462,6 +453,7 @@ static void getAcpiBatteries(BatteryInfo* info) {
    close(fd);
 
    Battery_aggregate(raws, nbat, info);
+   free(raws);
 }
 
 void Platform_getBattery(BatteryInfo* info) {

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -386,11 +386,7 @@ void Platform_getBattery(BatteryInfo* info) {
    if (sysctlbyname("hw.acpi.acline", &acline, &acline_len, NULL, 0) != -1)
       info->ac = (acline == 0) ? AC_ABSENT : AC_PRESENT;
 
-   /* DragonFly does not define ACPIIO_BATT_GET_UNITS in
-    * <dev/acpica/acpiio.h> (only the BIF/BST ioctls are exposed), so
-    * obtain the unit count via the same hw.acpi.battery.units sysctl
-    * that FreeBSD uses. The /dev/acpi BIF/BST ioctls below remain the
-    * read source for per-unit data. */
+   /* DragonFly lacks ACPIIO_BATT_GET_UNITS; use sysctl like FreeBSD. */
    int units = 0;
    size_t units_len = sizeof(units);
    if (sysctlbyname("hw.acpi.battery.units", &units, &units_len, NULL, 0) == -1 || units <= 0)
@@ -400,44 +396,30 @@ void Platform_getBattery(BatteryInfo* info) {
    if (fd == -1)
       return;
 
-   /* Energy totals (require voltage on mAh systems) — used for energyCurr/Full
-    * and as the preferred basis for info->percent. */
+   /* µWh (energy preferred for percent). */
    int64_t totalEnergyRemain = 0;
    int64_t totalEnergyFull = 0;
    int unitsWithEnergy = 0;
 
-   /* Parallel raw-charge totals — used solely as a fallback basis for
-    * info->percent when voltage is unknown on mAh systems and the energy
-    * totals are therefore incomplete. */
+   /* µAh (charge fallback when voltage unknown). */
    int64_t totalChargeRemain = 0;
    int64_t totalChargeFull = 0;
    int unitsWithCharge = 0;
 
-   /* Power total. A unit is considered "covered" once its BIF/BST data is
-    * in hand; powerComplete additionally requires every unit's rate to be
-    * known and convertible to watts. Only publish powerCurr when both
-    * conditions hold for every unit. */
    int64_t totalPower = 0;
    int unitsCovered = 0;
    bool powerComplete = true;
 
-   /* Energy/charge completeness flags. Cleared when a per-unit ioctl fails
-    * so we don't override the kernel's hw.acpi.battery.life sysctl with a
-    * partial aggregate that omits units we couldn't read. */
+   /* Cleared on ioctl failure to keep partial aggregates out. */
    bool energyComplete = true;
    bool chargeComplete = true;
 
-   /* Count slots that are physically present. ACPI may report N units while
-    * one bay is empty; an empty bay's BST succeeds with NOT_PRESENT and zero
-    * fields, which would otherwise drag down aggregate percent/energy. */
    int unitsPresent = 0;
 
    for (int u = 0; u < units; u++) {
       union acpi_battery_ioctl_arg bifArg = { .unit = u };
       if (ioctl(fd, ACPIIO_BATT_GET_BIF, &bifArg) == -1) {
-         /* Failed read: we don't know whether this slot is present or not,
-          * so conservatively mark every aggregate incomplete. Otherwise a
-          * partial sum would override the kernel's authoritative sysctl. */
+         /* Read failed; aggregate stays incomplete. */
          energyComplete = false;
          chargeComplete = false;
          powerComplete = false;
@@ -446,7 +428,6 @@ void Platform_getBattery(BatteryInfo* info) {
 
       union acpi_battery_ioctl_arg bstArg = { .unit = u };
       if (ioctl(fd, ACPIIO_BATT_GET_BST, &bstArg) == -1) {
-         /* Same reasoning as the BIF failure above. */
          energyComplete = false;
          chargeComplete = false;
          powerComplete = false;
@@ -455,12 +436,7 @@ void Platform_getBattery(BatteryInfo* info) {
 
       const struct acpi_bst* bst = &bstArg.bst;
 
-      /* Empty battery bay: BST can succeed with zeroed cap/rate fields and
-       * state reported as the NOT_PRESENT sentinel. NOT_PRESENT is a
-       * synthetic value (the OR of all _BST state bits), not a standalone
-       * flag, so test it with == rather than masking. Skip absent slots —
-       * the completeness checks below use unitsPresent (not units) so absent
-       * slots are treated as nonexistent rather than units with missing data. */
+      /* NOT_PRESENT is a synthetic _BST mask value, not a single bit. */
       if (bst->state == ACPI_BATT_STAT_NOT_PRESENT)
          continue;
 
@@ -488,18 +464,13 @@ void Platform_getBattery(BatteryInfo* info) {
             haveBatteryEnergyCurr = true;
             haveBatteryEnergyFull = true;
          } else {
-            /* Always populate the charge fallback so we can still compute
-             * percent when voltage is unknown. */
+            /* Charge fallback for percent when voltage is unknown. */
             batteryChargeCurr = (int64_t) bst->cap;
             batteryChargeFull = (int64_t) bif->lfcap;
             haveBatteryChargeCurr = true;
             haveBatteryChargeFull = true;
 
-            /* Use design voltage to convert charge into energy: bst->volt
-             * (instantaneous terminal voltage) drifts as the pack charges and
-             * discharges, which would skew batteryEnergyFull over time. Fall
-             * back to the present voltage only if the design value is
-             * missing. */
+            /* Design voltage for energy reference. */
             uint32_t referenceVoltage = (bif->dvol != ACPI_BATT_UNKNOWN && bif->dvol != 0)
                                          ? bif->dvol
                                          : bst->volt;
@@ -512,10 +483,7 @@ void Platform_getBattery(BatteryInfo* info) {
          }
       }
 
-      /* Clamp per-battery curr to full before summing: a quirky firmware
-       * can report bst->cap > bif->lfcap, which would otherwise let the
-       * published info->energyCurr / info->energyFull values exceed each
-       * other's bounds even though the percent gate caps at 100. */
+      /* Clamp curr <= full per battery (firmware may report cap > lfcap). */
       if (haveBatteryEnergyCurr && haveBatteryEnergyFull && batteryEnergyFull > 0) {
          int64_t clampedEnergy = batteryEnergyCurr > batteryEnergyFull ? batteryEnergyFull : batteryEnergyCurr;
          totalEnergyRemain += clampedEnergy;
@@ -531,25 +499,18 @@ void Platform_getBattery(BatteryInfo* info) {
       }
 
       if (bst->rate == ACPI_BATT_UNKNOWN) {
-         /* A genuinely unknown rate means the totalPower sum can't represent
-          * this unit. Treat as incomplete so we don't publish a misleading
-          * 0 W aggregate; the 0.0 fallback is reserved for known-zero rates
-          * (e.g., idle on AC). */
          powerComplete = false;
          continue;
       }
 
       if (bst->rate == 0) {
-         /* Zero rate is a known 0 W reading regardless of units or voltage:
-          * I * V = 0 when I is zero, so the mAh path's voltage lookup is
-          * unnecessary. batteryPower is already 0 from its declaration. */
+         /* I=0 ⇒ 0 W known regardless of voltage. */
          haveBatteryPower = true;
       } else if (bif->units == ACPI_BIF_UNITS_MW) {
          batteryPower = (int64_t) bst->rate * 1000;
          haveBatteryPower = true;
       } else {
-         /* Instantaneous power P = I * V wants the present terminal voltage;
-          * fall back to design voltage only when it isn't exposed. */
+         /* Present voltage for I*V. */
          uint32_t rateVoltage = (bst->volt != ACPI_BATT_UNKNOWN && bst->volt != 0)
                                  ? bst->volt
                                  : bif->dvol;
@@ -561,8 +522,6 @@ void Platform_getBattery(BatteryInfo* info) {
       }
 
       if (!haveBatteryPower) {
-         /* A non-zero rate that we couldn't convert (mAh with unknown voltage)
-          * means the totalPower sum is missing real charge/discharge activity. */
          powerComplete = false;
          continue;
       }
@@ -576,16 +535,7 @@ void Platform_getBattery(BatteryInfo* info) {
 
    close(fd);
 
-   /* Only override the sysctl-derived percent when every present battery
-    * unit contributed to the totals — partial aggregates would misrepresent
-    * the pack against the kernel's hw.acpi.battery.life summary. Compare
-    * against unitsPresent so empty bays don't fail the check, and require
-    * the matching completeness flag (energyComplete / chargeComplete) so a
-    * BIF/BST ioctl failure on any unit forces us back to the kernel's
-    * authoritative summary instead of publishing a partial aggregate.
-    * Prefer the energy (Wh) ratio over the raw-charge (mAh) ratio: on
-    * multi-pack systems with differing voltages the energy ratio is the
-    * physically correct aggregate, while an mAh-weighted ratio is not. */
+   /* Energy ratio preferred (mAh-weighted is wrong on mixed-voltage packs). */
    if (energyComplete && unitsPresent > 0 && unitsWithEnergy == unitsPresent && totalEnergyFull > 0) {
       info->percent = ((double) totalEnergyRemain * 100.0) / (double) totalEnergyFull;
       if (totalEnergyRemain >= totalEnergyFull)
@@ -596,16 +546,11 @@ void Platform_getBattery(BatteryInfo* info) {
          info->percent = 100;
    }
 
-   /* Only publish energy totals when complete in watt-hours for every present unit. */
    if (energyComplete && unitsPresent > 0 && unitsWithEnergy == unitsPresent && totalEnergyFull > 0) {
       info->energyCurr = (double) totalEnergyRemain / 1000000.0;
       info->energyFull = (double) totalEnergyFull / 1000000.0;
    }
 
-   /* Only publish power when every present unit was covered and every rate
-    * was known and convertible to W. An unknown rate on any unit leaves the
-    * sysctl-derived powerCurr (NaN) in place rather than reporting a
-    * misleading 0 W aggregate. */
    if (powerComplete && unitsPresent > 0 && unitsCovered == unitsPresent) {
       info->powerCurr = (double) totalPower / 1000000.0;
    }

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -417,6 +417,11 @@ void Platform_getBattery(BatteryInfo* info) {
    int unitsCovered = 0;
    bool powerComplete = true;
 
+   /* Count slots that are physically present. ACPI may report N units while
+    * one bay is empty; an empty bay's BST succeeds with NOT_PRESENT and zero
+    * fields, which would otherwise drag down aggregate percent/energy. */
+   int unitsPresent = 0;
+
    for (int u = 0; u < units; u++) {
       union acpi_battery_ioctl_arg bifArg = { .unit = u };
       if (ioctl(fd, ACPIIO_BATT_GET_BIF, &bifArg) == -1)
@@ -426,10 +431,22 @@ void Platform_getBattery(BatteryInfo* info) {
       if (ioctl(fd, ACPIIO_BATT_GET_BST, &bstArg) == -1)
          continue;
 
+      const struct acpi_bst* bst = &bstArg.bst;
+
+      /* Empty battery bay: BST can succeed with zeroed cap/rate fields and
+       * the NOT_PRESENT state bit set. Skip it entirely — the kernel's
+       * hw.acpi.battery.life sysctl already accounts for absence, and
+       * counting a missing pack as a 0 Wh battery would drag the aggregate
+       * percent and energy totals down. The completeness checks below use
+       * unitsPresent (not units) so absent slots are treated as
+       * nonexistent rather than as units with missing data. */
+      if ((bst->state & ACPI_BATT_STAT_NOT_PRESENT) != 0)
+         continue;
+
+      unitsPresent++;
       unitsCovered++;
 
       const struct acpi_bif* bif = &bifArg.bif;
-      const struct acpi_bst* bst = &bstArg.bst;
 
       bool haveBatteryEnergyCurr = false;
       bool haveBatteryEnergyFull = false;
@@ -516,33 +533,34 @@ void Platform_getBattery(BatteryInfo* info) {
 
    close(fd);
 
-   /* Only override the sysctl-derived percent when every battery unit
-    * contributed to the totals — partial aggregates would misrepresent the
-    * pack against the kernel's hw.acpi.battery.life summary. Prefer the
+   /* Only override the sysctl-derived percent when every present battery
+    * unit contributed to the totals — partial aggregates would misrepresent
+    * the pack against the kernel's hw.acpi.battery.life summary. Compare
+    * against unitsPresent so empty bays don't fail the check. Prefer the
     * energy (Wh) ratio over the raw-charge (mAh) ratio: on multi-pack
     * systems with differing voltages the energy ratio is the physically
     * correct aggregate, while an mAh-weighted ratio is not. */
-   if (unitsWithEnergy == units && totalEnergyFull > 0) {
+   if (unitsPresent > 0 && unitsWithEnergy == unitsPresent && totalEnergyFull > 0) {
       info->percent = ((double) totalEnergyRemain * 100.0) / (double) totalEnergyFull;
       if (totalEnergyRemain >= totalEnergyFull)
          info->percent = 100;
-   } else if (unitsWithCharge == units && totalChargeFull > 0) {
+   } else if (unitsPresent > 0 && unitsWithCharge == unitsPresent && totalChargeFull > 0) {
       info->percent = ((double) totalChargeRemain * 100.0) / (double) totalChargeFull;
       if (totalChargeRemain >= totalChargeFull)
          info->percent = 100;
    }
 
-   /* Only publish energy totals when complete in watt-hours for every unit. */
-   if (unitsWithEnergy == units && totalEnergyFull > 0) {
+   /* Only publish energy totals when complete in watt-hours for every present unit. */
+   if (unitsPresent > 0 && unitsWithEnergy == unitsPresent && totalEnergyFull > 0) {
       info->energyCurr = (double) totalEnergyRemain / 1000000.0;
       info->energyFull = (double) totalEnergyFull / 1000000.0;
    }
 
-   /* Only publish power when every unit was covered and every rate was
-    * known and convertible to W. An unknown rate on any unit leaves the
+   /* Only publish power when every present unit was covered and every rate
+    * was known and convertible to W. An unknown rate on any unit leaves the
     * sysctl-derived powerCurr (NaN) in place rather than reporting a
     * misleading 0 W aggregate. */
-   if (powerComplete && unitsCovered == units) {
+   if (powerComplete && unitsPresent > 0 && unitsCovered == unitsPresent) {
       info->powerCurr = (double) totalPower / 1000000.0;
    }
 }

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -26,6 +26,7 @@ in the source distribution for its full text.
 #include <sys/types.h>
 #include <vm/vm_param.h>
 
+#include "Battery.h"
 #include "CPUMeter.h"
 #include "DateTimeMeter.h"
 #include "FileDescriptorMeter.h"
@@ -367,26 +368,74 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    return true;
 }
 
-void Platform_getBattery(BatteryInfo* info) {
-   *info = (BatteryInfo) {
-      .ac = AC_ERROR,
-      .percent = NAN,
-      .powerCurr = NAN,
-      .energyCurr = NAN,
-      .energyFull = NAN,
+#define ACPI_MAX_BATTERIES 32
+
+/* Read one ACPI battery into canonical SI units. Returns false to skip:
+ * NOT_PRESENT bays drop entirely so they don't block the aggregation gate.
+ * ioctl failures return true with an empty BatteryRaw so the unit still
+ * counts and forces the gate closed. */
+static bool parseAcpiBattery(int fd, int unit, BatteryRaw* out) {
+   *out = (BatteryRaw){
+      .level = NAN,
+      .energyFull = NAN, .energyNow = NAN,
+      .chargeFull = NAN, .chargeNow = NAN,
+      .voltageNow = NAN, .voltageDesign = NAN,
+      .current = NAN, .power = NAN,
    };
 
-   int life;
-   size_t life_len = sizeof(life);
-   if (sysctlbyname("hw.acpi.battery.life", &life, &life_len, NULL, 0) != -1)
-      info->percent = life;
+   union acpi_battery_ioctl_arg bifArg = { .unit = unit };
+   if (ioctl(fd, ACPIIO_BATT_GET_BIF, &bifArg) == -1)
+      return true;
 
-   int acline;
-   size_t acline_len = sizeof(acline);
-   if (sysctlbyname("hw.acpi.acline", &acline, &acline_len, NULL, 0) != -1)
-      info->ac = (acline == 0) ? AC_ABSENT : AC_PRESENT;
+   union acpi_battery_ioctl_arg bstArg = { .unit = unit };
+   if (ioctl(fd, ACPIIO_BATT_GET_BST, &bstArg) == -1)
+      return true;
 
-   /* DragonFly lacks ACPIIO_BATT_GET_UNITS; use sysctl like FreeBSD. */
+   const struct acpi_bif* bif = &bifArg.bif;
+   const struct acpi_bst* bst = &bstArg.bst;
+
+   /* NOT_PRESENT is a synthetic _BST mask value, not a single bit. */
+   if (bst->state == ACPI_BATT_STAT_NOT_PRESENT)
+      return false;
+
+   if (bif->dvol != ACPI_BATT_UNKNOWN && bif->dvol != 0)
+      out->voltageDesign = (double) bif->dvol / 1000.0;
+   if (bst->volt != ACPI_BATT_UNKNOWN && bst->volt != 0)
+      out->voltageNow = (double) bst->volt / 1000.0;
+
+   /* mWh capacity flag: bif->lfcap and bst->cap are in mWh, bst->rate in mW.
+    * Otherwise the same fields are in mAh / mA, with voltage from BIF/BST. */
+   bool unitsAreMW = (bif->units == ACPI_BIF_UNITS_MW);
+
+   if (bif->lfcap != ACPI_BATT_UNKNOWN && bst->cap != ACPI_BATT_UNKNOWN) {
+      if (unitsAreMW) {
+         out->energyFull = (double) bif->lfcap / 1000.0;
+         out->energyNow  = (double) bst->cap   / 1000.0;
+      } else {
+         out->chargeFull = (double) bif->lfcap / 1000.0;
+         out->chargeNow  = (double) bst->cap   / 1000.0;
+      }
+   }
+
+   /* Sign convention: + discharging in htop. CHARGING bit (without DISCHARG)
+    * flips the magnitude; the firmware reports rate as unsigned. */
+   bool charging = (bst->state & ACPI_BATT_STAT_DISCHARG) == 0
+                && (bst->state & ACPI_BATT_STAT_CHARGING) != 0;
+   double sign = charging ? -1.0 : 1.0;
+
+   if (bst->rate != ACPI_BATT_UNKNOWN) {
+      if (unitsAreMW)
+         out->power = sign * ((double) bst->rate / 1000.0);
+      else
+         out->current = sign * ((double) bst->rate / 1000.0);
+   }
+
+   return true;
+}
+
+/* DragonFly lacks ACPIIO_BATT_GET_UNITS; use the sysctl that FreeBSD also
+ * exposes for the ACPI batteries enumeration. */
+static void getAcpiBatteries(BatteryInfo* info) {
    int units = 0;
    size_t units_len = sizeof(units);
    if (sysctlbyname("hw.acpi.battery.units", &units, &units_len, NULL, 0) == -1 || units <= 0)
@@ -396,158 +445,42 @@ void Platform_getBattery(BatteryInfo* info) {
    if (fd == -1)
       return;
 
-   /* µWh (energy preferred for percent). */
-   int64_t totalEnergyRemain = 0;
-   int64_t totalEnergyFull = 0;
-   int unitsWithEnergy = 0;
+   if (units > ACPI_MAX_BATTERIES)
+      units = ACPI_MAX_BATTERIES;
 
-   /* µAh (charge fallback when voltage unknown). */
-   int64_t totalChargeRemain = 0;
-   int64_t totalChargeFull = 0;
-   int unitsWithCharge = 0;
-
-   int64_t totalPower = 0;            /* µW */
-   bool powerComplete = true;
-
-   /* Cleared on ioctl failure to keep partial aggregates out. */
-   bool energyComplete = true;
-   bool chargeComplete = true;
-
-   int unitsPresent = 0;
-
+   BatteryRaw raws[ACPI_MAX_BATTERIES];
+   size_t nbat = 0;
    for (int u = 0; u < units; u++) {
-      union acpi_battery_ioctl_arg bifArg = { .unit = u };
-      if (ioctl(fd, ACPIIO_BATT_GET_BIF, &bifArg) == -1) {
-         /* Read failed; aggregate stays incomplete. */
-         energyComplete = false;
-         chargeComplete = false;
-         powerComplete = false;
-         continue;
-      }
-
-      union acpi_battery_ioctl_arg bstArg = { .unit = u };
-      if (ioctl(fd, ACPIIO_BATT_GET_BST, &bstArg) == -1) {
-         energyComplete = false;
-         chargeComplete = false;
-         powerComplete = false;
-         continue;
-      }
-
-      const struct acpi_bst* bst = &bstArg.bst;
-
-      /* NOT_PRESENT is a synthetic _BST mask value, not a single bit. */
-      if (bst->state == ACPI_BATT_STAT_NOT_PRESENT)
-         continue;
-
-      unitsPresent++;
-
-      const struct acpi_bif* bif = &bifArg.bif;
-
-      bool haveBatteryEnergyCurr = false;
-      bool haveBatteryEnergyFull = false;
-      bool haveBatteryChargeCurr = false;
-      bool haveBatteryChargeFull = false;
-      bool haveBatteryPower = false;
-
-      int64_t batteryEnergyCurr = 0;
-      int64_t batteryEnergyFull = 0;
-      int64_t batteryChargeCurr = 0;
-      int64_t batteryChargeFull = 0;
-      int64_t batteryPower = 0;
-
-      if (bif->lfcap != ACPI_BATT_UNKNOWN && bst->cap != ACPI_BATT_UNKNOWN) {
-         if (bif->units == ACPI_BIF_UNITS_MW) {
-            batteryEnergyCurr = (int64_t) bst->cap * 1000;
-            batteryEnergyFull = (int64_t) bif->lfcap * 1000;
-            haveBatteryEnergyCurr = true;
-            haveBatteryEnergyFull = true;
-         } else {
-            /* Charge fallback for percent when voltage is unknown. */
-            batteryChargeCurr = (int64_t) bst->cap;
-            batteryChargeFull = (int64_t) bif->lfcap;
-            haveBatteryChargeCurr = true;
-            haveBatteryChargeFull = true;
-
-            /* Design voltage for energy reference. */
-            uint32_t referenceVoltage = (bif->dvol != ACPI_BATT_UNKNOWN && bif->dvol != 0)
-                                         ? bif->dvol
-                                         : bst->volt;
-            if (referenceVoltage != ACPI_BATT_UNKNOWN && referenceVoltage != 0) {
-               batteryEnergyCurr = (int64_t) bst->cap * referenceVoltage;
-               batteryEnergyFull = (int64_t) bif->lfcap * referenceVoltage;
-               haveBatteryEnergyCurr = true;
-               haveBatteryEnergyFull = true;
-            }
-         }
-      }
-
-      /* Clamp curr <= full per battery (firmware may report cap > lfcap). */
-      if (haveBatteryEnergyCurr && haveBatteryEnergyFull && batteryEnergyFull > 0) {
-         totalEnergyRemain += MINIMUM(batteryEnergyCurr, batteryEnergyFull);
-         totalEnergyFull += batteryEnergyFull;
-         unitsWithEnergy++;
-      }
-
-      if (haveBatteryChargeCurr && haveBatteryChargeFull && batteryChargeFull > 0) {
-         totalChargeRemain += MINIMUM(batteryChargeCurr, batteryChargeFull);
-         totalChargeFull += batteryChargeFull;
-         unitsWithCharge++;
-      }
-
-      if (bst->rate == ACPI_BATT_UNKNOWN) {
-         powerComplete = false;
-         continue;
-      }
-
-      if (bst->rate == 0) {
-         /* I=0 ⇒ 0 W known regardless of voltage. */
-         haveBatteryPower = true;
-      } else if (bif->units == ACPI_BIF_UNITS_MW) {
-         batteryPower = (int64_t) bst->rate * 1000;
-         haveBatteryPower = true;
-      } else {
-         /* Present voltage for I*V. */
-         uint32_t rateVoltage = (bst->volt != ACPI_BATT_UNKNOWN && bst->volt != 0)
-                                 ? bst->volt
-                                 : bif->dvol;
-
-         if (rateVoltage != ACPI_BATT_UNKNOWN && rateVoltage != 0) {
-            batteryPower = (int64_t) bst->rate * rateVoltage;
-            haveBatteryPower = true;
-         }
-      }
-
-      if (!haveBatteryPower) {
-         powerComplete = false;
-         continue;
-      }
-
-      if ((bst->state & ACPI_BATT_STAT_DISCHARG) == 0 &&
-         (bst->state & ACPI_BATT_STAT_CHARGING) != 0)
-         batteryPower = -batteryPower;
-
-      totalPower += batteryPower;
+      if (parseAcpiBattery(fd, u, &raws[nbat]))
+         nbat++;
    }
-
    close(fd);
 
-   /* Energy ratio preferred (mAh-weighted is wrong on mixed-voltage packs). */
-   if (energyComplete && unitsPresent > 0 && unitsWithEnergy == unitsPresent && totalEnergyFull > 0) {
-      info->percent = ((double) totalEnergyRemain * 100.0) / (double) totalEnergyFull;
-      if (totalEnergyRemain >= totalEnergyFull)
-         info->percent = 100;
-   } else if (chargeComplete && unitsPresent > 0 && unitsWithCharge == unitsPresent && totalChargeFull > 0) {
-      info->percent = ((double) totalChargeRemain * 100.0) / (double) totalChargeFull;
-      if (totalChargeRemain >= totalChargeFull)
-         info->percent = 100;
-   }
+   Battery_aggregate(raws, nbat, info);
+}
 
-   if (energyComplete && unitsPresent > 0 && unitsWithEnergy == unitsPresent && totalEnergyFull > 0) {
-      info->energyCurr = (double) totalEnergyRemain / 1000000.0;
-      info->energyFull = (double) totalEnergyFull / 1000000.0;
-   }
+void Platform_getBattery(BatteryInfo* info) {
+   *info = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+      .powerCurr = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
+   };
 
-   if (powerComplete && unitsPresent > 0) {
-      info->powerCurr = (double) totalPower / 1000000.0;
+   int acline;
+   size_t acline_len = sizeof(acline);
+   if (sysctlbyname("hw.acpi.acline", &acline, &acline_len, NULL, 0) != -1)
+      info->ac = (acline == 0) ? AC_ABSENT : AC_PRESENT;
+
+   getAcpiBatteries(info);
+
+   /* hw.acpi.battery.life is the ACPI BIOS-aggregated percent; use it only
+    * when the per-battery path could not produce a reading. */
+   if (!isfinite(info->percent)) {
+      int life;
+      size_t life_len = sizeof(life);
+      if (sysctlbyname("hw.acpi.battery.life", &life, &life_len, NULL, 0) != -1)
+         info->percent = life;
    }
 }

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -417,6 +417,12 @@ void Platform_getBattery(BatteryInfo* info) {
    int unitsCovered = 0;
    bool powerComplete = true;
 
+   /* Energy/charge completeness flags. Cleared when a per-unit ioctl fails
+    * so we don't override the kernel's hw.acpi.battery.life sysctl with a
+    * partial aggregate that omits units we couldn't read. */
+   bool energyComplete = true;
+   bool chargeComplete = true;
+
    /* Count slots that are physically present. ACPI may report N units while
     * one bay is empty; an empty bay's BST succeeds with NOT_PRESENT and zero
     * fields, which would otherwise drag down aggregate percent/energy. */
@@ -424,12 +430,24 @@ void Platform_getBattery(BatteryInfo* info) {
 
    for (int u = 0; u < units; u++) {
       union acpi_battery_ioctl_arg bifArg = { .unit = u };
-      if (ioctl(fd, ACPIIO_BATT_GET_BIF, &bifArg) == -1)
+      if (ioctl(fd, ACPIIO_BATT_GET_BIF, &bifArg) == -1) {
+         /* Failed read: we don't know whether this slot is present or not,
+          * so conservatively mark every aggregate incomplete. Otherwise a
+          * partial sum would override the kernel's authoritative sysctl. */
+         energyComplete = false;
+         chargeComplete = false;
+         powerComplete = false;
          continue;
+      }
 
       union acpi_battery_ioctl_arg bstArg = { .unit = u };
-      if (ioctl(fd, ACPIIO_BATT_GET_BST, &bstArg) == -1)
+      if (ioctl(fd, ACPIIO_BATT_GET_BST, &bstArg) == -1) {
+         /* Same reasoning as the BIF failure above. */
+         energyComplete = false;
+         chargeComplete = false;
+         powerComplete = false;
          continue;
+      }
 
       const struct acpi_bst* bst = &bstArg.bst;
 
@@ -535,22 +553,25 @@ void Platform_getBattery(BatteryInfo* info) {
    /* Only override the sysctl-derived percent when every present battery
     * unit contributed to the totals — partial aggregates would misrepresent
     * the pack against the kernel's hw.acpi.battery.life summary. Compare
-    * against unitsPresent so empty bays don't fail the check. Prefer the
-    * energy (Wh) ratio over the raw-charge (mAh) ratio: on multi-pack
-    * systems with differing voltages the energy ratio is the physically
-    * correct aggregate, while an mAh-weighted ratio is not. */
-   if (unitsPresent > 0 && unitsWithEnergy == unitsPresent && totalEnergyFull > 0) {
+    * against unitsPresent so empty bays don't fail the check, and require
+    * the matching completeness flag (energyComplete / chargeComplete) so a
+    * BIF/BST ioctl failure on any unit forces us back to the kernel's
+    * authoritative summary instead of publishing a partial aggregate.
+    * Prefer the energy (Wh) ratio over the raw-charge (mAh) ratio: on
+    * multi-pack systems with differing voltages the energy ratio is the
+    * physically correct aggregate, while an mAh-weighted ratio is not. */
+   if (energyComplete && unitsPresent > 0 && unitsWithEnergy == unitsPresent && totalEnergyFull > 0) {
       info->percent = ((double) totalEnergyRemain * 100.0) / (double) totalEnergyFull;
       if (totalEnergyRemain >= totalEnergyFull)
          info->percent = 100;
-   } else if (unitsPresent > 0 && unitsWithCharge == unitsPresent && totalChargeFull > 0) {
+   } else if (chargeComplete && unitsPresent > 0 && unitsWithCharge == unitsPresent && totalChargeFull > 0) {
       info->percent = ((double) totalChargeRemain * 100.0) / (double) totalChargeFull;
       if (totalChargeRemain >= totalChargeFull)
          info->percent = 100;
    }
 
    /* Only publish energy totals when complete in watt-hours for every present unit. */
-   if (unitsPresent > 0 && unitsWithEnergy == unitsPresent && totalEnergyFull > 0) {
+   if (energyComplete && unitsPresent > 0 && unitsWithEnergy == unitsPresent && totalEnergyFull > 0) {
       info->energyCurr = (double) totalEnergyRemain / 1000000.0;
       info->energyFull = (double) totalEnergyFull / 1000000.0;
    }

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -491,10 +491,17 @@ void Platform_getBattery(BatteryInfo* info) {
             haveBatteryChargeCurr = true;
             haveBatteryChargeFull = true;
 
-            uint32_t batteryVoltage = (bst->volt != ACPI_BATT_UNKNOWN) ? bst->volt : bif->dvol;
-            if (batteryVoltage != ACPI_BATT_UNKNOWN && batteryVoltage != 0) {
-               batteryEnergyCurr = (int64_t) bst->cap * batteryVoltage;
-               batteryEnergyFull = (int64_t) bif->lfcap * batteryVoltage;
+            /* Use design voltage to convert charge into energy: bst->volt
+             * (instantaneous terminal voltage) drifts as the pack charges and
+             * discharges, which would skew batteryEnergyFull over time. Fall
+             * back to the present voltage only if the design value is
+             * missing. */
+            uint32_t referenceVoltage = (bif->dvol != ACPI_BATT_UNKNOWN && bif->dvol != 0)
+                                         ? bif->dvol
+                                         : bst->volt;
+            if (referenceVoltage != ACPI_BATT_UNKNOWN && referenceVoltage != 0) {
+               batteryEnergyCurr = (int64_t) bst->cap * referenceVoltage;
+               batteryEnergyFull = (int64_t) bif->lfcap * referenceVoltage;
                haveBatteryEnergyCurr = true;
                haveBatteryEnergyFull = true;
             }
@@ -526,10 +533,14 @@ void Platform_getBattery(BatteryInfo* info) {
          batteryPower = (int64_t) bst->rate * 1000;
          haveBatteryPower = true;
       } else {
-         uint32_t batteryVoltage = (bst->volt != ACPI_BATT_UNKNOWN) ? bst->volt : bif->dvol;
+         /* Instantaneous power P = I * V wants the present terminal voltage;
+          * fall back to design voltage only when it isn't exposed. */
+         uint32_t rateVoltage = (bst->volt != ACPI_BATT_UNKNOWN && bst->volt != 0)
+                                 ? bst->volt
+                                 : bif->dvol;
 
-         if (batteryVoltage != ACPI_BATT_UNKNOWN && batteryVoltage != 0) {
-            batteryPower = (int64_t) bst->rate * batteryVoltage;
+         if (rateVoltage != ACPI_BATT_UNKNOWN && rateVoltage != 0) {
+            batteryPower = (int64_t) bst->rate * rateVoltage;
             haveBatteryPower = true;
          }
       }

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -406,7 +406,7 @@ void Platform_getBattery(BatteryInfo* info) {
    int64_t totalChargeFull = 0;
    int unitsWithCharge = 0;
 
-   int64_t totalPower = 0;
+   int64_t totalPower = 0;            /* µW */
    int unitsCovered = 0;
    bool powerComplete = true;
 
@@ -485,15 +485,13 @@ void Platform_getBattery(BatteryInfo* info) {
 
       /* Clamp curr <= full per battery (firmware may report cap > lfcap). */
       if (haveBatteryEnergyCurr && haveBatteryEnergyFull && batteryEnergyFull > 0) {
-         int64_t clampedEnergy = batteryEnergyCurr > batteryEnergyFull ? batteryEnergyFull : batteryEnergyCurr;
-         totalEnergyRemain += clampedEnergy;
+         totalEnergyRemain += MINIMUM(batteryEnergyCurr, batteryEnergyFull);
          totalEnergyFull += batteryEnergyFull;
          unitsWithEnergy++;
       }
 
       if (haveBatteryChargeCurr && haveBatteryChargeFull && batteryChargeFull > 0) {
-         int64_t clampedCharge = batteryChargeCurr > batteryChargeFull ? batteryChargeFull : batteryChargeCurr;
-         totalChargeRemain += clampedCharge;
+         totalChargeRemain += MINIMUM(batteryChargeCurr, batteryChargeFull);
          totalChargeFull += batteryChargeFull;
          unitsWithCharge++;
       }

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -396,13 +396,24 @@ void Platform_getBattery(BatteryInfo* info) {
       return;
    }
 
-   bool haveTotalRemain = false;
-   bool haveTotalFull = false;
-   bool haveTotalPower = false;
+   /* Energy totals (require voltage on mAh systems) — used for energyCurr/Full
+    * and as the preferred basis for info->percent. */
+   int64_t totalEnergyRemain = 0;
+   int64_t totalEnergyFull = 0;
+   int unitsWithEnergy = 0;
 
-   int64_t totalRemain = 0;
-   int64_t totalFull = 0;
+   /* Parallel charge-or-energy totals — used solely as a fallback for
+    * info->percent when voltage is unknown on mAh systems. */
+   int64_t totalChargeRemain = 0;
+   int64_t totalChargeFull = 0;
+   int unitsWithCharge = 0;
+
+   /* Power total. Idle batteries (rate == ACPI_BATT_UNKNOWN) contribute 0 W;
+    * a unit is considered "covered" once its BIF/BST data is in hand. Only
+    * publish powerCurr when every unit was covered. */
    int64_t totalPower = 0;
+   int unitsCovered = 0;
+   bool powerComplete = true;
 
    for (int u = 0; u < units; u++) {
       union acpi_battery_ioctl_arg bifArg = { .unit = u };
@@ -413,15 +424,21 @@ void Platform_getBattery(BatteryInfo* info) {
       if (ioctl(fd, ACPIIO_BATT_GET_BST, &bstArg) == -1)
          continue;
 
+      unitsCovered++;
+
       const struct acpi_bif* bif = &bifArg.bif;
       const struct acpi_bst* bst = &bstArg.bst;
 
       bool haveBatteryEnergyCurr = false;
       bool haveBatteryEnergyFull = false;
+      bool haveBatteryChargeCurr = false;
+      bool haveBatteryChargeFull = false;
       bool haveBatteryPower = false;
 
       int64_t batteryEnergyCurr = 0;
       int64_t batteryEnergyFull = 0;
+      int64_t batteryChargeCurr = 0;
+      int64_t batteryChargeFull = 0;
       int64_t batteryPower = 0;
 
       if (bif->lfcap != ACPI_BATT_UNKNOWN && bst->cap != ACPI_BATT_UNKNOWN) {
@@ -431,6 +448,13 @@ void Platform_getBattery(BatteryInfo* info) {
             haveBatteryEnergyCurr = true;
             haveBatteryEnergyFull = true;
          } else {
+            /* Always populate the charge fallback so we can still compute
+             * percent when voltage is unknown. */
+            batteryChargeCurr = (int64_t) bst->cap;
+            batteryChargeFull = (int64_t) bif->lfcap;
+            haveBatteryChargeCurr = true;
+            haveBatteryChargeFull = true;
+
             uint32_t batteryVoltage = (bst->volt != ACPI_BATT_UNKNOWN) ? bst->volt : bif->dvol;
             if (batteryVoltage != ACPI_BATT_UNKNOWN && batteryVoltage != 0) {
                batteryEnergyCurr = (int64_t) bst->cap * batteryVoltage;
@@ -442,11 +466,21 @@ void Platform_getBattery(BatteryInfo* info) {
       }
 
       if (haveBatteryEnergyCurr && haveBatteryEnergyFull && batteryEnergyFull > 0) {
-         totalRemain += batteryEnergyCurr;
-         haveTotalRemain = true;
+         totalEnergyRemain += batteryEnergyCurr;
+         totalEnergyFull += batteryEnergyFull;
+         unitsWithEnergy++;
+      }
 
-         totalFull += batteryEnergyFull;
-         haveTotalFull = true;
+      if (haveBatteryChargeCurr && haveBatteryChargeFull && batteryChargeFull > 0) {
+         totalChargeRemain += batteryChargeCurr;
+         totalChargeFull += batteryChargeFull;
+         unitsWithCharge++;
+      } else if (haveBatteryEnergyCurr && haveBatteryEnergyFull && batteryEnergyFull > 0) {
+         /* mW-units batteries don't populate the charge fallback explicitly,
+          * but their energy values are equally valid as a percent basis. */
+         totalChargeRemain += batteryEnergyCurr;
+         totalChargeFull += batteryEnergyFull;
+         unitsWithCharge++;
       }
 
       if (bst->rate == ACPI_BATT_UNKNOWN)
@@ -464,29 +498,41 @@ void Platform_getBattery(BatteryInfo* info) {
          }
       }
 
-      if (!haveBatteryPower)
+      if (!haveBatteryPower) {
+         /* A non-zero rate that we couldn't convert (mAh with unknown voltage)
+          * means the totalPower sum is missing real charge/discharge activity. */
+         powerComplete = false;
          continue;
+      }
 
       if ((bst->state & ACPI_BATT_STAT_DISCHARG) == 0 &&
          (bst->state & ACPI_BATT_STAT_CHARGING) != 0)
          batteryPower = -batteryPower;
 
       totalPower += batteryPower;
-      haveTotalPower = true;
    }
 
    close(fd);
 
-   if (haveTotalRemain && haveTotalFull && totalFull > 0) {
-      info->percent = ((double) totalRemain * 100.0) / (double) totalFull;
-      if (totalRemain >= totalFull)
+   /* Only override the sysctl-derived percent when every battery unit
+    * contributed to the totals — partial aggregates would misrepresent the
+    * pack against the kernel's hw.acpi.battery.life summary. */
+   if (unitsWithCharge == units && totalChargeFull > 0) {
+      info->percent = ((double) totalChargeRemain * 100.0) / (double) totalChargeFull;
+      if (totalChargeRemain >= totalChargeFull)
          info->percent = 100;
-
-      info->energyCurr = (double) totalRemain / 1000000.0;
-      info->energyFull = (double) totalFull / 1000000.0;
    }
 
-   if (haveTotalPower) {
+   /* Only publish energy totals when complete in watt-hours for every unit. */
+   if (unitsWithEnergy == units && totalEnergyFull > 0) {
+      info->energyCurr = (double) totalEnergyRemain / 1000000.0;
+      info->energyFull = (double) totalEnergyFull / 1000000.0;
+   }
+
+   /* Only publish power when every unit was covered and convertible to W.
+    * Idle batteries (unknown rate) contribute 0 W and are still considered
+    * complete. */
+   if (powerComplete && unitsCovered == units) {
       info->powerCurr = (double) totalPower / 1000000.0;
    }
 }

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -434,13 +434,12 @@ void Platform_getBattery(BatteryInfo* info) {
       const struct acpi_bst* bst = &bstArg.bst;
 
       /* Empty battery bay: BST can succeed with zeroed cap/rate fields and
-       * the NOT_PRESENT state bit set. Skip it entirely — the kernel's
-       * hw.acpi.battery.life sysctl already accounts for absence, and
-       * counting a missing pack as a 0 Wh battery would drag the aggregate
-       * percent and energy totals down. The completeness checks below use
-       * unitsPresent (not units) so absent slots are treated as
-       * nonexistent rather than as units with missing data. */
-      if ((bst->state & ACPI_BATT_STAT_NOT_PRESENT) != 0)
+       * state reported as the NOT_PRESENT sentinel. NOT_PRESENT is a
+       * synthetic value (the OR of all _BST state bits), not a standalone
+       * flag, so test it with == rather than masking. Skip absent slots —
+       * the completeness checks below use unitsPresent (not units) so absent
+       * slots are treated as nonexistent rather than units with missing data. */
+      if (bst->state == ACPI_BATT_STAT_NOT_PRESENT)
          continue;
 
       unitsPresent++;

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -445,8 +445,13 @@ static void getAcpiBatteries(BatteryInfo* info) {
    if (fd == -1)
       return;
 
-   if (units > ACPI_MAX_BATTERIES)
-      units = ACPI_MAX_BATTERIES;
+   /* Refuse to publish a partial aggregate when the firmware reports
+    * more batteries than the fixed buffer holds; the fallback path
+    * (hw.acpi.battery.life) still runs after this returns. */
+   if (units > ACPI_MAX_BATTERIES) {
+      close(fd);
+      return;
+   }
 
    BatteryRaw raws[ACPI_MAX_BATTERIES];
    size_t nbat = 0;

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -402,15 +402,17 @@ void Platform_getBattery(BatteryInfo* info) {
    int64_t totalEnergyFull = 0;
    int unitsWithEnergy = 0;
 
-   /* Parallel charge-or-energy totals — used solely as a fallback for
-    * info->percent when voltage is unknown on mAh systems. */
+   /* Parallel raw-charge totals — used solely as a fallback basis for
+    * info->percent when voltage is unknown on mAh systems and the energy
+    * totals are therefore incomplete. */
    int64_t totalChargeRemain = 0;
    int64_t totalChargeFull = 0;
    int unitsWithCharge = 0;
 
-   /* Power total. Idle batteries (rate == ACPI_BATT_UNKNOWN) contribute 0 W;
-    * a unit is considered "covered" once its BIF/BST data is in hand. Only
-    * publish powerCurr when every unit was covered. */
+   /* Power total. A unit is considered "covered" once its BIF/BST data is
+    * in hand; powerComplete additionally requires every unit's rate to be
+    * known and convertible to watts. Only publish powerCurr when both
+    * conditions hold for every unit. */
    int64_t totalPower = 0;
    int unitsCovered = 0;
    bool powerComplete = true;
@@ -475,16 +477,16 @@ void Platform_getBattery(BatteryInfo* info) {
          totalChargeRemain += batteryChargeCurr;
          totalChargeFull += batteryChargeFull;
          unitsWithCharge++;
-      } else if (haveBatteryEnergyCurr && haveBatteryEnergyFull && batteryEnergyFull > 0) {
-         /* mW-units batteries don't populate the charge fallback explicitly,
-          * but their energy values are equally valid as a percent basis. */
-         totalChargeRemain += batteryEnergyCurr;
-         totalChargeFull += batteryEnergyFull;
-         unitsWithCharge++;
       }
 
-      if (bst->rate == ACPI_BATT_UNKNOWN)
+      if (bst->rate == ACPI_BATT_UNKNOWN) {
+         /* A genuinely unknown rate means the totalPower sum can't represent
+          * this unit. Treat as incomplete so we don't publish a misleading
+          * 0 W aggregate; the 0.0 fallback is reserved for known-zero rates
+          * (e.g., idle on AC). */
+         powerComplete = false;
          continue;
+      }
 
       if (bif->units == ACPI_BIF_UNITS_MW) {
          batteryPower = (int64_t) bst->rate * 1000;
@@ -516,8 +518,15 @@ void Platform_getBattery(BatteryInfo* info) {
 
    /* Only override the sysctl-derived percent when every battery unit
     * contributed to the totals — partial aggregates would misrepresent the
-    * pack against the kernel's hw.acpi.battery.life summary. */
-   if (unitsWithCharge == units && totalChargeFull > 0) {
+    * pack against the kernel's hw.acpi.battery.life summary. Prefer the
+    * energy (Wh) ratio over the raw-charge (mAh) ratio: on multi-pack
+    * systems with differing voltages the energy ratio is the physically
+    * correct aggregate, while an mAh-weighted ratio is not. */
+   if (unitsWithEnergy == units && totalEnergyFull > 0) {
+      info->percent = ((double) totalEnergyRemain * 100.0) / (double) totalEnergyFull;
+      if (totalEnergyRemain >= totalEnergyFull)
+         info->percent = 100;
+   } else if (unitsWithCharge == units && totalChargeFull > 0) {
       info->percent = ((double) totalChargeRemain * 100.0) / (double) totalChargeFull;
       if (totalChargeRemain >= totalChargeFull)
          info->percent = 100;
@@ -529,9 +538,10 @@ void Platform_getBattery(BatteryInfo* info) {
       info->energyFull = (double) totalEnergyFull / 1000000.0;
    }
 
-   /* Only publish power when every unit was covered and convertible to W.
-    * Idle batteries (unknown rate) contribute 0 W and are still considered
-    * complete. */
+   /* Only publish power when every unit was covered and every rate was
+    * known and convertible to W. An unknown rate on any unit leaves the
+    * sysctl-derived powerCurr (NaN) in place rather than reporting a
+    * misleading 0 W aggregate. */
    if (powerComplete && unitsCovered == units) {
       info->powerCurr = (double) totalPower / 1000000.0;
    }

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -529,7 +529,12 @@ void Platform_getBattery(BatteryInfo* info) {
          continue;
       }
 
-      if (bif->units == ACPI_BIF_UNITS_MW) {
+      if (bst->rate == 0) {
+         /* Zero rate is a known 0 W reading regardless of units or voltage:
+          * I * V = 0 when I is zero, so the mAh path's voltage lookup is
+          * unnecessary. batteryPower is already 0 from its declaration. */
+         haveBatteryPower = true;
+      } else if (bif->units == ACPI_BIF_UNITS_MW) {
          batteryPower = (int64_t) bst->rate * 1000;
          haveBatteryPower = true;
       } else {

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -407,7 +407,6 @@ void Platform_getBattery(BatteryInfo* info) {
    int unitsWithCharge = 0;
 
    int64_t totalPower = 0;            /* µW */
-   int unitsCovered = 0;
    bool powerComplete = true;
 
    /* Cleared on ioctl failure to keep partial aggregates out. */
@@ -441,7 +440,6 @@ void Platform_getBattery(BatteryInfo* info) {
          continue;
 
       unitsPresent++;
-      unitsCovered++;
 
       const struct acpi_bif* bif = &bifArg.bif;
 
@@ -549,7 +547,7 @@ void Platform_getBattery(BatteryInfo* info) {
       info->energyFull = (double) totalEnergyFull / 1000000.0;
    }
 
-   if (powerComplete && unitsPresent > 0 && unitsCovered == unitsPresent) {
+   if (powerComplete && unitsPresent > 0) {
       info->powerCurr = (double) totalPower / 1000000.0;
    }
 }

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -508,14 +508,20 @@ void Platform_getBattery(BatteryInfo* info) {
          }
       }
 
+      /* Clamp per-battery curr to full before summing: a quirky firmware
+       * can report bst->cap > bif->lfcap, which would otherwise let the
+       * published info->energyCurr / info->energyFull values exceed each
+       * other's bounds even though the percent gate caps at 100. */
       if (haveBatteryEnergyCurr && haveBatteryEnergyFull && batteryEnergyFull > 0) {
-         totalEnergyRemain += batteryEnergyCurr;
+         int64_t clampedEnergy = batteryEnergyCurr > batteryEnergyFull ? batteryEnergyFull : batteryEnergyCurr;
+         totalEnergyRemain += clampedEnergy;
          totalEnergyFull += batteryEnergyFull;
          unitsWithEnergy++;
       }
 
       if (haveBatteryChargeCurr && haveBatteryChargeFull && batteryChargeFull > 0) {
-         totalChargeRemain += batteryChargeCurr;
+         int64_t clampedCharge = batteryChargeCurr > batteryChargeFull ? batteryChargeFull : batteryChargeCurr;
+         totalChargeRemain += clampedCharge;
          totalChargeFull += batteryChargeFull;
          unitsWithCharge++;
       }

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -386,15 +386,19 @@ void Platform_getBattery(BatteryInfo* info) {
    if (sysctlbyname("hw.acpi.acline", &acline, &acline_len, NULL, 0) != -1)
       info->ac = (acline == 0) ? AC_ABSENT : AC_PRESENT;
 
+   /* DragonFly does not define ACPIIO_BATT_GET_UNITS in
+    * <dev/acpica/acpiio.h> (only the BIF/BST ioctls are exposed), so
+    * obtain the unit count via the same hw.acpi.battery.units sysctl
+    * that FreeBSD uses. The /dev/acpi BIF/BST ioctls below remain the
+    * read source for per-unit data. */
    int units = 0;
+   size_t units_len = sizeof(units);
+   if (sysctlbyname("hw.acpi.battery.units", &units, &units_len, NULL, 0) == -1 || units <= 0)
+      return;
+
    int fd = open("/dev/acpi", O_RDONLY | O_CLOEXEC);
    if (fd == -1)
       return;
-
-   if (ioctl(fd, ACPIIO_BATT_GET_UNITS, &units) == -1 || units <= 0) {
-      close(fd);
-      return;
-   }
 
    /* Energy totals (require voltage on mAh systems) — used for energyCurr/Full
     * and as the preferred basis for info->percent. */

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -443,8 +443,9 @@ static void getAcpiBatteries(BatteryInfo* info) {
    if (fd == -1)
       return;
 
-   /* Sized to the firmware-reported unit count; xMalloc never returns NULL. */
-   BatteryRaw* raws = xMalloc((size_t) units * sizeof(BatteryRaw));
+   /* Sized to the firmware-reported unit count; xMallocArray traps on
+    * size_t overflow if the firmware reports a bogus large value. */
+   BatteryRaw* raws = xMallocArray((size_t) units, sizeof(BatteryRaw));
    size_t nbat = 0;
    for (int u = 0; u < units; u++) {
       if (parseAcpiBattery(fd, u, &raws[nbat]))

--- a/dragonflybsd/Platform.h
+++ b/dragonflybsd/Platform.h
@@ -71,7 +71,7 @@ bool Platform_getDiskIO(DiskIOData* data);
 
 bool Platform_getNetworkIO(NetworkIOData* data);
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC);
+void Platform_getBattery(BatteryInfo* info);
 
 static inline void Platform_getHostname(char* buffer, size_t size) {
    Generic_hostname(buffer, size);

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -396,18 +396,19 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    return true;
 }
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC) {
+void Platform_getBattery(BatteryInfo* info) {
+   *info = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
+
    int life;
    size_t life_len = sizeof(life);
-   if (sysctlbyname("hw.acpi.battery.life", &life, &life_len, NULL, 0) == -1)
-      *percent = NAN;
-   else
-      *percent = life;
+   if (sysctlbyname("hw.acpi.battery.life", &life, &life_len, NULL, 0) != -1)
+      info->percent = life;
 
    int acline;
    size_t acline_len = sizeof(acline);
-   if (sysctlbyname("hw.acpi.acline", &acline, &acline_len, NULL, 0) == -1)
-      *isOnAC = AC_ERROR;
-   else
-      *isOnAC = acline == 0 ? AC_ABSENT : AC_PRESENT;
+   if (sysctlbyname("hw.acpi.acline", &acline, &acline_len, NULL, 0) != -1)
+      info->ac = (acline == 0) ? AC_ABSENT : AC_PRESENT;
 }

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -404,6 +404,7 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .powerCurr = NAN,
       .energyCurr = NAN,
       .energyFull = NAN,
    };
@@ -429,9 +430,11 @@ void Platform_getBattery(BatteryInfo* info) {
 
    bool haveTotalRemain = false;
    bool haveTotalFull = false;
+   bool haveTotalPower = false;
 
    int64_t totalRemain = 0;
    int64_t totalFull = 0;
+   int64_t totalPower = 0;
 
    for (int u = 0; u < units; u++) {
       union acpi_battery_ioctl_arg bixArg = { .unit = u };
@@ -447,9 +450,11 @@ void Platform_getBattery(BatteryInfo* info) {
 
       bool haveBatteryEnergyCurr = false;
       bool haveBatteryEnergyFull = false;
+      bool haveBatteryPower = false;
 
       int64_t batteryEnergyCurr = 0;
       int64_t batteryEnergyFull = 0;
+      int64_t batteryPower = 0;
 
       if (bix->lfcap != ACPI_BATT_UNKNOWN && bst->cap != ACPI_BATT_UNKNOWN) {
          if (bix->units == ACPI_BIX_UNITS_MW) {
@@ -474,6 +479,25 @@ void Platform_getBattery(BatteryInfo* info) {
          haveTotalRemain = true;
          haveTotalFull = true;
       }
+
+      if (bst->rate != ACPI_BATT_UNKNOWN && bst->rate > 0) {
+         if (bix->units == ACPI_BIX_UNITS_MW) {
+            batteryPower = (int64_t) bst->rate * 1000;
+            haveBatteryPower = true;
+         } else {
+            uint32_t rateVoltage = (bst->volt != ACPI_BATT_UNKNOWN) ? bst->volt : bix->dvol;
+
+            if (rateVoltage != ACPI_BATT_UNKNOWN && rateVoltage != 0) {
+               batteryPower = (int64_t) bst->rate * rateVoltage;
+               haveBatteryPower = true;
+            }
+         }
+      }
+
+      if (haveBatteryPower) {
+         totalPower += batteryPower;
+         haveTotalPower = true;
+      }
    }
 
    close(fd);
@@ -485,5 +509,9 @@ void Platform_getBattery(BatteryInfo* info) {
 
       info->energyCurr = (double) totalRemain / 1000000.0;
       info->energyFull = (double) totalFull / 1000000.0;
+   }
+
+   if (haveTotalPower) {
+      info->powerCurr = (double) totalPower / 1000000.0;
    }
 }

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -400,6 +400,8 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 
    int life;

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -10,14 +10,18 @@ in the source distribution for its full text.
 #include "freebsd/Platform.h"
 
 #include <devstat.h>
+#include <fcntl.h>
 #include <math.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <time.h>
+#include <unistd.h>
+#include <dev/acpica/acpiio.h>
 #include <net/if.h>
 #include <net/if_mib.h>
 #include <sys/_types.h>
 #include <sys/devicestat.h>
+#include <sys/ioctl.h>
 #include <sys/param.h>
 #include <sys/resource.h>
 #include <sys/socket.h>
@@ -413,4 +417,73 @@ void Platform_getBattery(BatteryInfo* info) {
    size_t acline_len = sizeof(acline);
    if (sysctlbyname("hw.acpi.acline", &acline, &acline_len, NULL, 0) != -1)
       info->ac = (acline == 0) ? AC_ABSENT : AC_PRESENT;
+
+   int units = 0;
+   size_t units_len = sizeof(units);
+   if (sysctlbyname("hw.acpi.battery.units", &units, &units_len, NULL, 0) == -1 || units <= 0)
+      return;
+
+   int fd = open("/dev/acpi", O_RDONLY | O_CLOEXEC);
+   if (fd == -1)
+      return;
+
+   bool haveTotalRemain = false;
+   bool haveTotalFull = false;
+
+   int64_t totalRemain = 0;
+   int64_t totalFull = 0;
+
+   for (int u = 0; u < units; u++) {
+      union acpi_battery_ioctl_arg bixArg = { .unit = u };
+      if (ioctl(fd, ACPIIO_BATT_GET_BIX, &bixArg) == -1)
+         continue;
+
+      union acpi_battery_ioctl_arg bstArg = { .unit = u };
+      if (ioctl(fd, ACPIIO_BATT_GET_BST, &bstArg) == -1)
+         continue;
+
+      const struct acpi_bix* bix = &bixArg.bix;
+      const struct acpi_bst* bst = &bstArg.bst;
+
+      bool haveBatteryEnergyCurr = false;
+      bool haveBatteryEnergyFull = false;
+
+      int64_t batteryEnergyCurr = 0;
+      int64_t batteryEnergyFull = 0;
+
+      if (bix->lfcap != ACPI_BATT_UNKNOWN && bst->cap != ACPI_BATT_UNKNOWN) {
+         if (bix->units == ACPI_BIX_UNITS_MW) {
+            batteryEnergyCurr = (int64_t) bst->cap * 1000;
+            batteryEnergyFull = (int64_t) bix->lfcap * 1000;
+            haveBatteryEnergyCurr = true;
+            haveBatteryEnergyFull = true;
+         } else {
+            uint32_t batteryVoltage = (bst->volt != ACPI_BATT_UNKNOWN) ? bst->volt : bix->dvol;
+            if (batteryVoltage != ACPI_BATT_UNKNOWN && batteryVoltage != 0) {
+               batteryEnergyCurr = (int64_t) bst->cap * batteryVoltage;
+               batteryEnergyFull = (int64_t) bix->lfcap * batteryVoltage;
+               haveBatteryEnergyCurr = true;
+               haveBatteryEnergyFull = true;
+            }
+         }
+      }
+
+      if (haveBatteryEnergyCurr && haveBatteryEnergyFull && batteryEnergyFull > 0) {
+         totalRemain += batteryEnergyCurr;
+         totalFull += batteryEnergyFull;
+         haveTotalRemain = true;
+         haveTotalFull = true;
+      }
+   }
+
+   close(fd);
+
+   if (haveTotalRemain && haveTotalFull && totalFull > 0) {
+      info->percent = ((double) totalRemain * 100.0) / (double) totalFull;
+      if (totalRemain >= totalFull)
+         info->percent = 100;
+
+      info->energyCurr = (double) totalRemain / 1000000.0;
+      info->energyFull = (double) totalFull / 1000000.0;
+   }
 }

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -459,11 +459,11 @@ void Platform_getBattery(BatteryInfo* info) {
       const struct acpi_bst* bst = &bstArg.bst;
 
       /* Empty battery bay: BST can succeed with zeroed cap/rate fields and
-       * the NOT_PRESENT state bit set. Skip it entirely — the kernel's
-       * hw.acpi.battery.life sysctl already accounts for absence, and
-       * counting a missing pack as a 0 Wh battery would drag the aggregate
-       * percent and energy totals down. */
-      if ((bst->state & ACPI_BATT_STAT_NOT_PRESENT) != 0)
+       * state reported as the NOT_PRESENT sentinel. NOT_PRESENT is a
+       * synthetic value (the OR of all _BST state bits), not a standalone
+       * flag, so test it with == rather than masking. Skip absent slots —
+       * the kernel's hw.acpi.battery.life sysctl already accounts for them. */
+      if (bst->state == ACPI_BATT_STAT_NOT_PRESENT)
          continue;
 
       bool haveBatteryEnergyCurr = false;

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -27,8 +27,7 @@ in the source distribution for its full text.
 #include <sys/sysctl.h>
 #include <sys/time.h>
 #include <sys/types.h>
-/* <dev/acpica/acpiio.h> uses _IOWR macros from <sys/ioccom.h> (pulled in via
- * <sys/ioctl.h>) but does not include them itself; keep this after <sys/ioctl.h>. */
+/* <acpiio.h> needs _IOWR from <sys/ioctl.h>; keep order. */
 #include <dev/acpica/acpiio.h>
 #include <vm/vm_param.h>
 
@@ -458,11 +457,7 @@ void Platform_getBattery(BatteryInfo* info) {
       const struct acpi_bix* bix = &bixArg.bix;
       const struct acpi_bst* bst = &bstArg.bst;
 
-      /* Empty battery bay: BST can succeed with zeroed cap/rate fields and
-       * state reported as the NOT_PRESENT sentinel. NOT_PRESENT is a
-       * synthetic value (the OR of all _BST state bits), not a standalone
-       * flag, so test it with == rather than masking. Skip absent slots —
-       * the kernel's hw.acpi.battery.life sysctl already accounts for them. */
+      /* NOT_PRESENT is a synthetic _BST mask value, not a single bit. */
       if (bst->state == ACPI_BATT_STAT_NOT_PRESENT)
          continue;
 
@@ -481,11 +476,7 @@ void Platform_getBattery(BatteryInfo* info) {
             haveBatteryEnergyCurr = true;
             haveBatteryEnergyFull = true;
          } else {
-            /* Use design voltage to convert charge into energy: bst->volt
-             * (instantaneous terminal voltage) drifts as the pack charges and
-             * discharges, which would skew batteryEnergyFull over time. Fall
-             * back to the present voltage only if the design value is
-             * missing. */
+            /* Design voltage for energy reference (bst->volt drifts). */
             uint32_t referenceVoltage = (bix->dvol != ACPI_BATT_UNKNOWN && bix->dvol != 0)
                                          ? bix->dvol
                                          : bst->volt;
@@ -499,10 +490,7 @@ void Platform_getBattery(BatteryInfo* info) {
       }
 
       if (haveBatteryEnergyCurr && haveBatteryEnergyFull && batteryEnergyFull > 0) {
-         /* Clamp curr to full per battery before summing: a quirky firmware
-          * can report bst->cap > bix->lfcap, which would otherwise let
-          * info->energyCurr exceed info->energyFull on the published value
-          * even though the percent gate already caps at 100. */
+         /* Clamp curr <= full per battery (firmware can report cap > lfcap). */
          int64_t clampedCurr = batteryEnergyCurr > batteryEnergyFull ? batteryEnergyFull : batteryEnergyCurr;
          totalRemain += clampedCurr;
          totalFull += batteryEnergyFull;
@@ -519,9 +507,7 @@ void Platform_getBattery(BatteryInfo* info) {
             batteryPower = (int64_t) bst->rate * 1000;
             haveBatteryPower = true;
          } else {
-            /* Instantaneous power P = I * V wants the present terminal
-             * voltage; fall back to design voltage only when it isn't
-             * exposed. */
+            /* Present voltage for I*V power. */
             uint32_t rateVoltage = (bst->volt != ACPI_BATT_UNKNOWN && bst->volt != 0)
                                     ? bst->volt
                                     : bix->dvol;
@@ -533,11 +519,8 @@ void Platform_getBattery(BatteryInfo* info) {
          }
       }
 
-      /* htop convention: positive = discharging, negative = charging.
-       * ACPI _BST reports rate as a magnitude; charging direction is in
-       * bst->state. Some firmware sets both DISCHARG and CHARGING bits;
-       * the kernel treats that as discharging, so only negate when
-       * CHARGING is set and DISCHARG is clear (mirroring DragonFly). */
+      /* Negate when charging bit set and discharging bit clear; some
+       * firmware sets both, kernel resolves to discharging. */
       if (bst->state != ACPI_BATT_STAT_NOT_PRESENT &&
           (bst->state & ACPI_BATT_STAT_DISCHARG) == 0 &&
           (bst->state & ACPI_BATT_STAT_CHARGING) != 0) {
@@ -554,9 +537,7 @@ void Platform_getBattery(BatteryInfo* info) {
 
    close(fd);
 
-   /* Only publish aggregate energy/percent when every battery contributed.
-      Otherwise the totals are partial and would contradict the sysctl
-      `hw.acpi.battery.life` value (which already covers all units). */
+   /* Partial aggregates would contradict hw.acpi.battery.life. */
    if (energyComplete && haveTotalRemain && haveTotalFull && totalFull > 0) {
       info->percent = ((double) totalRemain * 100.0) / (double) totalFull;
       if (totalRemain >= totalFull)
@@ -566,8 +547,6 @@ void Platform_getBattery(BatteryInfo* info) {
       info->energyFull = (double) totalFull / 1000000.0;
    }
 
-   /* Power total is meaningful only when every battery's rate was readable
-      (a known rate of zero counts as a contribution). */
    if (powerComplete && haveTotalPower) {
       info->powerCurr = (double) totalPower / 1000000.0;
    }

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -472,8 +472,9 @@ static void getAcpiBatteries(BatteryInfo* info) {
    if (fd == -1)
       return;
 
-   /* Sized to the firmware-reported unit count; xMalloc never returns NULL. */
-   BatteryRaw* raws = xMalloc((size_t) units * sizeof(BatteryRaw));
+   /* Sized to the firmware-reported unit count; xMallocArray traps on
+    * size_t overflow if the firmware reports a bogus large value. */
+   BatteryRaw* raws = xMallocArray((size_t) units, sizeof(BatteryRaw));
    size_t nbat = 0;
    for (int u = 0; u < units; u++) {
       if (parseAcpiBattery(fd, u, &raws[nbat]))

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -440,7 +440,11 @@ static bool parseAcpiBattery(int fd, int unit, BatteryRaw* out) {
       if (unitsAreMW) {
          out->energyFull = (double) bix->lfcap / 1000.0;
          out->energyNow  = (double) bst->cap   / 1000.0;
-      } else {
+      } else if (out->voltageDesign > 0 || out->voltageNow > 0) {
+         /* Store charge only when a voltage is available so the aggregator
+          * derives energy from charge * voltage. The FreeBSD getter has no
+          * charge-axis fallback historically; without voltage the per-
+          * battery path stays empty so hw.acpi.battery.life can run. */
          out->chargeFull = (double) bix->lfcap / 1000.0;
          out->chargeNow  = (double) bst->cap   / 1000.0;
       }

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -534,8 +534,12 @@ void Platform_getBattery(BatteryInfo* info) {
       }
 
       /* htop convention: positive = discharging, negative = charging.
-       * ACPI _BST reports rate as a magnitude; charging direction is in bst->state. */
+       * ACPI _BST reports rate as a magnitude; charging direction is in
+       * bst->state. Some firmware sets both DISCHARG and CHARGING bits;
+       * the kernel treats that as discharging, so only negate when
+       * CHARGING is set and DISCHARG is clear (mirroring DragonFly). */
       if (bst->state != ACPI_BATT_STAT_NOT_PRESENT &&
+          (bst->state & ACPI_BATT_STAT_DISCHARG) == 0 &&
           (bst->state & ACPI_BATT_STAT_CHARGING) != 0) {
          batteryPower = -batteryPower;
       }

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -435,9 +435,9 @@ void Platform_getBattery(BatteryInfo* info) {
    bool energyComplete = true;
    bool powerComplete = true;
 
-   int64_t totalRemain = 0;
-   int64_t totalFull = 0;
-   int64_t totalPower = 0;
+   int64_t totalRemain = 0;     /* µWh */
+   int64_t totalFull = 0;       /* µWh */
+   int64_t totalPower = 0;      /* µW */
 
    for (int u = 0; u < units; u++) {
       union acpi_battery_ioctl_arg bixArg = { .unit = u };
@@ -491,8 +491,7 @@ void Platform_getBattery(BatteryInfo* info) {
 
       if (haveBatteryEnergyCurr && haveBatteryEnergyFull && batteryEnergyFull > 0) {
          /* Clamp curr <= full per battery (firmware can report cap > lfcap). */
-         int64_t clampedCurr = batteryEnergyCurr > batteryEnergyFull ? batteryEnergyFull : batteryEnergyCurr;
-         totalRemain += clampedCurr;
+         totalRemain += MINIMUM(batteryEnergyCurr, batteryEnergyFull);
          totalFull += batteryEnergyFull;
          haveTotalRemain = true;
          haveTotalFull = true;

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -474,8 +474,13 @@ static void getAcpiBatteries(BatteryInfo* info) {
    if (fd == -1)
       return;
 
-   if (units > ACPI_MAX_BATTERIES)
-      units = ACPI_MAX_BATTERIES;
+   /* Refuse to publish a partial aggregate when the firmware reports
+    * more batteries than the fixed buffer holds; the fallback path
+    * (hw.acpi.battery.life) still runs after this returns. */
+   if (units > ACPI_MAX_BATTERIES) {
+      close(fd);
+      return;
+   }
 
    BatteryRaw raws[ACPI_MAX_BATTERIES];
    size_t nbat = 0;

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -16,7 +16,6 @@ in the source distribution for its full text.
 #include <stdlib.h>
 #include <time.h>
 #include <unistd.h>
-#include <dev/acpica/acpiio.h>
 #include <net/if.h>
 #include <net/if_mib.h>
 #include <sys/_types.h>
@@ -28,6 +27,9 @@ in the source distribution for its full text.
 #include <sys/sysctl.h>
 #include <sys/time.h>
 #include <sys/types.h>
+/* <dev/acpica/acpiio.h> uses _IOWR macros from <sys/ioccom.h> (pulled in via
+ * <sys/ioctl.h>) but does not include them itself; keep this after <sys/ioctl.h>. */
+#include <dev/acpica/acpiio.h>
 #include <vm/vm_param.h>
 
 #include "CPUMeter.h"
@@ -504,6 +506,13 @@ void Platform_getBattery(BatteryInfo* info) {
                haveBatteryPower = true;
             }
          }
+      }
+
+      /* htop convention: positive = discharging, negative = charging.
+       * ACPI _BST reports rate as a magnitude; charging direction is in bst->state. */
+      if (bst->state != ACPI_BATT_STAT_NOT_PRESENT &&
+          (bst->state & ACPI_BATT_STAT_CHARGING) != 0) {
+         batteryPower = -batteryPower;
       }
 
       if (haveBatteryPower) {

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -481,10 +481,17 @@ void Platform_getBattery(BatteryInfo* info) {
             haveBatteryEnergyCurr = true;
             haveBatteryEnergyFull = true;
          } else {
-            uint32_t batteryVoltage = (bst->volt != ACPI_BATT_UNKNOWN) ? bst->volt : bix->dvol;
-            if (batteryVoltage != ACPI_BATT_UNKNOWN && batteryVoltage != 0) {
-               batteryEnergyCurr = (int64_t) bst->cap * batteryVoltage;
-               batteryEnergyFull = (int64_t) bix->lfcap * batteryVoltage;
+            /* Use design voltage to convert charge into energy: bst->volt
+             * (instantaneous terminal voltage) drifts as the pack charges and
+             * discharges, which would skew batteryEnergyFull over time. Fall
+             * back to the present voltage only if the design value is
+             * missing. */
+            uint32_t referenceVoltage = (bix->dvol != ACPI_BATT_UNKNOWN && bix->dvol != 0)
+                                         ? bix->dvol
+                                         : bst->volt;
+            if (referenceVoltage != ACPI_BATT_UNKNOWN && referenceVoltage != 0) {
+               batteryEnergyCurr = (int64_t) bst->cap * referenceVoltage;
+               batteryEnergyFull = (int64_t) bix->lfcap * referenceVoltage;
                haveBatteryEnergyCurr = true;
                haveBatteryEnergyFull = true;
             }
@@ -507,7 +514,12 @@ void Platform_getBattery(BatteryInfo* info) {
             batteryPower = (int64_t) bst->rate * 1000;
             haveBatteryPower = true;
          } else {
-            uint32_t rateVoltage = (bst->volt != ACPI_BATT_UNKNOWN) ? bst->volt : bix->dvol;
+            /* Instantaneous power P = I * V wants the present terminal
+             * voltage; fall back to design voltage only when it isn't
+             * exposed. */
+            uint32_t rateVoltage = (bst->volt != ACPI_BATT_UNKNOWN && bst->volt != 0)
+                                    ? bst->volt
+                                    : bix->dvol;
 
             if (rateVoltage != ACPI_BATT_UNKNOWN && rateVoltage != 0) {
                batteryPower = (int64_t) bst->rate * rateVoltage;

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -458,6 +458,14 @@ void Platform_getBattery(BatteryInfo* info) {
       const struct acpi_bix* bix = &bixArg.bix;
       const struct acpi_bst* bst = &bstArg.bst;
 
+      /* Empty battery bay: BST can succeed with zeroed cap/rate fields and
+       * the NOT_PRESENT state bit set. Skip it entirely — the kernel's
+       * hw.acpi.battery.life sysctl already accounts for absence, and
+       * counting a missing pack as a 0 Wh battery would drag the aggregate
+       * percent and energy totals down. */
+      if ((bst->state & ACPI_BATT_STAT_NOT_PRESENT) != 0)
+         continue;
+
       bool haveBatteryEnergyCurr = false;
       bool haveBatteryEnergyFull = false;
       bool haveBatteryPower = false;

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -402,8 +402,6 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    return true;
 }
 
-#define ACPI_MAX_BATTERIES 32
-
 /* Read one ACPI battery into canonical SI units. Returns false to skip:
  * NOT_PRESENT bays drop entirely so they don't block the aggregation gate.
  * ioctl failures return true with an empty BatteryRaw so the unit still
@@ -474,15 +472,8 @@ static void getAcpiBatteries(BatteryInfo* info) {
    if (fd == -1)
       return;
 
-   /* Refuse to publish a partial aggregate when the firmware reports
-    * more batteries than the fixed buffer holds; the fallback path
-    * (hw.acpi.battery.life) still runs after this returns. */
-   if (units > ACPI_MAX_BATTERIES) {
-      close(fd);
-      return;
-   }
-
-   BatteryRaw raws[ACPI_MAX_BATTERIES];
+   /* Sized to the firmware-reported unit count; xMalloc never returns NULL. */
+   BatteryRaw* raws = xMalloc((size_t) units * sizeof(BatteryRaw));
    size_t nbat = 0;
    for (int u = 0; u < units; u++) {
       if (parseAcpiBattery(fd, u, &raws[nbat]))
@@ -491,6 +482,7 @@ static void getAcpiBatteries(BatteryInfo* info) {
    close(fd);
 
    Battery_aggregate(raws, nbat, info);
+   free(raws);
 }
 
 void Platform_getBattery(BatteryInfo* info) {

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -31,6 +31,7 @@ in the source distribution for its full text.
 #include <dev/acpica/acpiio.h>
 #include <vm/vm_param.h>
 
+#include "Battery.h"
 #include "CPUMeter.h"
 #include "DateTimeMeter.h"
 #include "DiskIOMeter.h"
@@ -401,25 +402,69 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    return true;
 }
 
-void Platform_getBattery(BatteryInfo* info) {
-   *info = (BatteryInfo) {
-      .ac = AC_ERROR,
-      .percent = NAN,
-      .powerCurr = NAN,
-      .energyCurr = NAN,
-      .energyFull = NAN,
+#define ACPI_MAX_BATTERIES 32
+
+/* Read one ACPI battery into canonical SI units. Returns false to skip:
+ * NOT_PRESENT bays drop entirely so they don't block the aggregation gate.
+ * ioctl failures return true with an empty BatteryRaw so the unit still
+ * counts and forces aggregation incomplete. */
+static bool parseAcpiBattery(int fd, int unit, BatteryRaw* out) {
+   *out = (BatteryRaw){
+      .level = NAN,
+      .energyFull = NAN, .energyNow = NAN,
+      .chargeFull = NAN, .chargeNow = NAN,
+      .voltageNow = NAN, .voltageDesign = NAN,
+      .current = NAN, .power = NAN,
    };
 
-   int life;
-   size_t life_len = sizeof(life);
-   if (sysctlbyname("hw.acpi.battery.life", &life, &life_len, NULL, 0) != -1)
-      info->percent = life;
+   union acpi_battery_ioctl_arg bixArg = { .unit = unit };
+   if (ioctl(fd, ACPIIO_BATT_GET_BIX, &bixArg) == -1)
+      return true;
 
-   int acline;
-   size_t acline_len = sizeof(acline);
-   if (sysctlbyname("hw.acpi.acline", &acline, &acline_len, NULL, 0) != -1)
-      info->ac = (acline == 0) ? AC_ABSENT : AC_PRESENT;
+   union acpi_battery_ioctl_arg bstArg = { .unit = unit };
+   if (ioctl(fd, ACPIIO_BATT_GET_BST, &bstArg) == -1)
+      return true;
 
+   const struct acpi_bix* bix = &bixArg.bix;
+   const struct acpi_bst* bst = &bstArg.bst;
+
+   if (bst->state == ACPI_BATT_STAT_NOT_PRESENT)
+      return false;
+
+   if (bix->dvol != ACPI_BATT_UNKNOWN && bix->dvol != 0)
+      out->voltageDesign = (double) bix->dvol / 1000.0;
+   if (bst->volt != ACPI_BATT_UNKNOWN && bst->volt != 0)
+      out->voltageNow = (double) bst->volt / 1000.0;
+
+   bool unitsAreMW = (bix->units == ACPI_BIX_UNITS_MW);
+
+   if (bix->lfcap != ACPI_BATT_UNKNOWN && bst->cap != ACPI_BATT_UNKNOWN) {
+      if (unitsAreMW) {
+         out->energyFull = (double) bix->lfcap / 1000.0;
+         out->energyNow  = (double) bst->cap   / 1000.0;
+      } else {
+         out->chargeFull = (double) bix->lfcap / 1000.0;
+         out->chargeNow  = (double) bst->cap   / 1000.0;
+      }
+   }
+
+   /* Sign convention: + discharging in htop. CHARGING bit (without DISCHARG)
+    * flips the magnitude; firmware reports rate as unsigned. */
+   bool charging = (bst->state & ACPI_BATT_STAT_DISCHARG) == 0
+                && (bst->state & ACPI_BATT_STAT_CHARGING) != 0;
+   double sign = charging ? -1.0 : 1.0;
+
+   if (bst->rate != ACPI_BATT_UNKNOWN) {
+      if (unitsAreMW)
+         out->power = sign * ((double) bst->rate / 1000.0);
+      else
+         out->current = sign * ((double) bst->rate / 1000.0);
+   }
+
+   return true;
+}
+
+static void getAcpiBatteries(BatteryInfo* info) {
    int units = 0;
    size_t units_len = sizeof(units);
    if (sysctlbyname("hw.acpi.battery.units", &units, &units_len, NULL, 0) == -1 || units <= 0)
@@ -429,124 +474,42 @@ void Platform_getBattery(BatteryInfo* info) {
    if (fd == -1)
       return;
 
-   bool haveTotalRemain = false;
-   bool haveTotalFull = false;
-   bool haveTotalPower = false;
-   bool energyComplete = true;
-   bool powerComplete = true;
+   if (units > ACPI_MAX_BATTERIES)
+      units = ACPI_MAX_BATTERIES;
 
-   int64_t totalRemain = 0;     /* µWh */
-   int64_t totalFull = 0;       /* µWh */
-   int64_t totalPower = 0;      /* µW */
-
+   BatteryRaw raws[ACPI_MAX_BATTERIES];
+   size_t nbat = 0;
    for (int u = 0; u < units; u++) {
-      union acpi_battery_ioctl_arg bixArg = { .unit = u };
-      if (ioctl(fd, ACPIIO_BATT_GET_BIX, &bixArg) == -1) {
-         energyComplete = false;
-         powerComplete = false;
-         continue;
-      }
-
-      union acpi_battery_ioctl_arg bstArg = { .unit = u };
-      if (ioctl(fd, ACPIIO_BATT_GET_BST, &bstArg) == -1) {
-         energyComplete = false;
-         powerComplete = false;
-         continue;
-      }
-
-      const struct acpi_bix* bix = &bixArg.bix;
-      const struct acpi_bst* bst = &bstArg.bst;
-
-      /* NOT_PRESENT is a synthetic _BST mask value, not a single bit. */
-      if (bst->state == ACPI_BATT_STAT_NOT_PRESENT)
-         continue;
-
-      bool haveBatteryEnergyCurr = false;
-      bool haveBatteryEnergyFull = false;
-      bool haveBatteryPower = false;
-
-      int64_t batteryEnergyCurr = 0;
-      int64_t batteryEnergyFull = 0;
-      int64_t batteryPower = 0;
-
-      if (bix->lfcap != ACPI_BATT_UNKNOWN && bst->cap != ACPI_BATT_UNKNOWN) {
-         if (bix->units == ACPI_BIX_UNITS_MW) {
-            batteryEnergyCurr = (int64_t) bst->cap * 1000;
-            batteryEnergyFull = (int64_t) bix->lfcap * 1000;
-            haveBatteryEnergyCurr = true;
-            haveBatteryEnergyFull = true;
-         } else {
-            /* Design voltage for energy reference (bst->volt drifts). */
-            uint32_t referenceVoltage = (bix->dvol != ACPI_BATT_UNKNOWN && bix->dvol != 0)
-                                         ? bix->dvol
-                                         : bst->volt;
-            if (referenceVoltage != ACPI_BATT_UNKNOWN && referenceVoltage != 0) {
-               batteryEnergyCurr = (int64_t) bst->cap * referenceVoltage;
-               batteryEnergyFull = (int64_t) bix->lfcap * referenceVoltage;
-               haveBatteryEnergyCurr = true;
-               haveBatteryEnergyFull = true;
-            }
-         }
-      }
-
-      if (haveBatteryEnergyCurr && haveBatteryEnergyFull && batteryEnergyFull > 0) {
-         /* Clamp curr <= full per battery (firmware can report cap > lfcap). */
-         totalRemain += MINIMUM(batteryEnergyCurr, batteryEnergyFull);
-         totalFull += batteryEnergyFull;
-         haveTotalRemain = true;
-         haveTotalFull = true;
-      } else {
-         energyComplete = false;
-      }
-
-      if (bst->rate != ACPI_BATT_UNKNOWN) {
-         if (bst->rate == 0) {
-            haveBatteryPower = true;
-         } else if (bix->units == ACPI_BIX_UNITS_MW) {
-            batteryPower = (int64_t) bst->rate * 1000;
-            haveBatteryPower = true;
-         } else {
-            /* Present voltage for I*V power. */
-            uint32_t rateVoltage = (bst->volt != ACPI_BATT_UNKNOWN && bst->volt != 0)
-                                    ? bst->volt
-                                    : bix->dvol;
-
-            if (rateVoltage != ACPI_BATT_UNKNOWN && rateVoltage != 0) {
-               batteryPower = (int64_t) bst->rate * rateVoltage;
-               haveBatteryPower = true;
-            }
-         }
-      }
-
-      /* Negate when charging bit set and discharging bit clear; some
-       * firmware sets both, kernel resolves to discharging. */
-      if (bst->state != ACPI_BATT_STAT_NOT_PRESENT &&
-          (bst->state & ACPI_BATT_STAT_DISCHARG) == 0 &&
-          (bst->state & ACPI_BATT_STAT_CHARGING) != 0) {
-         batteryPower = -batteryPower;
-      }
-
-      if (haveBatteryPower) {
-         totalPower += batteryPower;
-         haveTotalPower = true;
-      } else {
-         powerComplete = false;
-      }
+      if (parseAcpiBattery(fd, u, &raws[nbat]))
+         nbat++;
    }
-
    close(fd);
 
-   /* Partial aggregates would contradict hw.acpi.battery.life. */
-   if (energyComplete && haveTotalRemain && haveTotalFull && totalFull > 0) {
-      info->percent = ((double) totalRemain * 100.0) / (double) totalFull;
-      if (totalRemain >= totalFull)
-         info->percent = 100;
+   Battery_aggregate(raws, nbat, info);
+}
 
-      info->energyCurr = (double) totalRemain / 1000000.0;
-      info->energyFull = (double) totalFull / 1000000.0;
-   }
+void Platform_getBattery(BatteryInfo* info) {
+   *info = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+      .powerCurr = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
+   };
 
-   if (powerComplete && haveTotalPower) {
-      info->powerCurr = (double) totalPower / 1000000.0;
+   int acline;
+   size_t acline_len = sizeof(acline);
+   if (sysctlbyname("hw.acpi.acline", &acline, &acline_len, NULL, 0) != -1)
+      info->ac = (acline == 0) ? AC_ABSENT : AC_PRESENT;
+
+   getAcpiBatteries(info);
+
+   /* hw.acpi.battery.life is the ACPI BIOS-aggregated percent; use it only
+    * when the per-battery path could not produce a reading. */
+   if (!isfinite(info->percent)) {
+      int life;
+      size_t life_len = sizeof(life);
+      if (sysctlbyname("hw.acpi.battery.life", &life, &life_len, NULL, 0) != -1)
+         info->percent = life;
    }
 }

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -499,7 +499,12 @@ void Platform_getBattery(BatteryInfo* info) {
       }
 
       if (haveBatteryEnergyCurr && haveBatteryEnergyFull && batteryEnergyFull > 0) {
-         totalRemain += batteryEnergyCurr;
+         /* Clamp curr to full per battery before summing: a quirky firmware
+          * can report bst->cap > bix->lfcap, which would otherwise let
+          * info->energyCurr exceed info->energyFull on the published value
+          * even though the percent gate already caps at 100. */
+         int64_t clampedCurr = batteryEnergyCurr > batteryEnergyFull ? batteryEnergyFull : batteryEnergyCurr;
+         totalRemain += clampedCurr;
          totalFull += batteryEnergyFull;
          haveTotalRemain = true;
          haveTotalFull = true;

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -431,6 +431,8 @@ void Platform_getBattery(BatteryInfo* info) {
    bool haveTotalRemain = false;
    bool haveTotalFull = false;
    bool haveTotalPower = false;
+   bool energyComplete = true;
+   bool powerComplete = true;
 
    int64_t totalRemain = 0;
    int64_t totalFull = 0;
@@ -438,12 +440,18 @@ void Platform_getBattery(BatteryInfo* info) {
 
    for (int u = 0; u < units; u++) {
       union acpi_battery_ioctl_arg bixArg = { .unit = u };
-      if (ioctl(fd, ACPIIO_BATT_GET_BIX, &bixArg) == -1)
+      if (ioctl(fd, ACPIIO_BATT_GET_BIX, &bixArg) == -1) {
+         energyComplete = false;
+         powerComplete = false;
          continue;
+      }
 
       union acpi_battery_ioctl_arg bstArg = { .unit = u };
-      if (ioctl(fd, ACPIIO_BATT_GET_BST, &bstArg) == -1)
+      if (ioctl(fd, ACPIIO_BATT_GET_BST, &bstArg) == -1) {
+         energyComplete = false;
+         powerComplete = false;
          continue;
+      }
 
       const struct acpi_bix* bix = &bixArg.bix;
       const struct acpi_bst* bst = &bstArg.bst;
@@ -478,10 +486,14 @@ void Platform_getBattery(BatteryInfo* info) {
          totalFull += batteryEnergyFull;
          haveTotalRemain = true;
          haveTotalFull = true;
+      } else {
+         energyComplete = false;
       }
 
-      if (bst->rate != ACPI_BATT_UNKNOWN && bst->rate > 0) {
-         if (bix->units == ACPI_BIX_UNITS_MW) {
+      if (bst->rate != ACPI_BATT_UNKNOWN) {
+         if (bst->rate == 0) {
+            haveBatteryPower = true;
+         } else if (bix->units == ACPI_BIX_UNITS_MW) {
             batteryPower = (int64_t) bst->rate * 1000;
             haveBatteryPower = true;
          } else {
@@ -497,12 +509,17 @@ void Platform_getBattery(BatteryInfo* info) {
       if (haveBatteryPower) {
          totalPower += batteryPower;
          haveTotalPower = true;
+      } else {
+         powerComplete = false;
       }
    }
 
    close(fd);
 
-   if (haveTotalRemain && haveTotalFull && totalFull > 0) {
+   /* Only publish aggregate energy/percent when every battery contributed.
+      Otherwise the totals are partial and would contradict the sysctl
+      `hw.acpi.battery.life` value (which already covers all units). */
+   if (energyComplete && haveTotalRemain && haveTotalFull && totalFull > 0) {
       info->percent = ((double) totalRemain * 100.0) / (double) totalFull;
       if (totalRemain >= totalFull)
          info->percent = 100;
@@ -511,7 +528,9 @@ void Platform_getBattery(BatteryInfo* info) {
       info->energyFull = (double) totalFull / 1000000.0;
    }
 
-   if (haveTotalPower) {
+   /* Power total is meaningful only when every battery's rate was readable
+      (a known rate of zero counts as a contribution). */
+   if (powerComplete && haveTotalPower) {
       info->powerCurr = (double) totalPower / 1000000.0;
    }
 }

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -71,7 +71,7 @@ bool Platform_getDiskIO(DiskIOData* data);
 
 bool Platform_getNetworkIO(NetworkIOData* data);
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC);
+void Platform_getBattery(BatteryInfo* info);
 
 static inline void Platform_getHostname(char* buffer, size_t size) {
    Generic_hostname(buffer, size);

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -901,46 +901,103 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
          if (r < 0)
             goto next;
 
-         bool full = false;
-         bool now = false;
+         bool haveBatteryEnergyFull = false;
+         bool haveBatteryEnergyCurr = false;
 
-         double fullCharge = 0;
-         double capacityLevel = NAN;
+         bool haveBatteryChargeFull = false;
+         bool haveBatteryChargeCurr = false;
+
+         uint8_t haveBatteryVoltage = 0; // 0 = no, 1 = min_voltage, 2 = curr_voltage
+         bool haveBatteryLevel = false;
+
+         uint64_t batteryEnergyFull = 0;
+         uint64_t batteryEnergyCurr = 0;
+
+         uint64_t batteryChargeFull = 0;
+         uint64_t batteryChargeCurr = 0;
+
+         uint64_t batteryVoltage = 0;
+         uint64_t batteryLevel = 0;
+
          const char* line;
 
          char* buf = buffer;
          while ((line = strsep(&buf, "\n")) != NULL) {
             char field[100] = {0};
-            int val = 0;
-            if (2 != sscanf(line, "POWER_SUPPLY_%99[^=]=%d", field, &val))
+            int64_t val = 0;
+            if (2 != sscanf(line, "POWER_SUPPLY_%99[^=]=%" SCNd64, field, &val))
                continue;
 
             if (String_eq(field, "CAPACITY")) {
-               capacityLevel = val / 100.0;
+               batteryLevel = val;
+               haveBatteryLevel = true;
                continue;
             }
 
-            if (String_eq(field, "ENERGY_FULL") || String_eq(field, "CHARGE_FULL")) {
-               fullCharge = val;
-               totalFull += fullCharge;
-               full = true;
-               if (now)
-                  break;
+            if (String_eq(field, "ENERGY_FULL")) {
+               batteryEnergyFull = val;
+               haveBatteryEnergyFull = true;
                continue;
             }
 
-            if (String_eq(field, "ENERGY_NOW") || String_eq(field, "CHARGE_NOW")) {
-               totalRemain += val;
-               now = true;
-               if (full)
-                  break;
+            if (String_eq(field, "CHARGE_FULL")) {
+               batteryChargeFull = val;
+               haveBatteryChargeFull = true;
+               continue;
+            }
+
+            if (String_eq(field, "ENERGY_NOW")) {
+               batteryEnergyCurr = val;
+               haveBatteryEnergyCurr = true;
+               continue;
+            }
+
+            if (String_eq(field, "CHARGE_NOW")) {
+               batteryChargeCurr = val;
+               haveBatteryChargeCurr = true;
+               continue;
+            }
+
+            if (haveBatteryVoltage < 1 && String_eq(field, "VOLTAGE_MIN_DESIGN")) {
+               batteryVoltage = val;
+               haveBatteryVoltage = 1;
+               continue;
+            }
+
+            if (haveBatteryVoltage < 2 && String_eq(field, "VOLTAGE_NOW")) {
+               batteryVoltage = val;
+               haveBatteryVoltage = 2;
                continue;
             }
          }
 
-         if (!now && full && isNonnegative(capacityLevel))
-            totalRemain += capacityLevel * fullCharge;
+         if (haveBatteryLevel) {
+            // If we have capacity level but not charge or energy, we infer approximate values
+            if (haveBatteryChargeFull && !haveBatteryChargeCurr) {
+               batteryChargeCurr = batteryChargeFull * batteryLevel / 100.0;
+               haveBatteryChargeCurr = true;
+            }
+            if (haveBatteryEnergyFull && !haveBatteryEnergyCurr) {
+               batteryEnergyCurr = batteryEnergyFull * batteryLevel / 100.0;
+               haveBatteryEnergyCurr = true;
+            }
+         }
 
+         if (haveBatteryEnergyFull && haveBatteryEnergyCurr) {
+            // No need for conversion needed
+         } else if (haveBatteryChargeFull && haveBatteryChargeCurr && haveBatteryVoltage) {
+            // Convert charge to energy using voltage
+            batteryEnergyFull = (batteryChargeFull * batteryVoltage) / 1000000;
+            haveBatteryEnergyFull = true;
+
+            batteryEnergyCurr = (batteryChargeCurr * batteryVoltage) / 1000000;
+            haveBatteryEnergyCurr = true;
+         }
+
+         if (haveBatteryEnergyFull && haveBatteryEnergyCurr && batteryEnergyFull > 0) {
+            totalFull += batteryEnergyFull;
+            totalRemain += batteryEnergyCurr > batteryEnergyFull ? batteryEnergyFull : batteryEnergyCurr;
+         }
       } else if (type == AC) {
          if (info->ac != AC_ERROR)
             goto next;
@@ -964,10 +1021,10 @@ next:
 
    closedir(dir);
 
-   info->percent = totalFull > 0 ? ((double) totalRemain * 100.0) / (double) totalFull : NAN;
    if (totalFull > 0) {
-      info->energyCurr = (double) totalRemain;
-      info->energyFull = (double) totalFull;
+      info->percent = ((double) totalRemain * 100.0) / (double) totalFull;
+      info->energyCurr = (double) totalRemain / 1000000.0;
+      info->energyFull = (double) totalFull / 1000000.0;
    }
 }
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -162,8 +162,10 @@ const unsigned int Platform_numberOfMemoryClasses = ARRAYSIZE(Platform_memoryCla
 
 static enum { BAT_PROC, BAT_SYS, BAT_ERR } Platform_Battery_method = BAT_PROC;
 static time_t Platform_Battery_cacheTime;
-static double Platform_Battery_cachePercent = NAN;
-static ACPresence Platform_Battery_cacheIsOnAC;
+static BatteryInfo Platform_Battery_cache = {
+   .ac = AC_ERROR,
+   .percent = NAN,
+};
 
 #ifdef HAVE_LIBCAP
 static enum CapMode Platform_capabilitiesMode = CAP_MODE_BASIC;
@@ -833,18 +835,18 @@ static ACPresence procAcpiCheck(void) {
    return String_eq(buffer, "on-line") ? AC_PRESENT : AC_ABSENT;
 }
 
-static void Platform_Battery_getProcData(double* percent, ACPresence* isOnAC) {
-   *isOnAC = procAcpiCheck();
-   *percent = AC_ERROR != *isOnAC ? Platform_Battery_getProcBatInfo() : NAN;
+static void Platform_Battery_getProcData(BatteryInfo* info) {
+   info->ac = procAcpiCheck();
+   info->percent = AC_ERROR != info->ac ? Platform_Battery_getProcBatInfo() : NAN;
 }
 
 // ----------------------------------------
 // READ FROM /sys
 // ----------------------------------------
 
-static void Platform_Battery_getSysData(double* percent, ACPresence* isOnAC) {
-   *percent = NAN;
-   *isOnAC = AC_ERROR;
+static void Platform_Battery_getSysData(BatteryInfo* info) {
+   info->percent = NAN;
+   info->ac = AC_ERROR;
 
    DIR* dir = opendir(SYS_POWERSUPPLY_DIR);
    if (!dir)
@@ -936,20 +938,20 @@ static void Platform_Battery_getSysData(double* percent, ACPresence* isOnAC) {
             totalRemain += capacityLevel * fullCharge;
 
       } else if (type == AC) {
-         if (*isOnAC != AC_ERROR)
+         if (info->ac != AC_ERROR)
             goto next;
 
          char buffer[2];
          ssize_t r = Compat_readfileat(entryFd, "online", buffer, sizeof(buffer));
          if (r < 1) {
-            *isOnAC = AC_ERROR;
+            info->ac = AC_ERROR;
             goto next;
          }
 
          if (buffer[0] == '0')
-            *isOnAC = AC_ABSENT;
+            info->ac = AC_ABSENT;
          else if (buffer[0] == '1')
-            *isOnAC = AC_PRESENT;
+            info->ac = AC_PRESENT;
       }
 
 next:
@@ -958,37 +960,39 @@ next:
 
    closedir(dir);
 
-   *percent = totalFull > 0 ? ((double) totalRemain * 100.0) / (double) totalFull : NAN;
+   info->percent = totalFull > 0 ? ((double) totalRemain * 100.0) / (double) totalFull : NAN;
 }
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC) {
+void Platform_getBattery(BatteryInfo* info) {
    time_t now = time(NULL);
    // update battery reading is slow. Update it each 10 seconds only.
    if (now < Platform_Battery_cacheTime + 10) {
-      *percent = Platform_Battery_cachePercent;
-      *isOnAC = Platform_Battery_cacheIsOnAC;
+      *info = Platform_Battery_cache;
       return;
    }
 
+   Platform_Battery_cache = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
+
    if (Platform_Battery_method == BAT_PROC) {
-      Platform_Battery_getProcData(percent, isOnAC);
-      if (!isNonnegative(*percent))
+      Platform_Battery_getProcData(&Platform_Battery_cache);
+      if (!isNonnegative(Platform_Battery_cache.percent))
          Platform_Battery_method = BAT_SYS;
    }
    if (Platform_Battery_method == BAT_SYS) {
-      Platform_Battery_getSysData(percent, isOnAC);
-      if (!isNonnegative(*percent))
+      Platform_Battery_getSysData(&Platform_Battery_cache);
+      if (!isNonnegative(Platform_Battery_cache.percent))
          Platform_Battery_method = BAT_ERR;
    }
-   if (Platform_Battery_method == BAT_ERR) {
-      *percent = NAN;
-      *isOnAC = AC_ERROR;
-   } else {
-      *percent = CLAMP(*percent, 0.0, 100.0);
+   if (Platform_Battery_method != BAT_ERR) {
+      Platform_Battery_cache.percent = CLAMP(Platform_Battery_cache.percent, 0.0, 100.0);
    }
-   Platform_Battery_cachePercent = *percent;
-   Platform_Battery_cacheIsOnAC = *isOnAC;
+
    Platform_Battery_cacheTime = now;
+
+   *info = Platform_Battery_cache;
 }
 
 void Platform_longOptionsUsage(const char* name)

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -165,6 +165,8 @@ static time_t Platform_Battery_cacheTime;
 static BatteryInfo Platform_Battery_cache = {
    .ac = AC_ERROR,
    .percent = NAN,
+   .energyCurr = NAN,
+   .energyFull = NAN,
 };
 
 #ifdef HAVE_LIBCAP
@@ -847,6 +849,8 @@ static void Platform_Battery_getProcData(BatteryInfo* info) {
 static void Platform_Battery_getSysData(BatteryInfo* info) {
    info->percent = NAN;
    info->ac = AC_ERROR;
+   info->energyCurr = NAN;
+   info->energyFull = NAN;
 
    DIR* dir = opendir(SYS_POWERSUPPLY_DIR);
    if (!dir)
@@ -961,6 +965,10 @@ next:
    closedir(dir);
 
    info->percent = totalFull > 0 ? ((double) totalRemain * 100.0) / (double) totalFull : NAN;
+   if (totalFull > 0) {
+      info->energyCurr = (double) totalRemain;
+      info->energyFull = (double) totalFull;
+   }
 }
 
 void Platform_getBattery(BatteryInfo* info) {
@@ -974,6 +982,8 @@ void Platform_getBattery(BatteryInfo* info) {
    Platform_Battery_cache = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 
    if (Platform_Battery_method == BAT_PROC) {

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -165,6 +165,7 @@ static time_t Platform_Battery_cacheTime;
 static BatteryInfo Platform_Battery_cache = {
    .ac = AC_ERROR,
    .percent = NAN,
+   .powerCurr = NAN,
    .energyCurr = NAN,
    .energyFull = NAN,
 };
@@ -849,6 +850,7 @@ static void Platform_Battery_getProcData(BatteryInfo* info) {
 static void Platform_Battery_getSysData(BatteryInfo* info) {
    info->percent = NAN;
    info->ac = AC_ERROR;
+   info->powerCurr = NAN;
    info->energyCurr = NAN;
    info->energyFull = NAN;
 
@@ -858,6 +860,9 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
 
    uint64_t totalFull = 0;
    uint64_t totalRemain = 0;
+   int64_t totalPower = 0;
+
+   bool havePower = false;
 
    const struct dirent* dirEntry;
    while ((dirEntry = readdir(dir))) {
@@ -910,6 +915,9 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
          uint8_t haveBatteryVoltage = 0; // 0 = no, 1 = min_voltage, 2 = curr_voltage
          bool haveBatteryLevel = false;
 
+         bool haveBatteryCurrent = false;
+         bool haveBatteryPower = false;
+
          uint64_t batteryEnergyFull = 0;
          uint64_t batteryEnergyCurr = 0;
 
@@ -918,6 +926,9 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
 
          uint64_t batteryVoltage = 0;
          uint64_t batteryLevel = 0;
+
+         int64_t batteryCurrent = 0;
+         int64_t batteryPower = 0;
 
          const char* line;
 
@@ -969,6 +980,18 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
                haveBatteryVoltage = 2;
                continue;
             }
+
+            if (String_eq(field, "CURRENT_NOW")) {
+               batteryCurrent = val;
+               haveBatteryCurrent = true;
+               continue;
+            }
+
+            if (String_eq(field, "POWER_NOW")) {
+               batteryPower += val;
+               haveBatteryPower = true;
+               continue;
+            }
          }
 
          if (haveBatteryLevel) {
@@ -998,6 +1021,16 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
             totalFull += batteryEnergyFull;
             totalRemain += batteryEnergyCurr > batteryEnergyFull ? batteryEnergyFull : batteryEnergyCurr;
          }
+
+         if (!haveBatteryPower && haveBatteryCurrent && haveBatteryVoltage) {
+            batteryPower = (batteryCurrent * batteryVoltage) / 1000000;
+            haveBatteryPower = true;
+         }
+
+         if (haveBatteryPower) {
+            totalPower += batteryPower;
+            havePower = true;
+         }
       } else if (type == AC) {
          if (info->ac != AC_ERROR)
             goto next;
@@ -1026,6 +1059,10 @@ next:
       info->energyCurr = (double) totalRemain / 1000000.0;
       info->energyFull = (double) totalFull / 1000000.0;
    }
+
+   if (havePower) {
+      info->powerCurr = (double) totalPower / 1000000.0;
+   }
 }
 
 void Platform_getBattery(BatteryInfo* info) {
@@ -1039,6 +1076,7 @@ void Platform_getBattery(BatteryInfo* info) {
    Platform_Battery_cache = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .powerCurr = NAN,
       .energyCurr = NAN,
       .energyFull = NAN,
    };

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -1081,9 +1081,12 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
             batteryContributedCharge = true;
          }
 
-         if (!batteryContributedEnergy && !batteryContributedCharge)
-            goto next;
-
+         /* Count every present battery slot, even one whose data lets us
+          * derive only instantaneous power (POWER_NOW or CURRENT_NOW) and
+          * not energy/charge percent. Skipping such a battery from
+          * unitsTotal would let the surviving packs satisfy
+          * unitsContributingEnergy == unitsTotal and silently publish
+          * partial percent/power as if it represented the whole pack. */
          unitsTotal++;
          if (batteryContributedEnergy)
             unitsContributingEnergy++;

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -1051,7 +1051,7 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
           * the aggregate totals. Counting them toward unitsTotal would
           * prevent the real laptop battery from satisfying the
           * completeness gates and the meter would regress to N/A; adding
-          * their fields to totalEnergy*/totalCharge* would pollute the
+          * their fields to totalEnergyFull/Remain or totalChargeFull/Remain would pollute the
           * pack value while still being skipped from unitsTotal. */
          if (!isPresent || scopeIsDevice)
             goto next;

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -49,6 +49,7 @@ in the source distribution for its full text.
 #include "SysArchMeter.h"
 #include "TasksMeter.h"
 #include "UptimeMeter.h"
+#include "XUtils.h"
 #include "linux/Compat.h"
 #include "linux/IOPriority.h"
 #include "linux/IOPriorityPanel.h"

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -854,6 +854,205 @@ static uint64_t selectVoltage(bool havePref, uint64_t pref, bool haveAlt, uint64
    return 0;
 }
 
+/* Per-battery state parsed from a sysfs power_supply BAT entry's uevent. */
+typedef struct {
+   bool isPresent;             /* PRESENT, defaults true */
+   bool scopeIsDevice;         /* SCOPE=Device peripheral */
+   bool haveStatus;
+   char status[32];            /* STATUS string */
+   bool haveLevel;
+   uint64_t level;             /* CAPACITY 0-100 */
+   bool haveEnergyFull;
+   uint64_t energyFull;        /* µWh */
+   bool haveEnergyCurr;
+   uint64_t energyCurr;        /* µWh */
+   bool haveChargeFull;
+   uint64_t chargeFull;        /* µAh */
+   bool haveChargeCurr;
+   uint64_t chargeCurr;        /* µAh */
+   bool haveVoltageNominal;
+   uint64_t voltageNominal;    /* µV */
+   bool haveVoltageNow;
+   uint64_t voltageNow;        /* µV */
+   bool haveCurrent;
+   int64_t current;            /* µA, signed (kernel convention) */
+   bool havePower;
+   int64_t power;              /* µW; sign normalized via STATUS */
+} SysfsBattery;
+
+typedef struct {
+   uint64_t energyFull;            /* µWh */
+   uint64_t energyRemain;          /* µWh */
+   uint64_t chargeFull;            /* µAh */
+   uint64_t chargeRemain;          /* µAh */
+   int64_t power;                  /* µW, htop sign convention */
+   int unitsTotal;
+   int unitsContributingEnergy;
+   int unitsContributingCharge;
+   int unitsContributingPower;
+} SysfsAggregate;
+
+static void parseSysfsBattery(int entryFd, SysfsBattery* bat) {
+   *bat = (SysfsBattery){ .isPresent = true };
+
+   char buffer[1024];
+   ssize_t r = Compat_readfileat(entryFd, "uevent", buffer, sizeof(buffer));
+   if (r < 0)
+      return;
+
+   const char* line;
+   char* buf = buffer;
+   while ((line = strsep(&buf, "\n")) != NULL) {
+      if (sscanf(line, "POWER_SUPPLY_STATUS=%31s", bat->status) == 1) {
+         bat->haveStatus = true;
+         continue;
+      }
+
+      char scope[32] = {0};
+      if (sscanf(line, "POWER_SUPPLY_SCOPE=%31s", scope) == 1) {
+         if (String_eq(scope, "Device"))
+            bat->scopeIsDevice = true;
+         continue;
+      }
+
+      char field[100] = {0};
+      int64_t val = 0;
+      if (2 != sscanf(line, "POWER_SUPPLY_%99[^=]=%" SCNd64, field, &val))
+         continue;
+
+      if (String_eq(field, "PRESENT")) {
+         bat->isPresent = (val != 0);
+         continue;
+      }
+
+      /* Drivers publish -1 for "unknown". Reject for unsigned fields;
+       * CURRENT_NOW is signed (sign = direction). */
+      if (val < 0 && !String_eq(field, "CURRENT_NOW"))
+         continue;
+
+      if      (String_eq(field, "CAPACITY"))    { bat->level = val;       bat->haveLevel = true; }
+      else if (String_eq(field, "ENERGY_FULL")) { bat->energyFull = val;  bat->haveEnergyFull = true; }
+      else if (String_eq(field, "CHARGE_FULL")) { bat->chargeFull = val;  bat->haveChargeFull = true; }
+      else if (String_eq(field, "ENERGY_NOW"))  { bat->energyCurr = val;  bat->haveEnergyCurr = true; }
+      else if (String_eq(field, "CHARGE_NOW"))  { bat->chargeCurr = val;  bat->haveChargeCurr = true; }
+      else if (!bat->haveVoltageNominal && String_eq(field, "VOLTAGE_MIN_DESIGN"))
+                                                { bat->voltageNominal = val; bat->haveVoltageNominal = true; }
+      else if (!bat->haveVoltageNow && String_eq(field, "VOLTAGE_NOW"))
+                                                { bat->voltageNow = val;  bat->haveVoltageNow = true; }
+      else if (String_eq(field, "CURRENT_NOW")) { bat->current = val;     bat->haveCurrent = true; }
+      else if (String_eq(field, "POWER_NOW"))   { bat->power = val;       bat->havePower = true; }
+   }
+}
+
+static void aggregateSysfsBattery(SysfsBattery* bat, SysfsAggregate* agg) {
+   /* Skip empty bays and SCOPE=Device peripherals before any contribution. */
+   if (!bat->isPresent || bat->scopeIsDevice)
+      return;
+
+   /* Derive missing curr from FULL × level / 100 when only CAPACITY exists. */
+   if (bat->haveLevel) {
+      if (bat->haveChargeFull && !bat->haveChargeCurr) {
+         bat->chargeCurr = bat->chargeFull * bat->level / 100;
+         bat->haveChargeCurr = true;
+      }
+      if (bat->haveEnergyFull && !bat->haveEnergyCurr) {
+         bat->energyCurr = bat->energyFull * bat->level / 100;
+         bat->haveEnergyCurr = true;
+      }
+   }
+
+   /* Charge+voltage batteries contribute to both accumulators.
+    * Design preferred for energy reference. */
+   uint64_t referenceVoltage = selectVoltage(
+      bat->haveVoltageNominal, bat->voltageNominal,
+      bat->haveVoltageNow, bat->voltageNow);
+
+   if (!(bat->haveEnergyFull && bat->haveEnergyCurr)
+         && bat->haveChargeFull && bat->haveChargeCurr
+         && referenceVoltage > 0) {
+      bat->energyFull = (bat->chargeFull * referenceVoltage) / 1000000;
+      bat->haveEnergyFull = true;
+      bat->energyCurr = (bat->chargeCurr * referenceVoltage) / 1000000;
+      bat->haveEnergyCurr = true;
+   }
+
+   bool contribEnergy = false;
+   bool contribCharge = false;
+
+   if (bat->haveEnergyFull && bat->haveEnergyCurr && bat->energyFull > 0) {
+      agg->energyFull += bat->energyFull;
+      agg->energyRemain += MINIMUM(bat->energyCurr, bat->energyFull);
+      contribEnergy = true;
+   }
+
+   if (bat->haveChargeFull && bat->haveChargeCurr && bat->chargeFull > 0) {
+      agg->chargeFull += bat->chargeFull;
+      agg->chargeRemain += MINIMUM(bat->chargeCurr, bat->chargeFull);
+      contribCharge = true;
+   }
+
+   /* Skip true peripherals (no FULL counter, no instantaneous signal).
+    * A system battery with FULL but stale NOW must still count, so
+    * its missing contribution blocks the pack percent gate. */
+   if (!bat->haveEnergyFull && !bat->haveChargeFull
+         && !bat->havePower && !bat->haveCurrent)
+      return;
+
+   agg->unitsTotal++;
+   if (contribEnergy) agg->unitsContributingEnergy++;
+   if (contribCharge) agg->unitsContributingCharge++;
+
+   /* P=I*V: prefer VOLTAGE_NOW; reject 0. I=0 ⇒ 0 W known. */
+   if (!bat->havePower && bat->haveCurrent) {
+      if (bat->current == 0) {
+         bat->power = 0;
+         bat->havePower = true;
+      } else {
+         uint64_t powerVoltage = selectVoltage(
+            bat->haveVoltageNow, bat->voltageNow,
+            bat->haveVoltageNominal, bat->voltageNominal);
+         if (powerVoltage > 0) {
+            bat->power = (bat->current * (int64_t)powerVoltage) / 1000000;
+            bat->havePower = true;
+         }
+      }
+   }
+
+   if (bat->havePower) {
+      /* abs(value) then re-sign from STATUS: portable across drivers
+       * with mixed CURRENT_NOW sign conventions. */
+      if (bat->power < 0)
+         bat->power = -bat->power;
+      if (bat->haveStatus && String_eq(bat->status, "Charging"))
+         bat->power = -bat->power;
+
+      agg->power += bat->power;
+      agg->unitsContributingPower++;
+   }
+}
+
+static void publishSysfsAggregate(const SysfsAggregate* agg, BatteryInfo* info) {
+   /* Every present battery must contribute or the aggregate stays NaN. */
+   bool energyComplete = (agg->unitsTotal > 0) && (agg->unitsContributingEnergy == agg->unitsTotal);
+   bool chargeComplete = (agg->unitsTotal > 0) && (agg->unitsContributingCharge == agg->unitsTotal);
+
+   if (energyComplete && agg->energyFull > 0) {
+      info->energyCurr = (double) agg->energyRemain / 1000000.0;
+      info->energyFull = (double) agg->energyFull / 1000000.0;
+   }
+
+   /* Single-unit accumulator. Mixing µWh+µAh is dimensionally invalid. */
+   if (energyComplete && agg->energyFull > 0) {
+      info->percent = ((double) agg->energyRemain * 100.0) / (double) agg->energyFull;
+   } else if (chargeComplete && agg->chargeFull > 0) {
+      info->percent = ((double) agg->chargeRemain * 100.0) / (double) agg->chargeFull;
+   }
+
+   if (agg->unitsTotal > 0 && agg->unitsContributingPower == agg->unitsTotal) {
+      info->powerCurr = (double) agg->power / 1000000.0;
+   }
+}
+
 static void Platform_Battery_getSysData(BatteryInfo* info) {
    info->percent = NAN;
    info->ac = AC_ERROR;
@@ -865,17 +1064,7 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
    if (!dir)
       return;
 
-   uint64_t totalEnergyFull = 0;     /* µWh, energy-based or charge*voltage */
-   uint64_t totalEnergyRemain = 0;
-   uint64_t totalChargeFull = 0;     /* µAh, raw charge counters */
-   uint64_t totalChargeRemain = 0;
-   int64_t totalPower = 0;           /* µW */
-
-   /* charge+voltage batteries contribute to BOTH accumulators. */
-   int unitsTotal = 0;
-   int unitsContributingEnergy = 0;
-   int unitsContributingCharge = 0;
-   int unitsContributingPower = 0;
+   SysfsAggregate agg = {0};
 
    const struct dirent* dirEntry;
    while ((dirEntry = readdir(dir))) {
@@ -890,7 +1079,7 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
       xSnprintf(entryFd, sizeof(entryFd), SYS_POWERSUPPLY_DIR "/%s", entryName);
 #endif
 
-      enum { AC, BAT } type;
+      enum { AC, BAT, OTHER } type = OTHER;
       if (String_startsWith(entryName, "BAT")) {
          type = BAT;
       } else if (String_startsWith(entryName, "AC")) {
@@ -898,281 +1087,34 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
       } else {
          char buffer[32];
          ssize_t ret = Compat_readfileat(entryFd, "type", buffer, sizeof(buffer));
-         if (ret <= 0)
-            goto next;
-
-         /* drop optional trailing newlines */
-         for (char* buf = &buffer[(size_t)ret - 1]; *buf == '\n'; buf--)
-            *buf = '\0';
-
-         if (String_eq(buffer, "Battery"))
-            type = BAT;
-         else if (String_eq(buffer, "Mains"))
-            type = AC;
-         else
-            goto next;
+         if (ret > 0) {
+            for (char* buf = &buffer[(size_t)ret - 1]; *buf == '\n'; buf--)
+               *buf = '\0';
+            if (String_eq(buffer, "Battery"))
+               type = BAT;
+            else if (String_eq(buffer, "Mains"))
+               type = AC;
+         }
       }
 
       if (type == BAT) {
-         char buffer[1024];
-         ssize_t r = Compat_readfileat(entryFd, "uevent", buffer, sizeof(buffer));
-         if (r < 0)
-            goto next;
-
-         bool haveBatteryEnergyFull = false;
-         bool haveBatteryEnergyCurr = false;
-
-         bool haveBatteryChargeFull = false;
-         bool haveBatteryChargeCurr = false;
-
-         /* Design for energy reference; current for I*V power. */
-         bool haveBatteryVoltageNominal = false;
-         bool haveBatteryVoltageNow = false;
-         bool haveBatteryLevel = false;
-
-         bool haveBatteryCurrent = false;
-         bool haveBatteryPower = false;
-         bool haveBatteryStatus = false;
-
-         /* PRESENT defaults true: built-in batteries often omit the field. */
-         bool isPresent = true;
-         bool scopeIsDevice = false;
-
-         uint64_t batteryEnergyFull = 0;
-         uint64_t batteryEnergyCurr = 0;
-
-         uint64_t batteryChargeFull = 0;
-         uint64_t batteryChargeCurr = 0;
-
-         uint64_t batteryVoltageNominal = 0;
-         uint64_t batteryVoltageNow = 0;
-         uint64_t batteryLevel = 0;
-
-         int64_t batteryCurrent = 0;
-         int64_t batteryPower = 0;
-
-         char batteryStatus[32] = {0};
-
-         const char* line;
-
-         char* buf = buffer;
-         while ((line = strsep(&buf, "\n")) != NULL) {
-            char field[100] = {0};
-
-            /* STATUS is a string ("Discharging", "Charging", "Full", ...), so
-             * scan it separately from the numeric fields below. */
-            if (sscanf(line, "POWER_SUPPLY_STATUS=%31s", batteryStatus) == 1) {
-               haveBatteryStatus = true;
-               continue;
-            }
-
-            /* SCOPE=Device peripherals don't belong in the system pack. */
-            char scope[32] = {0};
-            if (sscanf(line, "POWER_SUPPLY_SCOPE=%31s", scope) == 1) {
-               if (String_eq(scope, "Device"))
-                  scopeIsDevice = true;
-               continue;
-            }
-
-            int64_t val = 0;
-            if (2 != sscanf(line, "POWER_SUPPLY_%99[^=]=%" SCNd64, field, &val))
-               continue;
-
-            if (String_eq(field, "PRESENT")) {
-               isPresent = (val != 0);
-               continue;
-            }
-
-            /* Drivers publish -1 for "unknown". Reject for unsigned fields;
-             * CURRENT_NOW is signed (sign = direction). */
-            if (val < 0 && !String_eq(field, "CURRENT_NOW"))
-               continue;
-
-            if (String_eq(field, "CAPACITY")) {
-               batteryLevel = val;
-               haveBatteryLevel = true;
-               continue;
-            }
-
-            if (String_eq(field, "ENERGY_FULL")) {
-               batteryEnergyFull = val;
-               haveBatteryEnergyFull = true;
-               continue;
-            }
-
-            if (String_eq(field, "CHARGE_FULL")) {
-               batteryChargeFull = val;
-               haveBatteryChargeFull = true;
-               continue;
-            }
-
-            if (String_eq(field, "ENERGY_NOW")) {
-               batteryEnergyCurr = val;
-               haveBatteryEnergyCurr = true;
-               continue;
-            }
-
-            if (String_eq(field, "CHARGE_NOW")) {
-               batteryChargeCurr = val;
-               haveBatteryChargeCurr = true;
-               continue;
-            }
-
-            if (!haveBatteryVoltageNominal && String_eq(field, "VOLTAGE_MIN_DESIGN")) {
-               batteryVoltageNominal = val;
-               haveBatteryVoltageNominal = true;
-               continue;
-            }
-
-            if (!haveBatteryVoltageNow && String_eq(field, "VOLTAGE_NOW")) {
-               batteryVoltageNow = val;
-               haveBatteryVoltageNow = true;
-               continue;
-            }
-
-            if (String_eq(field, "CURRENT_NOW")) {
-               batteryCurrent = val;
-               haveBatteryCurrent = true;
-               continue;
-            }
-
-            if (String_eq(field, "POWER_NOW")) {
-               batteryPower += val;
-               haveBatteryPower = true;
-               continue;
-            }
-         }
-
-         /* Skip empty bays and peripherals before any contribution. */
-         if (!isPresent || scopeIsDevice)
-            goto next;
-
-         if (haveBatteryLevel) {
-            // If we have capacity level but not charge or energy, we infer approximate values
-            if (haveBatteryChargeFull && !haveBatteryChargeCurr) {
-               batteryChargeCurr = batteryChargeFull * batteryLevel / 100.0;
-               haveBatteryChargeCurr = true;
-            }
-            if (haveBatteryEnergyFull && !haveBatteryEnergyCurr) {
-               batteryEnergyCurr = batteryEnergyFull * batteryLevel / 100.0;
-               haveBatteryEnergyCurr = true;
-            }
-         }
-
-         /* Charge+voltage batteries contribute to both accumulators.
-          * Design preferred for energy reference. */
-         uint64_t referenceVoltage = selectVoltage(
-            haveBatteryVoltageNominal, batteryVoltageNominal,
-            haveBatteryVoltageNow, batteryVoltageNow);
-
-         if (!(haveBatteryEnergyFull && haveBatteryEnergyCurr)
-               && haveBatteryChargeFull && haveBatteryChargeCurr
-               && referenceVoltage > 0) {
-            batteryEnergyFull = (batteryChargeFull * referenceVoltage) / 1000000;
-            haveBatteryEnergyFull = true;
-
-            batteryEnergyCurr = (batteryChargeCurr * referenceVoltage) / 1000000;
-            haveBatteryEnergyCurr = true;
-         }
-
-         bool batteryContributedEnergy = false;
-         bool batteryContributedCharge = false;
-
-         if (haveBatteryEnergyFull && haveBatteryEnergyCurr && batteryEnergyFull > 0) {
-            totalEnergyFull += batteryEnergyFull;
-            totalEnergyRemain += MINIMUM(batteryEnergyCurr, batteryEnergyFull);
-            batteryContributedEnergy = true;
-         }
-
-         if (haveBatteryChargeFull && haveBatteryChargeCurr && batteryChargeFull > 0) {
-            totalChargeFull += batteryChargeFull;
-            totalChargeRemain += MINIMUM(batteryChargeCurr, batteryChargeFull);
-            batteryContributedCharge = true;
-         }
-
-         /* Skip true peripherals (no FULL counter, no instantaneous signal).
-          * A system battery with FULL but stale NOW must still count, so
-          * its missing contribution blocks the pack percent gate. */
-         if (!haveBatteryEnergyFull && !haveBatteryChargeFull
-               && !haveBatteryPower && !haveBatteryCurrent)
-            goto next;
-
-         unitsTotal++;
-         if (batteryContributedEnergy)
-            unitsContributingEnergy++;
-         if (batteryContributedCharge)
-            unitsContributingCharge++;
-
-         /* P=I*V: prefer VOLTAGE_NOW; reject 0. I=0 ⇒ 0 W known. */
-         if (!haveBatteryPower && haveBatteryCurrent) {
-            if (batteryCurrent == 0) {
-               batteryPower = 0;
-               haveBatteryPower = true;
-            } else {
-               /* Present voltage preferred for instantaneous I*V. */
-               uint64_t powerVoltage = selectVoltage(
-                  haveBatteryVoltageNow, batteryVoltageNow,
-                  haveBatteryVoltageNominal, batteryVoltageNominal);
-               if (powerVoltage > 0) {
-                  batteryPower = (batteryCurrent * (int64_t)powerVoltage) / 1000000;
-                  haveBatteryPower = true;
-               }
-            }
-         }
-
-         if (haveBatteryPower) {
-            /* abs(value) then re-sign from STATUS: portable across drivers
-             * with mixed CURRENT_NOW sign conventions. */
-            if (batteryPower < 0)
-               batteryPower = -batteryPower;
-            if (haveBatteryStatus && String_eq(batteryStatus, "Charging"))
-               batteryPower = -batteryPower;
-
-            totalPower += batteryPower;
-            unitsContributingPower++;
-         }
-      } else if (type == AC) {
-         if (info->ac != AC_ERROR)
-            goto next;
-
+         SysfsBattery bat;
+         parseSysfsBattery(entryFd, &bat);
+         aggregateSysfsBattery(&bat, &agg);
+      } else if (type == AC && info->ac == AC_ERROR) {
          char buffer[2];
          ssize_t r = Compat_readfileat(entryFd, "online", buffer, sizeof(buffer));
-         if (r < 1) {
-            info->ac = AC_ERROR;
-            goto next;
+         if (r >= 1) {
+            if (buffer[0] == '0') info->ac = AC_ABSENT;
+            else if (buffer[0] == '1') info->ac = AC_PRESENT;
          }
-
-         if (buffer[0] == '0')
-            info->ac = AC_ABSENT;
-         else if (buffer[0] == '1')
-            info->ac = AC_PRESENT;
       }
 
-next:
       Compat_openatArgClose(entryFd);
    }
 
    closedir(dir);
-
-   /* Every present battery must contribute or the aggregate stays NaN. */
-   bool energyComplete = (unitsTotal > 0) && (unitsContributingEnergy == unitsTotal);
-   bool chargeComplete = (unitsTotal > 0) && (unitsContributingCharge == unitsTotal);
-
-   if (energyComplete && totalEnergyFull > 0) {
-      info->energyCurr = (double) totalEnergyRemain / 1000000.0;
-      info->energyFull = (double) totalEnergyFull / 1000000.0;
-   }
-
-   /* Single-unit accumulator. Mixing µWh+µAh is dimensionally invalid. */
-   if (energyComplete && totalEnergyFull > 0) {
-      info->percent = ((double) totalEnergyRemain * 100.0) / (double) totalEnergyFull;
-   } else if (chargeComplete && totalChargeFull > 0) {
-      info->percent = ((double) totalChargeRemain * 100.0) / (double) totalChargeFull;
-   }
-
-   if (unitsTotal > 0 && unitsContributingPower == unitsTotal) {
-      info->powerCurr = (double) totalPower / 1000000.0;
-   }
+   publishSysfsAggregate(&agg, info);
 }
 
 void Platform_getBattery(BatteryInfo* info) {

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -923,7 +923,12 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
          bool haveBatteryChargeFull = false;
          bool haveBatteryChargeCurr = false;
 
-         uint8_t haveBatteryVoltage = 0; // 0 = no, 1 = min_voltage, 2 = curr_voltage
+         /* Track design and instantaneous voltages separately: design voltage is
+          * the stable reference for converting CHARGE_FULL/CHARGE_NOW into an
+          * energy value, while VOLTAGE_NOW is only meaningful for the
+          * instantaneous P=I*V power calculation. */
+         bool haveBatteryVoltageNominal = false;
+         bool haveBatteryVoltageNow = false;
          bool haveBatteryLevel = false;
 
          bool haveBatteryCurrent = false;
@@ -936,7 +941,8 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
          uint64_t batteryChargeFull = 0;
          uint64_t batteryChargeCurr = 0;
 
-         uint64_t batteryVoltage = 0;
+         uint64_t batteryVoltageNominal = 0;
+         uint64_t batteryVoltageNow = 0;
          uint64_t batteryLevel = 0;
 
          int64_t batteryCurrent = 0;
@@ -991,15 +997,15 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
                continue;
             }
 
-            if (haveBatteryVoltage < 1 && String_eq(field, "VOLTAGE_MIN_DESIGN")) {
-               batteryVoltage = val;
-               haveBatteryVoltage = 1;
+            if (!haveBatteryVoltageNominal && String_eq(field, "VOLTAGE_MIN_DESIGN")) {
+               batteryVoltageNominal = val;
+               haveBatteryVoltageNominal = true;
                continue;
             }
 
-            if (haveBatteryVoltage < 2 && String_eq(field, "VOLTAGE_NOW")) {
-               batteryVoltage = val;
-               haveBatteryVoltage = 2;
+            if (!haveBatteryVoltageNow && String_eq(field, "VOLTAGE_NOW")) {
+               batteryVoltageNow = val;
+               haveBatteryVoltageNow = true;
                continue;
             }
 
@@ -1031,13 +1037,22 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
          /* Convert charge+voltage to energy when energy is not directly reported,
           * but keep the raw charge values: a charge+voltage battery contributes
           * to both accumulators so the charge total stays complete on packs that
-          * mix charge+voltage units with charge-only units. */
+          * mix charge+voltage units with charge-only units.
+          *
+          * Use design voltage (VOLTAGE_MIN_DESIGN) as the reference for
+          * FULL/REMAIN energy: VOLTAGE_NOW changes as the pack charges and
+          * discharges, which would make batteryEnergyFull drift over time and
+          * skew multi-battery percent weighting. Fall back to VOLTAGE_NOW only
+          * when no design voltage is exposed -- imperfect, but better than
+          * dropping the battery from the totals entirely. */
          if (!(haveBatteryEnergyFull && haveBatteryEnergyCurr)
-               && haveBatteryChargeFull && haveBatteryChargeCurr && haveBatteryVoltage) {
-            batteryEnergyFull = (batteryChargeFull * batteryVoltage) / 1000000;
+               && haveBatteryChargeFull && haveBatteryChargeCurr
+               && (haveBatteryVoltageNominal || haveBatteryVoltageNow)) {
+            uint64_t referenceVoltage = haveBatteryVoltageNominal ? batteryVoltageNominal : batteryVoltageNow;
+            batteryEnergyFull = (batteryChargeFull * referenceVoltage) / 1000000;
             haveBatteryEnergyFull = true;
 
-            batteryEnergyCurr = (batteryChargeCurr * batteryVoltage) / 1000000;
+            batteryEnergyCurr = (batteryChargeCurr * referenceVoltage) / 1000000;
             haveBatteryEnergyCurr = true;
          }
 
@@ -1065,9 +1080,20 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
          if (batteryContributedCharge)
             unitsContributingCharge++;
 
-         if (!haveBatteryPower && haveBatteryCurrent && haveBatteryVoltage) {
-            batteryPower = (batteryCurrent * (int64_t)batteryVoltage) / 1000000;
-            haveBatteryPower = true;
+         /* Instantaneous power P = I * V wants the present terminal voltage,
+          * so prefer VOLTAGE_NOW here; fall back to design voltage only when
+          * VOLTAGE_NOW is unavailable.
+          *
+          * Guard powerVoltage > 0: the kernel marks VOLTAGE_NOW/MIN_DESIGN as
+          * present even when it can't read the value (publishing 0). Without
+          * the guard we would publish 0 W as a known-good power reading
+          * instead of leaving power unknown. */
+         if (!haveBatteryPower && haveBatteryCurrent && (haveBatteryVoltageNow || haveBatteryVoltageNominal)) {
+            uint64_t powerVoltage = haveBatteryVoltageNow ? batteryVoltageNow : batteryVoltageNominal;
+            if (powerVoltage > 0) {
+               batteryPower = (batteryCurrent * (int64_t)powerVoltage) / 1000000;
+               haveBatteryPower = true;
+            }
          }
 
          if (haveBatteryPower) {

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -928,6 +928,7 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
 
          bool haveBatteryCurrent = false;
          bool haveBatteryPower = false;
+         bool haveBatteryStatus = false;
 
          uint64_t batteryEnergyFull = 0;
          uint64_t batteryEnergyCurr = 0;
@@ -941,11 +942,21 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
          int64_t batteryCurrent = 0;
          int64_t batteryPower = 0;
 
+         char batteryStatus[32] = {0};
+
          const char* line;
 
          char* buf = buffer;
          while ((line = strsep(&buf, "\n")) != NULL) {
             char field[100] = {0};
+
+            /* STATUS is a string ("Discharging", "Charging", "Full", ...), so
+             * scan it separately from the numeric fields below. */
+            if (sscanf(line, "POWER_SUPPLY_STATUS=%31s", batteryStatus) == 1) {
+               haveBatteryStatus = true;
+               continue;
+            }
+
             int64_t val = 0;
             if (2 != sscanf(line, "POWER_SUPPLY_%99[^=]=%" SCNd64, field, &val))
                continue;
@@ -1060,6 +1071,16 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
          }
 
          if (haveBatteryPower) {
+            /* Normalize sign per htop convention: positive = discharging,
+             * negative = charging. POWER_NOW is an unsigned magnitude;
+             * CURRENT_NOW is signed but its sign convention varies by
+             * kernel/driver, so taking the absolute value and re-applying
+             * the sign from STATUS is the only portable approach. */
+            if (batteryPower < 0)
+               batteryPower = -batteryPower;
+            if (haveBatteryStatus && String_eq(batteryStatus, "Charging"))
+               batteryPower = -batteryPower;
+
             totalPower += batteryPower;
             unitsContributingPower++;
          }

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -858,18 +858,22 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
    if (!dir)
       return;
 
-   uint64_t totalEnergyFull = 0;
+   uint64_t totalEnergyFull = 0;     /* µWh, energy-based or charge*voltage */
    uint64_t totalEnergyRemain = 0;
-   uint64_t totalChargeFull = 0;
+   uint64_t totalChargeFull = 0;     /* µAh, raw charge counters */
    uint64_t totalChargeRemain = 0;
-   int64_t totalPower = 0;
+   int64_t totalPower = 0;           /* µW */
 
-   bool havePower = false;
-   /* Tracks whether every contributing battery had energy data (or charge+voltage
-    * convertible to energy). Cleared the first time we fall back to a charge-only
-    * accumulation, so the aggregate energy fields stay NaN rather than publishing
-    * a partial Wh total that silently omits part of the pack. */
-   bool energyComplete = true;
+   /* Per-unit contribution tracking. A battery that exposes only charge counters
+    * with voltage contributes to BOTH accumulators (raw µAh into totalCharge*,
+    * converted µWh into totalEnergy*); a charge-only battery without voltage
+    * contributes only to totalCharge*; a pure-energy battery contributes only
+    * to totalEnergy*. The percent calculation then prefers whichever accumulator
+    * received every battery, avoiding the dimensionally invalid sum of µWh+µAh. */
+   int unitsTotal = 0;
+   int unitsContributingEnergy = 0;
+   int unitsContributingCharge = 0;
+   int unitsContributingPower = 0;
 
    const struct dirent* dirEntry;
    while ((dirEntry = readdir(dir))) {
@@ -1013,10 +1017,12 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
             }
          }
 
-         if (haveBatteryEnergyFull && haveBatteryEnergyCurr) {
-            // No need for conversion needed
-         } else if (haveBatteryChargeFull && haveBatteryChargeCurr && haveBatteryVoltage) {
-            // Convert charge to energy using voltage
+         /* Convert charge+voltage to energy when energy is not directly reported,
+          * but keep the raw charge values: a charge+voltage battery contributes
+          * to both accumulators so the charge total stays complete on packs that
+          * mix charge+voltage units with charge-only units. */
+         if (!(haveBatteryEnergyFull && haveBatteryEnergyCurr)
+               && haveBatteryChargeFull && haveBatteryChargeCurr && haveBatteryVoltage) {
             batteryEnergyFull = (batteryChargeFull * batteryVoltage) / 1000000;
             haveBatteryEnergyFull = true;
 
@@ -1024,17 +1030,29 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
             haveBatteryEnergyCurr = true;
          }
 
+         bool batteryContributedEnergy = false;
+         bool batteryContributedCharge = false;
+
          if (haveBatteryEnergyFull && haveBatteryEnergyCurr && batteryEnergyFull > 0) {
             totalEnergyFull += batteryEnergyFull;
             totalEnergyRemain += batteryEnergyCurr > batteryEnergyFull ? batteryEnergyFull : batteryEnergyCurr;
-         } else if (haveBatteryChargeFull && haveBatteryChargeCurr && batteryChargeFull > 0) {
-            // No voltage available to convert charge to energy; accumulate charge so
-            // that the percentage can still be computed. The energy fields remain
-            // unset for this battery, so the aggregate energy total is now partial.
+            batteryContributedEnergy = true;
+         }
+
+         if (haveBatteryChargeFull && haveBatteryChargeCurr && batteryChargeFull > 0) {
             totalChargeFull += batteryChargeFull;
             totalChargeRemain += batteryChargeCurr > batteryChargeFull ? batteryChargeFull : batteryChargeCurr;
-            energyComplete = false;
+            batteryContributedCharge = true;
          }
+
+         if (!batteryContributedEnergy && !batteryContributedCharge)
+            goto next;
+
+         unitsTotal++;
+         if (batteryContributedEnergy)
+            unitsContributingEnergy++;
+         if (batteryContributedCharge)
+            unitsContributingCharge++;
 
          if (!haveBatteryPower && haveBatteryCurrent && haveBatteryVoltage) {
             batteryPower = (batteryCurrent * batteryVoltage) / 1000000;
@@ -1043,7 +1061,7 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
 
          if (haveBatteryPower) {
             totalPower += batteryPower;
-            havePower = true;
+            unitsContributingPower++;
          }
       } else if (type == AC) {
          if (info->ac != AC_ERROR)
@@ -1068,26 +1086,32 @@ next:
 
    closedir(dir);
 
-   /* Only publish aggregate Wh values when every contributing battery had energy
-    * data (or charge + voltage convertible to energy). On a mixed pack where one
-    * battery exposed only charge counters without voltage, totalEnergyFull omits
-    * that battery and would understate the pack — leave the fields NaN instead. */
+   /* Publish aggregate Wh only when every contributing battery had energy data
+    * (or charge + voltage convertible to energy). On a mixed pack where one
+    * battery exposes only charge counters without voltage, totalEnergyFull
+    * omits that battery and would understate the pack — leave the fields NaN. */
+   bool energyComplete = (unitsTotal > 0) && (unitsContributingEnergy == unitsTotal);
+   bool chargeComplete = (unitsTotal > 0) && (unitsContributingCharge == unitsTotal);
+
    if (energyComplete && totalEnergyFull > 0) {
       info->energyCurr = (double) totalEnergyRemain / 1000000.0;
       info->energyFull = (double) totalEnergyFull / 1000000.0;
    }
 
-   // Compute percentage from whichever accumulator has data. If both are
-   // populated (mixed-battery system where some entries lack voltage), combine
-   // them; this is dimensionally inexact but matches pre-PR behaviour and
-   // keeps the meter functional rather than reporting N/A.
-   uint64_t totalFull = totalEnergyFull + totalChargeFull;
-   uint64_t totalRemain = totalEnergyRemain + totalChargeRemain;
-   if (totalFull > 0) {
-      info->percent = ((double) totalRemain * 100.0) / (double) totalFull;
+   /* Compute percent from a single, dimensionally consistent accumulator: prefer
+    * the energy total when every battery contributed to it, otherwise the charge
+    * total when every battery contributed to it. Summing µWh + µAh would be
+    * dimensionally invalid and voltage-weighted in arbitrary ways on mixed packs. */
+   if (energyComplete && totalEnergyFull > 0) {
+      info->percent = ((double) totalEnergyRemain * 100.0) / (double) totalEnergyFull;
+   } else if (chargeComplete && totalChargeFull > 0) {
+      info->percent = ((double) totalChargeRemain * 100.0) / (double) totalChargeFull;
    }
 
-   if (havePower) {
+   /* Publish aggregate power only when every contributing battery reported
+    * usable power (either POWER_NOW directly, or CURRENT_NOW with voltage).
+    * Otherwise totalPower omits part of the pack and would understate draw. */
+   if (unitsTotal > 0 && unitsContributingPower == unitsTotal) {
       info->powerCurr = (double) totalPower / 1000000.0;
    }
 }

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -956,6 +956,7 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
 
    BatteryRaw raws[SYSFS_MAX_BATTERIES];
    size_t nbat = 0;
+   bool batteryOverflow = false;
 
    const struct dirent* dirEntry;
    while ((dirEntry = readdir(dir))) {
@@ -988,9 +989,12 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
          }
       }
 
-      if (type == BAT && nbat < SYSFS_MAX_BATTERIES) {
-         if (parseSysfsBattery(entryFd, &raws[nbat]))
+      if (type == BAT) {
+         if (nbat >= SYSFS_MAX_BATTERIES) {
+            batteryOverflow = true;
+         } else if (parseSysfsBattery(entryFd, &raws[nbat])) {
             nbat++;
+         }
       } else if (type == AC && info->ac == AC_ERROR) {
          char buffer[2];
          ssize_t r = Compat_readfileat(entryFd, "online", buffer, sizeof(buffer));
@@ -1004,6 +1008,12 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
    }
 
    closedir(dir);
+
+   /* On overflow we cannot publish a partial total; let percent stay NaN
+    * so a stale or under-counted aggregate is not displayed. */
+   if (batteryOverflow)
+      return;
+
    Battery_aggregate(raws, nbat, info);
 }
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -934,8 +934,11 @@ static bool parseSysfsBattery(openat_arg_t entryFd, BatteryRaw* out) {
    /* Reject true peripherals: no FULL counter and no instantaneous signal.
     * A system battery with FULL but stale NOW must still contribute so its
     * missing dimension blocks the pack gate. CAPACITY alone is reported by
-    * peripherals like wireless headsets; reject those too. */
-   if (!(out->energyFull > 0) && !(out->chargeFull > 0)
+    * peripherals like wireless headsets; reject those too. Use isfinite()
+    * so a present battery whose firmware reports FULL=0 still enters the
+    * array and the aggregator's > 0 gate (not parse-time filter) closes
+    * the multi-battery all-or-nothing gate. */
+   if (!isfinite(out->energyFull) && !isfinite(out->chargeFull)
          && !isfinite(out->power) && !isfinite(out->current))
       return false;
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -1044,11 +1044,21 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
           * discharges, which would make batteryEnergyFull drift over time and
           * skew multi-battery percent weighting. Fall back to VOLTAGE_NOW only
           * when no design voltage is exposed -- imperfect, but better than
-          * dropping the battery from the totals entirely. */
+          * dropping the battery from the totals entirely.
+          *
+          * Require the chosen voltage to be > 0: the kernel marks
+          * VOLTAGE_MIN_DESIGN/VOLTAGE_NOW as present even when its driver can't
+          * read the value (publishing 0). Selecting on presence alone would
+          * pick a 0 over a valid sibling and zero out batteryEnergyFull. */
+         uint64_t referenceVoltage = 0;
+         if (haveBatteryVoltageNominal && batteryVoltageNominal > 0)
+            referenceVoltage = batteryVoltageNominal;
+         else if (haveBatteryVoltageNow && batteryVoltageNow > 0)
+            referenceVoltage = batteryVoltageNow;
+
          if (!(haveBatteryEnergyFull && haveBatteryEnergyCurr)
                && haveBatteryChargeFull && haveBatteryChargeCurr
-               && (haveBatteryVoltageNominal || haveBatteryVoltageNow)) {
-            uint64_t referenceVoltage = haveBatteryVoltageNominal ? batteryVoltageNominal : batteryVoltageNow;
+               && referenceVoltage > 0) {
             batteryEnergyFull = (batteryChargeFull * referenceVoltage) / 1000000;
             haveBatteryEnergyFull = true;
 
@@ -1082,17 +1092,32 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
 
          /* Instantaneous power P = I * V wants the present terminal voltage,
           * so prefer VOLTAGE_NOW here; fall back to design voltage only when
-          * VOLTAGE_NOW is unavailable.
+          * VOLTAGE_NOW is unavailable or zero.
           *
-          * Guard powerVoltage > 0: the kernel marks VOLTAGE_NOW/MIN_DESIGN as
-          * present even when it can't read the value (publishing 0). Without
-          * the guard we would publish 0 W as a known-good power reading
-          * instead of leaving power unknown. */
-         if (!haveBatteryPower && haveBatteryCurrent && (haveBatteryVoltageNow || haveBatteryVoltageNominal)) {
-            uint64_t powerVoltage = haveBatteryVoltageNow ? batteryVoltageNow : batteryVoltageNominal;
-            if (powerVoltage > 0) {
-               batteryPower = (batteryCurrent * (int64_t)powerVoltage) / 1000000;
+          * Selection enforces > 0 directly: the kernel marks
+          * VOLTAGE_NOW/MIN_DESIGN as present even when it can't read the
+          * value (publishing 0). Picking on presence alone would publish 0 W
+          * as a known-good power reading instead of leaving power unknown.
+          *
+          * Special case batteryCurrent == 0: I * V = 0 regardless of V, so
+          * idle-on-AC is a known 0 W reading even when no usable voltage is
+          * exposed. Without this short-circuit the powerVoltage > 0 guard
+          * would leave power unknown for a value we can compute exactly. */
+         if (!haveBatteryPower && haveBatteryCurrent) {
+            if (batteryCurrent == 0) {
+               batteryPower = 0;
                haveBatteryPower = true;
+            } else {
+               uint64_t powerVoltage = 0;
+               if (haveBatteryVoltageNow && batteryVoltageNow > 0)
+                  powerVoltage = batteryVoltageNow;
+               else if (haveBatteryVoltageNominal && batteryVoltageNominal > 0)
+                  powerVoltage = batteryVoltageNominal;
+
+               if (powerVoltage > 0) {
+                  batteryPower = (batteryCurrent * (int64_t)powerVoltage) / 1000000;
+                  haveBatteryPower = true;
+               }
             }
          }
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -952,11 +952,11 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
    if (!dir)
       return;
 
-   /* Sized dynamically so the buffer never caps the readdir walk; htop's
-    * xRealloc never returns NULL. */
+   /* Sized dynamically so the buffer never caps the readdir walk; the
+    * xMallocArray / xReallocArray helpers refuse on size_t overflow. */
    size_t cap = 4;
    size_t nbat = 0;
-   BatteryRaw* raws = xMalloc(cap * sizeof(BatteryRaw));
+   BatteryRaw* raws = xMallocArray(cap, sizeof(BatteryRaw));
 
    const struct dirent* dirEntry;
    while ((dirEntry = readdir(dir))) {
@@ -992,7 +992,7 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
       if (type == BAT) {
          if (nbat == cap) {
             cap *= 2;
-            raws = xRealloc(raws, cap * sizeof(BatteryRaw));
+            raws = xReallocArray(raws, cap, sizeof(BatteryRaw));
          }
          if (parseSysfsBattery(entryFd, &raws[nbat]))
             nbat++;

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -992,6 +992,16 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
             }
 
             if (String_eq(field, "CAPACITY")) {
+               /* sysfs CAPACITY is documented 0-100, but the kernel
+                * publishes -1 to signal "unknown" on some drivers.
+                * Assigning a negative val into the unsigned batteryLevel
+                * wraps to a huge value; the haveBatteryLevel fallback
+                * below would then infer a huge fake current charge,
+                * clamp it to full, and publish a misleading 100%. Reject
+                * negative values so haveBatteryLevel stays false and
+                * the meter reports unknown. */
+               if (val < 0)
+                  continue;
                batteryLevel = val;
                haveBatteryLevel = true;
                continue;

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -865,6 +865,11 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
    int64_t totalPower = 0;
 
    bool havePower = false;
+   /* Tracks whether every contributing battery had energy data (or charge+voltage
+    * convertible to energy). Cleared the first time we fall back to a charge-only
+    * accumulation, so the aggregate energy fields stay NaN rather than publishing
+    * a partial Wh total that silently omits part of the pack. */
+   bool energyComplete = true;
 
    const struct dirent* dirEntry;
    while ((dirEntry = readdir(dir))) {
@@ -1025,9 +1030,10 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
          } else if (haveBatteryChargeFull && haveBatteryChargeCurr && batteryChargeFull > 0) {
             // No voltage available to convert charge to energy; accumulate charge so
             // that the percentage can still be computed. The energy fields remain
-            // unset for this battery.
+            // unset for this battery, so the aggregate energy total is now partial.
             totalChargeFull += batteryChargeFull;
             totalChargeRemain += batteryChargeCurr > batteryChargeFull ? batteryChargeFull : batteryChargeCurr;
+            energyComplete = false;
          }
 
          if (!haveBatteryPower && haveBatteryCurrent && haveBatteryVoltage) {
@@ -1062,7 +1068,11 @@ next:
 
    closedir(dir);
 
-   if (totalEnergyFull > 0) {
+   /* Only publish aggregate Wh values when every contributing battery had energy
+    * data (or charge + voltage convertible to energy). On a mixed pack where one
+    * battery exposed only charge counters without voltage, totalEnergyFull omits
+    * that battery and would understate the pack — leave the fields NaN instead. */
+   if (energyComplete && totalEnergyFull > 0) {
       info->energyCurr = (double) totalEnergyRemain / 1000000.0;
       info->energyFull = (double) totalEnergyFull / 1000000.0;
    }

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -848,8 +848,6 @@ static void Platform_Battery_getProcData(BatteryInfo* info) {
 // READ FROM /sys
 // ----------------------------------------
 
-#define SYSFS_MAX_BATTERIES 32
-
 /* Parse one BAT* uevent into canonical units. Returns false to skip:
  * absent bays, SCOPE=Device peripherals, and unreadable entries. A
  * present system battery whose NOW counters are stale still returns
@@ -954,9 +952,11 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
    if (!dir)
       return;
 
-   BatteryRaw raws[SYSFS_MAX_BATTERIES];
+   /* Sized dynamically so the buffer never caps the readdir walk; htop's
+    * xRealloc never returns NULL. */
+   size_t cap = 4;
    size_t nbat = 0;
-   bool batteryOverflow = false;
+   BatteryRaw* raws = xMalloc(cap * sizeof(BatteryRaw));
 
    const struct dirent* dirEntry;
    while ((dirEntry = readdir(dir))) {
@@ -990,11 +990,12 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
       }
 
       if (type == BAT) {
-         if (nbat >= SYSFS_MAX_BATTERIES) {
-            batteryOverflow = true;
-         } else if (parseSysfsBattery(entryFd, &raws[nbat])) {
-            nbat++;
+         if (nbat == cap) {
+            cap *= 2;
+            raws = xRealloc(raws, cap * sizeof(BatteryRaw));
          }
+         if (parseSysfsBattery(entryFd, &raws[nbat]))
+            nbat++;
       } else if (type == AC && info->ac == AC_ERROR) {
          char buffer[2];
          ssize_t r = Compat_readfileat(entryFd, "online", buffer, sizeof(buffer));
@@ -1009,12 +1010,8 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
 
    closedir(dir);
 
-   /* On overflow we cannot publish a partial total; let percent stay NaN
-    * so a stale or under-counted aggregate is not displayed. */
-   if (batteryOverflow)
-      return;
-
    Battery_aggregate(raws, nbat, info);
+   free(raws);
 }
 
 void Platform_getBattery(BatteryInfo* info) {

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -864,12 +864,7 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
    uint64_t totalChargeRemain = 0;
    int64_t totalPower = 0;           /* µW */
 
-   /* Per-unit contribution tracking. A battery that exposes only charge counters
-    * with voltage contributes to BOTH accumulators (raw µAh into totalCharge*,
-    * converted µWh into totalEnergy*); a charge-only battery without voltage
-    * contributes only to totalCharge*; a pure-energy battery contributes only
-    * to totalEnergy*. The percent calculation then prefers whichever accumulator
-    * received every battery, avoiding the dimensionally invalid sum of µWh+µAh. */
+   /* charge+voltage batteries contribute to BOTH accumulators. */
    int unitsTotal = 0;
    int unitsContributingEnergy = 0;
    int unitsContributingCharge = 0;
@@ -923,10 +918,7 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
          bool haveBatteryChargeFull = false;
          bool haveBatteryChargeCurr = false;
 
-         /* Track design and instantaneous voltages separately: design voltage is
-          * the stable reference for converting CHARGE_FULL/CHARGE_NOW into an
-          * energy value, while VOLTAGE_NOW is only meaningful for the
-          * instantaneous P=I*V power calculation. */
+         /* Design for energy reference; current for I*V power. */
          bool haveBatteryVoltageNominal = false;
          bool haveBatteryVoltageNow = false;
          bool haveBatteryLevel = false;
@@ -935,13 +927,7 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
          bool haveBatteryPower = false;
          bool haveBatteryStatus = false;
 
-         /* Skip filters: an empty bay reports POWER_SUPPLY_PRESENT=0, and
-          * peripheral batteries (e.g. wireless mouse, headset) report
-          * POWER_SUPPLY_SCOPE=Device rather than System. Counting them as
-          * required contributors would suppress the real laptop battery's
-          * percent because they cannot satisfy unitsContributingEnergy ==
-          * unitsTotal. PRESENT defaults to true: built-in laptop batteries
-          * frequently omit the field entirely. */
+         /* PRESENT defaults true: built-in batteries often omit the field. */
          bool isPresent = true;
          bool scopeIsDevice = false;
 
@@ -973,8 +959,7 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
                continue;
             }
 
-            /* SCOPE is a string ("System" or "Device"). Only system-scope
-             * batteries belong in the laptop pack aggregate. */
+            /* SCOPE=Device peripherals don't belong in the system pack. */
             char scope[32] = {0};
             if (sscanf(line, "POWER_SUPPLY_SCOPE=%31s", scope) == 1) {
                if (String_eq(scope, "Device"))
@@ -991,19 +976,8 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
                continue;
             }
 
-            /* Reject negative sysfs values for fields that are documented
-             * as unsigned. The kernel publishes -1 on some drivers to
-             * mean "unknown"; treating that as a magnitude would produce
-             * astronomical wrapped values for uint64_t destinations and
-             * a misleading near-zero power reading for POWER_NOW (which
-             * the kernel ABI documents as an unsigned magnitude — see
-             * Documentation/ABI/testing/sysfs-class-power).
-             *
-             * Only CURRENT_NOW is signed: its sign carries the kernel's
-             * charge/discharge direction (convention varies by driver,
-             * but the sign is meaningful). Exempt CURRENT_NOW from the
-             * negative-rejection so its native sign reaches the abs +
-             * STATUS-based sign normalization below. */
+            /* Drivers publish -1 for "unknown". Reject for unsigned fields;
+             * CURRENT_NOW is signed (sign = direction). */
             if (val < 0 && !String_eq(field, "CURRENT_NOW"))
                continue;
 
@@ -1062,13 +1036,7 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
             }
          }
 
-         /* Skip empty bays (PRESENT=0) and peripheral batteries
-          * (SCOPE=Device, e.g. wireless mouse) BEFORE any contribution to
-          * the aggregate totals. Counting them toward unitsTotal would
-          * prevent the real laptop battery from satisfying the
-          * completeness gates and the meter would regress to N/A; adding
-          * their fields to totalEnergyFull/Remain or totalChargeFull/Remain would pollute the
-          * pack value while still being skipped from unitsTotal. */
+         /* Skip empty bays and peripherals before any contribution. */
          if (!isPresent || scopeIsDevice)
             goto next;
 
@@ -1084,22 +1052,9 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
             }
          }
 
-         /* Convert charge+voltage to energy when energy is not directly reported,
-          * but keep the raw charge values: a charge+voltage battery contributes
-          * to both accumulators so the charge total stays complete on packs that
-          * mix charge+voltage units with charge-only units.
-          *
-          * Use design voltage (VOLTAGE_MIN_DESIGN) as the reference for
-          * FULL/REMAIN energy: VOLTAGE_NOW changes as the pack charges and
-          * discharges, which would make batteryEnergyFull drift over time and
-          * skew multi-battery percent weighting. Fall back to VOLTAGE_NOW only
-          * when no design voltage is exposed -- imperfect, but better than
-          * dropping the battery from the totals entirely.
-          *
-          * Require the chosen voltage to be > 0: the kernel marks
-          * VOLTAGE_MIN_DESIGN/VOLTAGE_NOW as present even when its driver can't
-          * read the value (publishing 0). Selecting on presence alone would
-          * pick a 0 over a valid sibling and zero out batteryEnergyFull. */
+         /* Charge+voltage batteries contribute to both accumulators.
+          * Design voltage preferred; reject 0 (sysfs reports present
+          * fields with 0 value when the driver can't read them). */
          uint64_t referenceVoltage = 0;
          if (haveBatteryVoltageNominal && batteryVoltageNominal > 0)
             referenceVoltage = batteryVoltageNominal;
@@ -1131,47 +1086,20 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
             batteryContributedCharge = true;
          }
 
-         /* Distinguish "peripheral / unused slot" from "system battery
-          * with stale data". A peripheral (e.g. wireless mouse) typically
-          * exposes only CAPACITY and reports no FULL counters and no
-          * instantaneous power — skipping it lets the laptop pack's
-          * completeness gates pass. A system battery whose CAPACITY=-1
-          * (kernel quirk) also leaves batteryContributedEnergy/Charge
-          * false, but it DOES expose ENERGY_FULL/CHARGE_FULL — that
-          * battery must count toward unitsTotal so its missing
-          * contribution blocks the pack-level percent gate.
-          *
-          * Skip iff none of FULL counters, instantaneous power, or
-          * instantaneous current are present: a true peripheral. */
+         /* Skip true peripherals (no FULL counter, no instantaneous signal).
+          * A system battery with FULL but stale NOW must still count, so
+          * its missing contribution blocks the pack percent gate. */
          if (!haveBatteryEnergyFull && !haveBatteryChargeFull
                && !haveBatteryPower && !haveBatteryCurrent)
             goto next;
 
-         /* Count every present system battery slot, even one whose data
-          * lets us derive only instantaneous power (POWER_NOW or
-          * CURRENT_NOW) and not energy/charge percent. Skipping such a
-          * battery from unitsTotal would let the surviving packs satisfy
-          * unitsContributingEnergy == unitsTotal and silently publish
-          * partial percent/power as if it represented the whole pack. */
          unitsTotal++;
          if (batteryContributedEnergy)
             unitsContributingEnergy++;
          if (batteryContributedCharge)
             unitsContributingCharge++;
 
-         /* Instantaneous power P = I * V wants the present terminal voltage,
-          * so prefer VOLTAGE_NOW here; fall back to design voltage only when
-          * VOLTAGE_NOW is unavailable or zero.
-          *
-          * Selection enforces > 0 directly: the kernel marks
-          * VOLTAGE_NOW/MIN_DESIGN as present even when it can't read the
-          * value (publishing 0). Picking on presence alone would publish 0 W
-          * as a known-good power reading instead of leaving power unknown.
-          *
-          * Special case batteryCurrent == 0: I * V = 0 regardless of V, so
-          * idle-on-AC is a known 0 W reading even when no usable voltage is
-          * exposed. Without this short-circuit the powerVoltage > 0 guard
-          * would leave power unknown for a value we can compute exactly. */
+         /* P=I*V: prefer VOLTAGE_NOW; reject 0. I=0 ⇒ 0 W known. */
          if (!haveBatteryPower && haveBatteryCurrent) {
             if (batteryCurrent == 0) {
                batteryPower = 0;
@@ -1191,11 +1119,8 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
          }
 
          if (haveBatteryPower) {
-            /* Normalize sign per htop convention: positive = discharging,
-             * negative = charging. POWER_NOW is an unsigned magnitude;
-             * CURRENT_NOW is signed but its sign convention varies by
-             * kernel/driver, so taking the absolute value and re-applying
-             * the sign from STATUS is the only portable approach. */
+            /* abs(value) then re-sign from STATUS: portable across drivers
+             * with mixed CURRENT_NOW sign conventions. */
             if (batteryPower < 0)
                batteryPower = -batteryPower;
             if (haveBatteryStatus && String_eq(batteryStatus, "Charging"))
@@ -1227,10 +1152,7 @@ next:
 
    closedir(dir);
 
-   /* Publish aggregate Wh only when every contributing battery had energy data
-    * (or charge + voltage convertible to energy). On a mixed pack where one
-    * battery exposes only charge counters without voltage, totalEnergyFull
-    * omits that battery and would understate the pack — leave the fields NaN. */
+   /* Every present battery must contribute or the aggregate stays NaN. */
    bool energyComplete = (unitsTotal > 0) && (unitsContributingEnergy == unitsTotal);
    bool chargeComplete = (unitsTotal > 0) && (unitsContributingCharge == unitsTotal);
 
@@ -1239,19 +1161,13 @@ next:
       info->energyFull = (double) totalEnergyFull / 1000000.0;
    }
 
-   /* Compute percent from a single, dimensionally consistent accumulator: prefer
-    * the energy total when every battery contributed to it, otherwise the charge
-    * total when every battery contributed to it. Summing µWh + µAh would be
-    * dimensionally invalid and voltage-weighted in arbitrary ways on mixed packs. */
+   /* Single-unit accumulator. Mixing µWh+µAh is dimensionally invalid. */
    if (energyComplete && totalEnergyFull > 0) {
       info->percent = ((double) totalEnergyRemain * 100.0) / (double) totalEnergyFull;
    } else if (chargeComplete && totalChargeFull > 0) {
       info->percent = ((double) totalChargeRemain * 100.0) / (double) totalChargeFull;
    }
 
-   /* Publish aggregate power only when every contributing battery reported
-    * usable power (either POWER_NOW directly, or CURRENT_NOW with voltage).
-    * Otherwise totalPower omits part of the pack and would understate draw. */
    if (unitsTotal > 0 && unitsContributingPower == unitsTotal) {
       info->powerCurr = (double) totalPower / 1000000.0;
    }

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -991,17 +991,21 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
                continue;
             }
 
+            /* Reject negative sysfs values for the unsigned uint64_t
+             * accumulators below. The kernel publishes -1 on some drivers
+             * to mean "unknown" (CAPACITY is the documented case, others
+             * are quirks). Storing a negative val into an unsigned variable
+             * wraps to a huge value; the downstream `> 0` gates pass
+             * (huge unsigned > 0), and the published percent / energyCurr /
+             * energyFull become astronomical. Treat negative as
+             * "field absent". batteryCurrent and batteryPower are int64_t
+             * so they handle negatives natively and skip this filter. */
+            if (val < 0
+                  && !String_eq(field, "CURRENT_NOW")
+                  && !String_eq(field, "POWER_NOW"))
+               continue;
+
             if (String_eq(field, "CAPACITY")) {
-               /* sysfs CAPACITY is documented 0-100, but the kernel
-                * publishes -1 to signal "unknown" on some drivers.
-                * Assigning a negative val into the unsigned batteryLevel
-                * wraps to a huge value; the haveBatteryLevel fallback
-                * below would then infer a huge fake current charge,
-                * clamp it to full, and publish a misleading 100%. Reject
-                * negative values so haveBatteryLevel stays false and
-                * the meter reports unknown. */
-               if (val < 0)
-                  continue;
                batteryLevel = val;
                haveBatteryLevel = true;
                continue;

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -23,6 +23,7 @@ in the source distribution for its full text.
 #include <unistd.h>
 #include <sys/sysmacros.h>
 
+#include "Battery.h"
 #include "BatteryMeter.h"
 #include "CPUMeter.h"
 #include "DateTimeMeter.h"
@@ -847,71 +848,47 @@ static void Platform_Battery_getProcData(BatteryInfo* info) {
 // READ FROM /sys
 // ----------------------------------------
 
-/* Pick the first present, positive voltage; 0 means "no usable voltage". */
-static uint64_t selectVoltage(bool havePref, uint64_t pref, bool haveAlt, uint64_t alt) {
-   if (havePref && pref > 0) return pref;
-   if (haveAlt && alt > 0) return alt;
-   return 0;
-}
+#define SYSFS_MAX_BATTERIES 32
 
-/* Per-battery state parsed from a sysfs power_supply BAT entry's uevent. */
-typedef struct {
-   bool isPresent;             /* PRESENT, defaults true */
-   bool scopeIsDevice;         /* SCOPE=Device peripheral */
-   bool haveStatus;
-   char status[32];            /* STATUS string */
-   bool haveLevel;
-   uint64_t level;             /* CAPACITY 0-100 */
-   bool haveEnergyFull;
-   uint64_t energyFull;        /* µWh */
-   bool haveEnergyCurr;
-   uint64_t energyCurr;        /* µWh */
-   bool haveChargeFull;
-   uint64_t chargeFull;        /* µAh */
-   bool haveChargeCurr;
-   uint64_t chargeCurr;        /* µAh */
-   bool haveVoltageNominal;
-   uint64_t voltageNominal;    /* µV */
-   bool haveVoltageNow;
-   uint64_t voltageNow;        /* µV */
-   bool haveCurrent;
-   int64_t current;            /* µA, signed (kernel convention) */
-   bool havePower;
-   int64_t power;              /* µW; sign normalized via STATUS */
-} SysfsBattery;
-
-typedef struct {
-   uint64_t energyFull;            /* µWh */
-   uint64_t energyRemain;          /* µWh */
-   uint64_t chargeFull;            /* µAh */
-   uint64_t chargeRemain;          /* µAh */
-   int64_t power;                  /* µW, htop sign convention */
-   int unitsTotal;
-   int unitsContributingEnergy;
-   int unitsContributingCharge;
-   int unitsContributingPower;
-} SysfsAggregate;
-
-static void parseSysfsBattery(openat_arg_t entryFd, SysfsBattery* bat) {
-   *bat = (SysfsBattery){ .isPresent = true };
+/* Parse one BAT* uevent into canonical units. Returns false to skip:
+ * absent bays, SCOPE=Device peripherals, and unreadable entries. A
+ * present system battery whose NOW counters are stale still returns
+ * true so it can block the all-or-nothing aggregation gate. */
+static bool parseSysfsBattery(openat_arg_t entryFd, BatteryRaw* out) {
+   *out = (BatteryRaw){
+      .level = NAN,
+      .energyFull = NAN, .energyNow = NAN,
+      .chargeFull = NAN, .chargeNow = NAN,
+      .voltageNow = NAN, .voltageDesign = NAN,
+      .current = NAN, .power = NAN,
+   };
 
    char buffer[1024];
    ssize_t r = Compat_readfileat(entryFd, "uevent", buffer, sizeof(buffer));
    if (r < 0)
-      return;
+      return false;
+
+   bool isPresent = true;
+   bool scopeIsDevice = false;
+   char status[32] = {0};
+   bool haveStatus = false;
+   int64_t rawCurrent = 0;
+   bool haveCurrent = false;
+   int64_t rawPower = 0;
+   bool havePower = false;
 
    const char* line;
    char* buf = buffer;
    while ((line = strsep(&buf, "\n")) != NULL) {
-      if (sscanf(line, "POWER_SUPPLY_STATUS=%31s", bat->status) == 1) {
-         bat->haveStatus = true;
+      if (sscanf(line, "POWER_SUPPLY_STATUS=%31s", status) == 1) {
+         haveStatus = true;
          continue;
       }
 
       char scope[32] = {0};
       if (sscanf(line, "POWER_SUPPLY_SCOPE=%31s", scope) == 1) {
          if (String_eq(scope, "Device"))
-            bat->scopeIsDevice = true;
+            scopeIsDevice = true;
          continue;
       }
 
@@ -921,7 +898,7 @@ static void parseSysfsBattery(openat_arg_t entryFd, SysfsBattery* bat) {
          continue;
 
       if (String_eq(field, "PRESENT")) {
-         bat->isPresent = (val != 0);
+         isPresent = (val != 0);
          continue;
       }
 
@@ -930,127 +907,40 @@ static void parseSysfsBattery(openat_arg_t entryFd, SysfsBattery* bat) {
       if (val < 0 && !String_eq(field, "CURRENT_NOW"))
          continue;
 
-      if      (String_eq(field, "CAPACITY"))    { bat->level = val;       bat->haveLevel = true; }
-      else if (String_eq(field, "ENERGY_FULL")) { bat->energyFull = val;  bat->haveEnergyFull = true; }
-      else if (String_eq(field, "CHARGE_FULL")) { bat->chargeFull = val;  bat->haveChargeFull = true; }
-      else if (String_eq(field, "ENERGY_NOW"))  { bat->energyCurr = val;  bat->haveEnergyCurr = true; }
-      else if (String_eq(field, "CHARGE_NOW"))  { bat->chargeCurr = val;  bat->haveChargeCurr = true; }
-      else if (!bat->haveVoltageNominal && String_eq(field, "VOLTAGE_MIN_DESIGN"))
-                                                { bat->voltageNominal = val; bat->haveVoltageNominal = true; }
-      else if (!bat->haveVoltageNow && String_eq(field, "VOLTAGE_NOW"))
-                                                { bat->voltageNow = val;  bat->haveVoltageNow = true; }
-      else if (String_eq(field, "CURRENT_NOW")) { bat->current = val;     bat->haveCurrent = true; }
-      else if (String_eq(field, "POWER_NOW"))   { bat->power = val;       bat->havePower = true; }
-   }
-}
-
-static void aggregateSysfsBattery(SysfsBattery* bat, SysfsAggregate* agg) {
-   /* Skip empty bays and SCOPE=Device peripherals before any contribution. */
-   if (!bat->isPresent || bat->scopeIsDevice)
-      return;
-
-   /* Derive missing curr from FULL × level / 100 when only CAPACITY exists. */
-   if (bat->haveLevel) {
-      if (bat->haveChargeFull && !bat->haveChargeCurr) {
-         bat->chargeCurr = bat->chargeFull * bat->level / 100;
-         bat->haveChargeCurr = true;
-      }
-      if (bat->haveEnergyFull && !bat->haveEnergyCurr) {
-         bat->energyCurr = bat->energyFull * bat->level / 100;
-         bat->haveEnergyCurr = true;
-      }
+      if      (String_eq(field, "CAPACITY"))    out->level         = (double) val;
+      else if (String_eq(field, "ENERGY_FULL")) out->energyFull    = (double) val / 1000000.0;
+      else if (String_eq(field, "CHARGE_FULL")) out->chargeFull    = (double) val / 1000000.0;
+      else if (String_eq(field, "ENERGY_NOW"))  out->energyNow     = (double) val / 1000000.0;
+      else if (String_eq(field, "CHARGE_NOW"))  out->chargeNow     = (double) val / 1000000.0;
+      else if (String_eq(field, "VOLTAGE_MIN_DESIGN") && !(out->voltageDesign > 0))
+                                                out->voltageDesign = (double) val / 1000000.0;
+      else if (String_eq(field, "VOLTAGE_NOW")  && !(out->voltageNow > 0))
+                                                out->voltageNow    = (double) val / 1000000.0;
+      else if (String_eq(field, "CURRENT_NOW")) { rawCurrent = val; haveCurrent = true; }
+      else if (String_eq(field, "POWER_NOW"))   { rawPower   = val; havePower   = true; }
    }
 
-   /* Charge+voltage batteries contribute to both accumulators.
-    * Design preferred for energy reference. */
-   uint64_t referenceVoltage = selectVoltage(
-      bat->haveVoltageNominal, bat->voltageNominal,
-      bat->haveVoltageNow, bat->voltageNow);
+   if (!isPresent || scopeIsDevice)
+      return false;
 
-   if (!(bat->haveEnergyFull && bat->haveEnergyCurr)
-         && bat->haveChargeFull && bat->haveChargeCurr
-         && referenceVoltage > 0) {
-      bat->energyFull = (bat->chargeFull * referenceVoltage) / 1000000;
-      bat->haveEnergyFull = true;
-      bat->energyCurr = (bat->chargeCurr * referenceVoltage) / 1000000;
-      bat->haveEnergyCurr = true;
-   }
+   /* abs-then-resign by STATUS: portable across drivers with mixed
+    * CURRENT_NOW polarity. + means discharging in htop's contract. */
+   bool charging = haveStatus && String_eq(status, "Charging");
+   double sign = charging ? -1.0 : 1.0;
+   if (haveCurrent)
+      out->current = sign * fabs((double) rawCurrent / 1000000.0);
+   if (havePower)
+      out->power = sign * fabs((double) rawPower / 1000000.0);
 
-   bool contribEnergy = false;
-   bool contribCharge = false;
+   /* Reject true peripherals: no FULL counter and no instantaneous signal.
+    * A system battery with FULL but stale NOW must still contribute so its
+    * missing dimension blocks the pack gate. CAPACITY alone is reported by
+    * peripherals like wireless headsets; reject those too. */
+   if (!(out->energyFull > 0) && !(out->chargeFull > 0)
+         && !isfinite(out->power) && !isfinite(out->current))
+      return false;
 
-   if (bat->haveEnergyFull && bat->haveEnergyCurr && bat->energyFull > 0) {
-      agg->energyFull += bat->energyFull;
-      agg->energyRemain += MINIMUM(bat->energyCurr, bat->energyFull);
-      contribEnergy = true;
-   }
-
-   if (bat->haveChargeFull && bat->haveChargeCurr && bat->chargeFull > 0) {
-      agg->chargeFull += bat->chargeFull;
-      agg->chargeRemain += MINIMUM(bat->chargeCurr, bat->chargeFull);
-      contribCharge = true;
-   }
-
-   /* Skip true peripherals (no FULL counter, no instantaneous signal).
-    * A system battery with FULL but stale NOW must still count, so
-    * its missing contribution blocks the pack percent gate. */
-   if (!bat->haveEnergyFull && !bat->haveChargeFull
-         && !bat->havePower && !bat->haveCurrent)
-      return;
-
-   agg->unitsTotal++;
-   if (contribEnergy) agg->unitsContributingEnergy++;
-   if (contribCharge) agg->unitsContributingCharge++;
-
-   /* P=I*V: prefer VOLTAGE_NOW; reject 0. I=0 ⇒ 0 W known. */
-   if (!bat->havePower && bat->haveCurrent) {
-      if (bat->current == 0) {
-         bat->power = 0;
-         bat->havePower = true;
-      } else {
-         uint64_t powerVoltage = selectVoltage(
-            bat->haveVoltageNow, bat->voltageNow,
-            bat->haveVoltageNominal, bat->voltageNominal);
-         if (powerVoltage > 0) {
-            bat->power = (bat->current * (int64_t)powerVoltage) / 1000000;
-            bat->havePower = true;
-         }
-      }
-   }
-
-   if (bat->havePower) {
-      /* abs(value) then re-sign from STATUS: portable across drivers
-       * with mixed CURRENT_NOW sign conventions. */
-      if (bat->power < 0)
-         bat->power = -bat->power;
-      if (bat->haveStatus && String_eq(bat->status, "Charging"))
-         bat->power = -bat->power;
-
-      agg->power += bat->power;
-      agg->unitsContributingPower++;
-   }
-}
-
-static void publishSysfsAggregate(const SysfsAggregate* agg, BatteryInfo* info) {
-   /* Every present battery must contribute or the aggregate stays NaN. */
-   bool energyComplete = (agg->unitsTotal > 0) && (agg->unitsContributingEnergy == agg->unitsTotal);
-   bool chargeComplete = (agg->unitsTotal > 0) && (agg->unitsContributingCharge == agg->unitsTotal);
-
-   if (energyComplete && agg->energyFull > 0) {
-      info->energyCurr = (double) agg->energyRemain / 1000000.0;
-      info->energyFull = (double) agg->energyFull / 1000000.0;
-   }
-
-   /* Single-unit accumulator. Mixing µWh+µAh is dimensionally invalid. */
-   if (energyComplete && agg->energyFull > 0) {
-      info->percent = ((double) agg->energyRemain * 100.0) / (double) agg->energyFull;
-   } else if (chargeComplete && agg->chargeFull > 0) {
-      info->percent = ((double) agg->chargeRemain * 100.0) / (double) agg->chargeFull;
-   }
-
-   if (agg->unitsTotal > 0 && agg->unitsContributingPower == agg->unitsTotal) {
-      info->powerCurr = (double) agg->power / 1000000.0;
-   }
+   return true;
 }
 
 static void Platform_Battery_getSysData(BatteryInfo* info) {
@@ -1064,7 +954,8 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
    if (!dir)
       return;
 
-   SysfsAggregate agg = {0};
+   BatteryRaw raws[SYSFS_MAX_BATTERIES];
+   size_t nbat = 0;
 
    const struct dirent* dirEntry;
    while ((dirEntry = readdir(dir))) {
@@ -1097,10 +988,9 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
          }
       }
 
-      if (type == BAT) {
-         SysfsBattery bat;
-         parseSysfsBattery(entryFd, &bat);
-         aggregateSysfsBattery(&bat, &agg);
+      if (type == BAT && nbat < SYSFS_MAX_BATTERIES) {
+         if (parseSysfsBattery(entryFd, &raws[nbat]))
+            nbat++;
       } else if (type == AC && info->ac == AC_ERROR) {
          char buffer[2];
          ssize_t r = Compat_readfileat(entryFd, "online", buffer, sizeof(buffer));
@@ -1114,7 +1004,7 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
    }
 
    closedir(dir);
-   publishSysfsAggregate(&agg, info);
+   Battery_aggregate(raws, nbat, info);
 }
 
 void Platform_getBattery(BatteryInfo* info) {

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -991,18 +991,20 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
                continue;
             }
 
-            /* Reject negative sysfs values for the unsigned uint64_t
-             * accumulators below. The kernel publishes -1 on some drivers
-             * to mean "unknown" (CAPACITY is the documented case, others
-             * are quirks). Storing a negative val into an unsigned variable
-             * wraps to a huge value; the downstream `> 0` gates pass
-             * (huge unsigned > 0), and the published percent / energyCurr /
-             * energyFull become astronomical. Treat negative as
-             * "field absent". batteryCurrent and batteryPower are int64_t
-             * so they handle negatives natively and skip this filter. */
-            if (val < 0
-                  && !String_eq(field, "CURRENT_NOW")
-                  && !String_eq(field, "POWER_NOW"))
+            /* Reject negative sysfs values for fields that are documented
+             * as unsigned. The kernel publishes -1 on some drivers to
+             * mean "unknown"; treating that as a magnitude would produce
+             * astronomical wrapped values for uint64_t destinations and
+             * a misleading near-zero power reading for POWER_NOW (which
+             * the kernel ABI documents as an unsigned magnitude — see
+             * Documentation/ABI/testing/sysfs-class-power).
+             *
+             * Only CURRENT_NOW is signed: its sign carries the kernel's
+             * charge/discharge direction (convention varies by driver,
+             * but the sign is meaningful). Exempt CURRENT_NOW from the
+             * negative-rejection so its native sign reaches the abs +
+             * STATUS-based sign normalization below. */
+            if (val < 0 && !String_eq(field, "CURRENT_NOW"))
                continue;
 
             if (String_eq(field, "CAPACITY")) {

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -1046,6 +1046,16 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
             }
          }
 
+         /* Skip empty bays (PRESENT=0) and peripheral batteries
+          * (SCOPE=Device, e.g. wireless mouse) BEFORE any contribution to
+          * the aggregate totals. Counting them toward unitsTotal would
+          * prevent the real laptop battery from satisfying the
+          * completeness gates and the meter would regress to N/A; adding
+          * their fields to totalEnergy*/totalCharge* would pollute the
+          * pack value while still being skipped from unitsTotal. */
+         if (!isPresent || scopeIsDevice)
+            goto next;
+
          if (haveBatteryLevel) {
             // If we have capacity level but not charge or energy, we infer approximate values
             if (haveBatteryChargeFull && !haveBatteryChargeCurr) {
@@ -1104,14 +1114,6 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
             totalChargeRemain += batteryChargeCurr > batteryChargeFull ? batteryChargeFull : batteryChargeCurr;
             batteryContributedCharge = true;
          }
-
-         /* Skip empty bays (PRESENT=0) and peripheral batteries
-          * (SCOPE=Device, e.g. wireless mouse). Counting them toward
-          * unitsTotal would prevent the real laptop battery from
-          * satisfying the completeness gates and the meter would
-          * regress to N/A. */
-         if (!isPresent || scopeIsDevice)
-            goto next;
 
          /* Count every present system battery slot, even one whose data
           * lets us derive only instantaneous power (POWER_NOW or

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -1066,7 +1066,7 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
             unitsContributingCharge++;
 
          if (!haveBatteryPower && haveBatteryCurrent && haveBatteryVoltage) {
-            batteryPower = (batteryCurrent * batteryVoltage) / 1000000;
+            batteryPower = (batteryCurrent * (int64_t)batteryVoltage) / 1000000;
             haveBatteryPower = true;
          }
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -847,6 +847,13 @@ static void Platform_Battery_getProcData(BatteryInfo* info) {
 // READ FROM /sys
 // ----------------------------------------
 
+/* Pick the first present, positive voltage; 0 means "no usable voltage". */
+static uint64_t selectVoltage(bool havePref, uint64_t pref, bool haveAlt, uint64_t alt) {
+   if (havePref && pref > 0) return pref;
+   if (haveAlt && alt > 0) return alt;
+   return 0;
+}
+
 static void Platform_Battery_getSysData(BatteryInfo* info) {
    info->percent = NAN;
    info->ac = AC_ERROR;
@@ -1053,13 +1060,10 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
          }
 
          /* Charge+voltage batteries contribute to both accumulators.
-          * Design voltage preferred; reject 0 (sysfs reports present
-          * fields with 0 value when the driver can't read them). */
-         uint64_t referenceVoltage = 0;
-         if (haveBatteryVoltageNominal && batteryVoltageNominal > 0)
-            referenceVoltage = batteryVoltageNominal;
-         else if (haveBatteryVoltageNow && batteryVoltageNow > 0)
-            referenceVoltage = batteryVoltageNow;
+          * Design preferred for energy reference. */
+         uint64_t referenceVoltage = selectVoltage(
+            haveBatteryVoltageNominal, batteryVoltageNominal,
+            haveBatteryVoltageNow, batteryVoltageNow);
 
          if (!(haveBatteryEnergyFull && haveBatteryEnergyCurr)
                && haveBatteryChargeFull && haveBatteryChargeCurr
@@ -1076,13 +1080,13 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
 
          if (haveBatteryEnergyFull && haveBatteryEnergyCurr && batteryEnergyFull > 0) {
             totalEnergyFull += batteryEnergyFull;
-            totalEnergyRemain += batteryEnergyCurr > batteryEnergyFull ? batteryEnergyFull : batteryEnergyCurr;
+            totalEnergyRemain += MINIMUM(batteryEnergyCurr, batteryEnergyFull);
             batteryContributedEnergy = true;
          }
 
          if (haveBatteryChargeFull && haveBatteryChargeCurr && batteryChargeFull > 0) {
             totalChargeFull += batteryChargeFull;
-            totalChargeRemain += batteryChargeCurr > batteryChargeFull ? batteryChargeFull : batteryChargeCurr;
+            totalChargeRemain += MINIMUM(batteryChargeCurr, batteryChargeFull);
             batteryContributedCharge = true;
          }
 
@@ -1105,12 +1109,10 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
                batteryPower = 0;
                haveBatteryPower = true;
             } else {
-               uint64_t powerVoltage = 0;
-               if (haveBatteryVoltageNow && batteryVoltageNow > 0)
-                  powerVoltage = batteryVoltageNow;
-               else if (haveBatteryVoltageNominal && batteryVoltageNominal > 0)
-                  powerVoltage = batteryVoltageNominal;
-
+               /* Present voltage preferred for instantaneous I*V. */
+               uint64_t powerVoltage = selectVoltage(
+                  haveBatteryVoltageNow, batteryVoltageNow,
+                  haveBatteryVoltageNominal, batteryVoltageNominal);
                if (powerVoltage > 0) {
                   batteryPower = (batteryCurrent * (int64_t)powerVoltage) / 1000000;
                   haveBatteryPower = true;

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -1129,16 +1129,19 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
             batteryContributedCharge = true;
          }
 
-         /* A battery slot that exposes no usable counter at all (only
-          * CAPACITY level, or a SCOPE-less peripheral) cannot contribute
-          * to any aggregate. Counting it toward unitsTotal would block
-          * the laptop pack's percent/energy/power gates and the meter
-          * would regress to N/A on hosts where such a device sits next
-          * to the real battery. Skip if neither energy/charge nor
-          * instantaneous power is available; power-only batteries
-          * (POWER_NOW or CURRENT_NOW without FULL counters) still
-          * count via the haveBatteryPower / haveBatteryCurrent paths. */
-         if (!batteryContributedEnergy && !batteryContributedCharge
+         /* Distinguish "peripheral / unused slot" from "system battery
+          * with stale data". A peripheral (e.g. wireless mouse) typically
+          * exposes only CAPACITY and reports no FULL counters and no
+          * instantaneous power — skipping it lets the laptop pack's
+          * completeness gates pass. A system battery whose CAPACITY=-1
+          * (kernel quirk) also leaves batteryContributedEnergy/Charge
+          * false, but it DOES expose ENERGY_FULL/CHARGE_FULL — that
+          * battery must count toward unitsTotal so its missing
+          * contribution blocks the pack-level percent gate.
+          *
+          * Skip iff none of FULL counters, instantaneous power, or
+          * instantaneous current are present: a true peripheral. */
+         if (!haveBatteryEnergyFull && !haveBatteryChargeFull
                && !haveBatteryPower && !haveBatteryCurrent)
             goto next;
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -892,7 +892,7 @@ typedef struct {
    int unitsContributingPower;
 } SysfsAggregate;
 
-static void parseSysfsBattery(int entryFd, SysfsBattery* bat) {
+static void parseSysfsBattery(openat_arg_t entryFd, SysfsBattery* bat) {
    *bat = (SysfsBattery){ .isPresent = true };
 
    char buffer[1024];

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -858,8 +858,10 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
    if (!dir)
       return;
 
-   uint64_t totalFull = 0;
-   uint64_t totalRemain = 0;
+   uint64_t totalEnergyFull = 0;
+   uint64_t totalEnergyRemain = 0;
+   uint64_t totalChargeFull = 0;
+   uint64_t totalChargeRemain = 0;
    int64_t totalPower = 0;
 
    bool havePower = false;
@@ -1018,8 +1020,14 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
          }
 
          if (haveBatteryEnergyFull && haveBatteryEnergyCurr && batteryEnergyFull > 0) {
-            totalFull += batteryEnergyFull;
-            totalRemain += batteryEnergyCurr > batteryEnergyFull ? batteryEnergyFull : batteryEnergyCurr;
+            totalEnergyFull += batteryEnergyFull;
+            totalEnergyRemain += batteryEnergyCurr > batteryEnergyFull ? batteryEnergyFull : batteryEnergyCurr;
+         } else if (haveBatteryChargeFull && haveBatteryChargeCurr && batteryChargeFull > 0) {
+            // No voltage available to convert charge to energy; accumulate charge so
+            // that the percentage can still be computed. The energy fields remain
+            // unset for this battery.
+            totalChargeFull += batteryChargeFull;
+            totalChargeRemain += batteryChargeCurr > batteryChargeFull ? batteryChargeFull : batteryChargeCurr;
          }
 
          if (!haveBatteryPower && haveBatteryCurrent && haveBatteryVoltage) {
@@ -1054,10 +1062,19 @@ next:
 
    closedir(dir);
 
+   if (totalEnergyFull > 0) {
+      info->energyCurr = (double) totalEnergyRemain / 1000000.0;
+      info->energyFull = (double) totalEnergyFull / 1000000.0;
+   }
+
+   // Compute percentage from whichever accumulator has data. If both are
+   // populated (mixed-battery system where some entries lack voltage), combine
+   // them; this is dimensionally inexact but matches pre-PR behaviour and
+   // keeps the meter functional rather than reporting N/A.
+   uint64_t totalFull = totalEnergyFull + totalChargeFull;
+   uint64_t totalRemain = totalEnergyRemain + totalChargeRemain;
    if (totalFull > 0) {
       info->percent = ((double) totalRemain * 100.0) / (double) totalFull;
-      info->energyCurr = (double) totalRemain / 1000000.0;
-      info->energyFull = (double) totalFull / 1000000.0;
    }
 
    if (havePower) {

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -1115,6 +1115,19 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
             batteryContributedCharge = true;
          }
 
+         /* A battery slot that exposes no usable counter at all (only
+          * CAPACITY level, or a SCOPE-less peripheral) cannot contribute
+          * to any aggregate. Counting it toward unitsTotal would block
+          * the laptop pack's percent/energy/power gates and the meter
+          * would regress to N/A on hosts where such a device sits next
+          * to the real battery. Skip if neither energy/charge nor
+          * instantaneous power is available; power-only batteries
+          * (POWER_NOW or CURRENT_NOW without FULL counters) still
+          * count via the haveBatteryPower / haveBatteryCurrent paths. */
+         if (!batteryContributedEnergy && !batteryContributedCharge
+               && !haveBatteryPower && !haveBatteryCurrent)
+            goto next;
+
          /* Count every present system battery slot, even one whose data
           * lets us derive only instantaneous power (POWER_NOW or
           * CURRENT_NOW) and not energy/charge percent. Skipping such a

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -935,6 +935,16 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
          bool haveBatteryPower = false;
          bool haveBatteryStatus = false;
 
+         /* Skip filters: an empty bay reports POWER_SUPPLY_PRESENT=0, and
+          * peripheral batteries (e.g. wireless mouse, headset) report
+          * POWER_SUPPLY_SCOPE=Device rather than System. Counting them as
+          * required contributors would suppress the real laptop battery's
+          * percent because they cannot satisfy unitsContributingEnergy ==
+          * unitsTotal. PRESENT defaults to true: built-in laptop batteries
+          * frequently omit the field entirely. */
+         bool isPresent = true;
+         bool scopeIsDevice = false;
+
          uint64_t batteryEnergyFull = 0;
          uint64_t batteryEnergyCurr = 0;
 
@@ -963,9 +973,23 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
                continue;
             }
 
+            /* SCOPE is a string ("System" or "Device"). Only system-scope
+             * batteries belong in the laptop pack aggregate. */
+            char scope[32] = {0};
+            if (sscanf(line, "POWER_SUPPLY_SCOPE=%31s", scope) == 1) {
+               if (String_eq(scope, "Device"))
+                  scopeIsDevice = true;
+               continue;
+            }
+
             int64_t val = 0;
             if (2 != sscanf(line, "POWER_SUPPLY_%99[^=]=%" SCNd64, field, &val))
                continue;
+
+            if (String_eq(field, "PRESENT")) {
+               isPresent = (val != 0);
+               continue;
+            }
 
             if (String_eq(field, "CAPACITY")) {
                batteryLevel = val;
@@ -1081,10 +1105,18 @@ static void Platform_Battery_getSysData(BatteryInfo* info) {
             batteryContributedCharge = true;
          }
 
-         /* Count every present battery slot, even one whose data lets us
-          * derive only instantaneous power (POWER_NOW or CURRENT_NOW) and
-          * not energy/charge percent. Skipping such a battery from
-          * unitsTotal would let the surviving packs satisfy
+         /* Skip empty bays (PRESENT=0) and peripheral batteries
+          * (SCOPE=Device, e.g. wireless mouse). Counting them toward
+          * unitsTotal would prevent the real laptop battery from
+          * satisfying the completeness gates and the meter would
+          * regress to N/A. */
+         if (!isPresent || scopeIsDevice)
+            goto next;
+
+         /* Count every present system battery slot, even one whose data
+          * lets us derive only instantaneous power (POWER_NOW or
+          * CURRENT_NOW) and not energy/charge percent. Skipping such a
+          * battery from unitsTotal would let the surviving packs satisfy
           * unitsContributingEnergy == unitsTotal and silently publish
           * partial percent/power as if it represented the whole pack. */
          unitsTotal++;

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -92,7 +92,7 @@ bool Platform_getDiskIO(DiskIOData* data);
 
 bool Platform_getNetworkIO(NetworkIOData* data);
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC);
+void Platform_getBattery(BatteryInfo* info);
 
 static inline void Platform_getHostname(char* buffer, size_t size) {
    Generic_hostname(buffer, size);

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -446,15 +446,17 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    return true;
 }
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC) {
+void Platform_getBattery(BatteryInfo* info) {
    prop_dictionary_t dict, fields, props;
    prop_object_t device, class;
 
    intmax_t totalCharge = 0;
    intmax_t totalCapacity = 0;
 
-   *percent = NAN;
-   *isOnAC = AC_ERROR;
+   *info = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
 
    int fd = open(_PATH_SYSMON, O_RDONLY);
    if (fd == -1)
@@ -522,11 +524,12 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
          totalCapacity += maxCharge;
       }
 
-      if (isACAdapter && *isOnAC != AC_PRESENT) {
-         *isOnAC = isConnected ? AC_PRESENT : AC_ABSENT;
+      if (isACAdapter && info->ac != AC_PRESENT) {
+         info->ac = isConnected ? AC_PRESENT : AC_ABSENT;
       }
    }
-   *percent = totalCapacity > 0 ? ((double)totalCharge / (double)totalCapacity) * 100.0 : NAN;
+
+   info->percent = totalCapacity > 0 ? ((double)totalCharge / (double)totalCapacity) * 100.0 : NAN;
 
 error:
    if (fd != -1)

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -488,6 +488,11 @@ void Platform_getBattery(BatteryInfo* info) {
       intmax_t isConnected = 0;
       intmax_t curCharge = 0;
       intmax_t maxCharge = 0;
+      intmax_t voltage = 0;
+      intmax_t designVoltage = 0;
+
+      bool haveCharge = false;
+      bool chargeIsAmpHours = false;
 
       while ((fields = prop_object_iterator_next(fieldsIter)) != NULL) {
          props = prop_dictionary_get(fields, "device-properties");
@@ -505,6 +510,7 @@ void Platform_getBattery(BatteryInfo* info) {
          prop_object_t curValue = prop_dictionary_get(fields, "cur-value");
          prop_object_t maxValue = prop_dictionary_get(fields, "max-value");
          prop_object_t descField = prop_dictionary_get(fields, "description");
+         prop_object_t typeField = prop_dictionary_get(fields, "type");
 
          if (descField == NULL || curValue == NULL)
             continue;
@@ -513,17 +519,48 @@ void Platform_getBattery(BatteryInfo* info) {
             isConnected = prop_number_signed_value(curValue);
          } else if (prop_string_equals_string(descField, "present")) {
             isPresent = prop_number_signed_value(curValue);
+         } else if (prop_string_equals_string(descField, "voltage")) {
+            voltage = prop_number_signed_value(curValue);
+         } else if (prop_string_equals_string(descField, "design voltage")) {
+            designVoltage = prop_number_signed_value(curValue);
          } else if (prop_string_equals_string(descField, "charge")) {
             if (maxValue == NULL)
                continue;
             curCharge = prop_number_signed_value(curValue);
             maxCharge = prop_number_signed_value(maxValue);
+            haveCharge = true;
+            chargeIsAmpHours = typeField != NULL &&
+               prop_string_equals_string(typeField, "Ampere hour");
          }
       }
 
       if (isBattery && isPresent) {
-         totalCharge += curCharge;
-         totalCapacity += maxCharge;
+         intmax_t batteryVoltage = (voltage != 0) ? voltage : designVoltage;
+
+         bool haveBatteryCharge = false;
+
+         intmax_t batteryCharge = 0;
+         intmax_t batteryCapacity = 0;
+
+         if (haveCharge) {
+            if (chargeIsAmpHours) {
+               if (batteryVoltage > 0) {
+                  batteryCharge = curCharge * batteryVoltage / 1000000;
+                  batteryCapacity = maxCharge * batteryVoltage / 1000000;
+                  haveBatteryCharge = true;
+               }
+            } else {
+               batteryCharge = curCharge;
+               batteryCapacity = maxCharge;
+               haveBatteryCharge = true;
+            }
+         }
+
+         if (haveBatteryCharge) {
+            totalCharge += batteryCharge;
+            totalCapacity += batteryCapacity;
+         }
+
       }
 
       if (isACAdapter && info->ac != AC_PRESENT) {
@@ -532,9 +569,12 @@ void Platform_getBattery(BatteryInfo* info) {
    }
 
    if (totalCapacity > 0) {
-      info->percent = ((double)totalCharge / (double)totalCapacity) * 100.0;
-      info->energyCurr = (double) totalCharge;
-      info->energyFull = (double) totalCapacity;
+      info->percent = ((double) totalCharge * 100.0) / (double) totalCapacity;
+      if (totalCharge >= totalCapacity)
+         info->percent = 100.0;
+
+      info->energyCurr = (double) totalCharge / 1000000.0;
+      info->energyFull = (double) totalCapacity / 1000000.0;
    }
 
 error:

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -453,9 +453,13 @@ void Platform_getBattery(BatteryInfo* info) {
    intmax_t totalCharge = 0;
    intmax_t totalCapacity = 0;
 
+   bool havePower = false;
+   intmax_t totalPower = 0;
+
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .powerCurr = NAN,
       .energyCurr = NAN,
       .energyFull = NAN,
    };
@@ -488,11 +492,17 @@ void Platform_getBattery(BatteryInfo* info) {
       intmax_t isConnected = 0;
       intmax_t curCharge = 0;
       intmax_t maxCharge = 0;
+      intmax_t chargeRate = 0;
+      intmax_t dischargeRate = 0;
       intmax_t voltage = 0;
       intmax_t designVoltage = 0;
 
       bool haveCharge = false;
+      bool haveChargeRate = false;
+      bool haveDischargeRate = false;
       bool chargeIsAmpHours = false;
+      bool chargeRateIsAmps = false;
+      bool dischargeRateIsAmps = false;
 
       while ((fields = prop_object_iterator_next(fieldsIter)) != NULL) {
          props = prop_dictionary_get(fields, "device-properties");
@@ -531,14 +541,29 @@ void Platform_getBattery(BatteryInfo* info) {
             haveCharge = true;
             chargeIsAmpHours = typeField != NULL &&
                prop_string_equals_string(typeField, "Ampere hour");
+         } else if (prop_string_equals_string(descField, "charge rate")) {
+            chargeRate = prop_number_signed_value(curValue);
+            chargeRateIsAmps = typeField != NULL &&
+               prop_string_equals_string(typeField, "Ampere");
+            haveChargeRate = true;
+         } else if (prop_string_equals_string(descField, "discharge rate")) {
+            dischargeRate = prop_number_signed_value(curValue);
+            dischargeRateIsAmps = typeField != NULL &&
+               prop_string_equals_string(typeField, "Ampere");
+            haveDischargeRate = true;
          }
       }
 
       if (isBattery && isPresent) {
          intmax_t batteryVoltage = (voltage != 0) ? voltage : designVoltage;
 
+         bool haveBatteryChargeRate = false;
+         bool haveBatteryDischargeRate = false;
+
          bool haveBatteryCharge = false;
 
+         intmax_t batteryChargeRate = 0;
+         intmax_t batteryDischargeRate = 0;
          intmax_t batteryCharge = 0;
          intmax_t batteryCapacity = 0;
 
@@ -556,11 +581,39 @@ void Platform_getBattery(BatteryInfo* info) {
             }
          }
 
+         if (haveChargeRate) {
+            if (chargeRateIsAmps) {
+               if (batteryVoltage > 0) {
+                  batteryChargeRate = chargeRate * batteryVoltage / 1000000;
+                  haveBatteryChargeRate = true;
+               }
+            } else {
+               batteryChargeRate = chargeRate;
+               haveBatteryChargeRate = true;
+            }
+         }
+
+         if (haveDischargeRate) {
+            if (dischargeRateIsAmps) {
+               if (batteryVoltage > 0) {
+                  batteryDischargeRate = dischargeRate * batteryVoltage / 1000000;
+                  haveBatteryDischargeRate = true;
+               }
+            } else {
+               batteryDischargeRate = dischargeRate;
+               haveBatteryDischargeRate = true;
+            }
+         }
+
          if (haveBatteryCharge) {
             totalCharge += batteryCharge;
             totalCapacity += batteryCapacity;
          }
 
+         if (haveBatteryChargeRate || haveBatteryDischargeRate) {
+            totalPower += batteryDischargeRate - batteryChargeRate;
+            havePower = true;
+         }
       }
 
       if (isACAdapter && info->ac != AC_PRESENT) {
@@ -575,6 +628,10 @@ void Platform_getBattery(BatteryInfo* info) {
 
       info->energyCurr = (double) totalCharge / 1000000.0;
       info->energyFull = (double) totalCapacity / 1000000.0;
+   }
+
+   if (havePower) {
+      info->powerCurr = (double) totalPower / 1000000.0;
    }
 
 error:

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -456,6 +456,8 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 
    int fd = open(_PATH_SYSMON, O_RDONLY);
@@ -529,7 +531,11 @@ void Platform_getBattery(BatteryInfo* info) {
       }
    }
 
-   info->percent = totalCapacity > 0 ? ((double)totalCharge / (double)totalCapacity) * 100.0 : NAN;
+   if (totalCapacity > 0) {
+      info->percent = ((double)totalCharge / (double)totalCapacity) * 100.0;
+      info->energyCurr = (double) totalCharge;
+      info->energyFull = (double) totalCapacity;
+   }
 
 error:
    if (fd != -1)

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -594,8 +594,7 @@ void Platform_getBattery(BatteryInfo* info) {
             if (chargeIsAmpHours) {
                /* Charge fallback when voltage is unknown. */
                if (maxCharge > 0) {
-                  intmax_t clampedCharge = curCharge > maxCharge ? maxCharge : curCharge;
-                  batteryChargeRemain = clampedCharge;
+                  batteryChargeRemain = MINIMUM(curCharge, maxCharge);
                   batteryChargeFull = maxCharge;
                   batteryContributedCharge = true;
                }
@@ -644,8 +643,7 @@ void Platform_getBattery(BatteryInfo* info) {
          }
 
          if (batteryContributedEnergy) {
-            intmax_t clampedEnergy = batteryEnergyRemain > batteryEnergyFull ? batteryEnergyFull : batteryEnergyRemain;
-            totalEnergyRemain += clampedEnergy;
+            totalEnergyRemain += MINIMUM(batteryEnergyRemain, batteryEnergyFull);
             totalEnergyFull += batteryEnergyFull;
          }
          if (batteryContributedCharge) {

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -447,8 +447,6 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    return true;
 }
 
-#define ENVSYS_MAX_BATTERIES 32
-
 /* envsys reports magnitudes in 10^-6 SI units. Convert when known and
  * non-negative; the kernel uses negative values as an "invalid" sentinel
  * separate from the explicit state="invalid" tag. */
@@ -617,9 +615,10 @@ void Platform_getBattery(BatteryInfo* info) {
       return;
    }
 
-   BatteryRaw raws[ENVSYS_MAX_BATTERIES];
+   /* Sized dynamically; xRealloc never returns NULL. */
+   size_t cap = 4;
    size_t nbat = 0;
-   bool batteryOverflow = false;
+   BatteryRaw* raws = xMalloc(cap * sizeof(BatteryRaw));
 
    prop_object_iterator_t devIter = prop_dictionary_iterator(dict);
    prop_object_t device;
@@ -640,10 +639,11 @@ void Platform_getBattery(BatteryInfo* info) {
       prop_object_iterator_release(fieldsIter);
 
       if (isBattery) {
-         if (nbat >= ENVSYS_MAX_BATTERIES)
-            batteryOverflow = true;
-         else
-            raws[nbat++] = raw;
+         if (nbat == cap) {
+            cap *= 2;
+            raws = xRealloc(raws, cap * sizeof(BatteryRaw));
+         }
+         raws[nbat++] = raw;
       }
 
       /* Invalid connected sensor leaves AC at AC_ERROR. */
@@ -655,9 +655,6 @@ void Platform_getBattery(BatteryInfo* info) {
 
    close(fd);
 
-   /* Refuse partial aggregation on overflow; percent stays NaN. */
-   if (batteryOverflow)
-      return;
-
    Battery_aggregate(raws, nbat, info);
+   free(raws);
 }

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -36,6 +36,7 @@ in the source distribution for its full text.
 #include <sys/time.h>
 #include <sys/types.h>
 
+#include "Battery.h"
 #include "CPUMeter.h"
 #include "DateTimeMeter.h"
 #include "FileDescriptorMeter.h"
@@ -446,23 +447,158 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    return true;
 }
 
+#define ENVSYS_MAX_BATTERIES 32
+
+/* envsys reports magnitudes in 10^-6 SI units. Convert when known and
+ * non-negative; the kernel uses negative values as an "invalid" sentinel
+ * separate from the explicit state="invalid" tag. */
+static double envsysToSI(intmax_t value) {
+   return (value >= 0) ? (double) value / 1000000.0 : NAN;
+}
+
+/* Read sensor fields from a single envsys device into a BatteryRaw.
+ * Returns false to skip non-battery devices and absent batteries. */
+static bool parseEnvsysBattery(prop_object_iterator_t fieldsIter, BatteryRaw* out, bool* isACAdapter, bool* haveConnected, intmax_t* isConnected) {
+   *out = (BatteryRaw){
+      .level = NAN,
+      .energyFull = NAN, .energyNow = NAN,
+      .chargeFull = NAN, .chargeNow = NAN,
+      .voltageNow = NAN, .voltageDesign = NAN,
+      .current = NAN, .power = NAN,
+   };
+   *isACAdapter = false;
+   *haveConnected = false;
+
+   bool isBattery = false;
+   intmax_t isPresent = 1;
+
+   intmax_t curCharge = 0, maxCharge = 0;
+   bool haveCharge = false;
+   bool chargeIsAmpHours = false;
+
+   intmax_t chargeRateMag = 0, dischargeRateMag = 0;
+   bool haveChargeRate = false, haveDischargeRate = false;
+   bool chargeRateIsAmps = false, dischargeRateIsAmps = false;
+
+   prop_object_t fields;
+   while ((fields = prop_object_iterator_next(fieldsIter)) != NULL) {
+      prop_object_t props = prop_dictionary_get(fields, "device-properties");
+      if (props != NULL) {
+         prop_object_t class = prop_dictionary_get(props, "device-class");
+         if (prop_string_equals_string(class, "ac-adapter"))
+            *isACAdapter = true;
+         else if (prop_string_equals_string(class, "battery"))
+            isBattery = true;
+         continue;
+      }
+
+      prop_object_t curValue = prop_dictionary_get(fields, "cur-value");
+      prop_object_t maxValue = prop_dictionary_get(fields, "max-value");
+      prop_object_t descField = prop_dictionary_get(fields, "description");
+      prop_object_t typeField = prop_dictionary_get(fields, "type");
+      prop_object_t stateField = prop_dictionary_get(fields, "state");
+
+      if (descField == NULL || curValue == NULL)
+         continue;
+
+      /* Reject sensors the kernel marks invalid. */
+      if (stateField != NULL && prop_string_equals_string(stateField, "invalid"))
+         continue;
+
+      if (prop_string_equals_string(descField, "connected")) {
+         *isConnected = prop_number_signed_value(curValue);
+         *haveConnected = true;
+      } else if (prop_string_equals_string(descField, "present")) {
+         isPresent = prop_number_signed_value(curValue);
+      } else if (prop_string_equals_string(descField, "voltage")) {
+         out->voltageNow = envsysToSI(prop_number_signed_value(curValue));
+      } else if (prop_string_equals_string(descField, "design voltage")) {
+         out->voltageDesign = envsysToSI(prop_number_signed_value(curValue));
+      } else if (prop_string_equals_string(descField, "charge")) {
+         if (maxValue == NULL)
+            continue;
+         curCharge = prop_number_signed_value(curValue);
+         maxCharge = prop_number_signed_value(maxValue);
+         haveCharge = true;
+         chargeIsAmpHours = typeField != NULL &&
+            prop_string_equals_string(typeField, "Ampere hour");
+      } else if (prop_string_equals_string(descField, "charge rate")) {
+         chargeRateMag = prop_number_signed_value(curValue);
+         chargeRateIsAmps = typeField != NULL &&
+            prop_string_equals_string(typeField, "Ampere");
+         haveChargeRate = true;
+      } else if (prop_string_equals_string(descField, "discharge rate")) {
+         dischargeRateMag = prop_number_signed_value(curValue);
+         dischargeRateIsAmps = typeField != NULL &&
+            prop_string_equals_string(typeField, "Ampere");
+         haveDischargeRate = true;
+      }
+   }
+
+   if (!isBattery || !isPresent)
+      return false;
+
+   /* charge sensor populates one capacity axis; the aggregator derives
+    * energy from charge * voltage when only Ah are known. */
+   if (haveCharge && maxCharge > 0) {
+      if (chargeIsAmpHours) {
+         out->chargeFull = (double) maxCharge / 1000000.0;
+         out->chargeNow  = (double) curCharge / 1000000.0;
+      } else {
+         out->energyFull = (double) maxCharge / 1000000.0;
+         out->energyNow  = (double) curCharge / 1000000.0;
+      }
+   }
+
+   /* Net rate = discharge - charge in canonical sign (positive = discharge).
+    * Each side may be in Watts or Amperes; combine after unit normalization
+    * via the instantaneous voltage (which the aggregator also uses). */
+   double instV = NAN;
+   if (out->voltageNow > 0)
+      instV = out->voltageNow;
+   else if (out->voltageDesign > 0)
+      instV = out->voltageDesign;
+
+   double netPower = 0.0;
+   double netCurrent = 0.0;
+   bool havePower = false;
+   bool haveCurrent = false;
+
+   if (haveChargeRate && chargeRateMag >= 0) {
+      double mag = (double) chargeRateMag / 1000000.0;
+      if (chargeRateIsAmps) {
+         if (instV > 0) { netPower -= mag * instV; havePower = true; }
+         else if (chargeRateMag == 0) { /* 0 A => 0 W known regardless of V */ havePower = true; }
+         netCurrent -= mag;
+         haveCurrent = true;
+      } else {
+         netPower -= mag;
+         havePower = true;
+      }
+   }
+
+   if (haveDischargeRate && dischargeRateMag >= 0) {
+      double mag = (double) dischargeRateMag / 1000000.0;
+      if (dischargeRateIsAmps) {
+         if (instV > 0) { netPower += mag * instV; havePower = true; }
+         else if (dischargeRateMag == 0) { havePower = true; }
+         netCurrent += mag;
+         haveCurrent = true;
+      } else {
+         netPower += mag;
+         havePower = true;
+      }
+   }
+
+   if (havePower)
+      out->power = netPower;
+   if (haveCurrent && !havePower)
+      out->current = netCurrent;
+
+   return true;
+}
+
 void Platform_getBattery(BatteryInfo* info) {
-   prop_dictionary_t dict, fields, props;
-   prop_object_t device, class;
-
-   /* charge+voltage batteries contribute to BOTH accumulators. */
-   intmax_t totalEnergyRemain = 0;     /* µWh */
-   intmax_t totalEnergyFull = 0;
-   intmax_t totalChargeRemain = 0;     /* µAh */
-   intmax_t totalChargeFull = 0;
-
-   int unitsPresent = 0;
-   int unitsContributingEnergy = 0;
-   int unitsContributingCharge = 0;
-   int unitsContributingPower = 0;
-
-   intmax_t totalPower = 0;
-
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
@@ -473,222 +609,46 @@ void Platform_getBattery(BatteryInfo* info) {
 
    int fd = open(_PATH_SYSMON, O_RDONLY);
    if (fd == -1)
-      goto error;
+      return;
 
-   if (prop_dictionary_recv_ioctl(fd, ENVSYS_GETDICTIONARY, &dict) != 0)
-      goto error;
+   prop_dictionary_t dict;
+   if (prop_dictionary_recv_ioctl(fd, ENVSYS_GETDICTIONARY, &dict) != 0) {
+      close(fd);
+      return;
+   }
+
+   BatteryRaw raws[ENVSYS_MAX_BATTERIES];
+   size_t nbat = 0;
 
    prop_object_iterator_t devIter = prop_dictionary_iterator(dict);
-   if (devIter == NULL)
-      goto error;
-
-   while ((device = prop_object_iterator_next(devIter)) != NULL) {
+   prop_object_t device;
+   while (devIter != NULL && (device = prop_object_iterator_next(devIter)) != NULL) {
       prop_object_t fieldsArray = prop_dictionary_get_keysym(dict, device);
       if (fieldsArray == NULL)
-         goto error;
+         continue;
 
       prop_object_iterator_t fieldsIter = prop_array_iterator(fieldsArray);
       if (fieldsIter == NULL)
-         goto error;
+         continue;
 
-      bool isACAdapter = false;
-      bool isBattery = false;
-
-      /* only assume battery is not present if explicitly stated */
-      intmax_t isPresent = 1;
+      bool isACAdapter;
+      bool haveConnected;
       intmax_t isConnected = 0;
-      bool haveConnected = false;
-      intmax_t curCharge = 0;
-      intmax_t maxCharge = 0;
-      intmax_t chargeRate = 0;
-      intmax_t dischargeRate = 0;
-      intmax_t voltage = 0;
-      intmax_t designVoltage = 0;
+      BatteryRaw raw;
+      bool isBattery = parseEnvsysBattery(fieldsIter, &raw, &isACAdapter, &haveConnected, &isConnected);
+      prop_object_iterator_release(fieldsIter);
 
-      bool haveCharge = false;
-      bool haveChargeRate = false;
-      bool haveDischargeRate = false;
-      bool chargeIsAmpHours = false;
-      bool chargeRateIsAmps = false;
-      bool dischargeRateIsAmps = false;
-
-      while ((fields = prop_object_iterator_next(fieldsIter)) != NULL) {
-         props = prop_dictionary_get(fields, "device-properties");
-         if (props != NULL) {
-            class = prop_dictionary_get(props, "device-class");
-
-            if (prop_string_equals_string(class, "ac-adapter")) {
-               isACAdapter = true;
-            } else if (prop_string_equals_string(class, "battery")) {
-               isBattery = true;
-            }
-            continue;
-         }
-
-         prop_object_t curValue = prop_dictionary_get(fields, "cur-value");
-         prop_object_t maxValue = prop_dictionary_get(fields, "max-value");
-         prop_object_t descField = prop_dictionary_get(fields, "description");
-         prop_object_t typeField = prop_dictionary_get(fields, "type");
-         prop_object_t stateField = prop_dictionary_get(fields, "state");
-
-         if (descField == NULL || curValue == NULL)
-            continue;
-
-         /* Reject sensors the kernel marks invalid. */
-         if (stateField != NULL && prop_string_equals_string(stateField, "invalid"))
-            continue;
-
-         if (prop_string_equals_string(descField, "connected")) {
-            isConnected = prop_number_signed_value(curValue);
-            haveConnected = true;
-         } else if (prop_string_equals_string(descField, "present")) {
-            isPresent = prop_number_signed_value(curValue);
-         } else if (prop_string_equals_string(descField, "voltage")) {
-            voltage = prop_number_signed_value(curValue);
-         } else if (prop_string_equals_string(descField, "design voltage")) {
-            designVoltage = prop_number_signed_value(curValue);
-         } else if (prop_string_equals_string(descField, "charge")) {
-            if (maxValue == NULL)
-               continue;
-            curCharge = prop_number_signed_value(curValue);
-            maxCharge = prop_number_signed_value(maxValue);
-            haveCharge = true;
-            chargeIsAmpHours = typeField != NULL &&
-               prop_string_equals_string(typeField, "Ampere hour");
-         } else if (prop_string_equals_string(descField, "charge rate")) {
-            chargeRate = prop_number_signed_value(curValue);
-            chargeRateIsAmps = typeField != NULL &&
-               prop_string_equals_string(typeField, "Ampere");
-            haveChargeRate = true;
-         } else if (prop_string_equals_string(descField, "discharge rate")) {
-            dischargeRate = prop_number_signed_value(curValue);
-            dischargeRateIsAmps = typeField != NULL &&
-               prop_string_equals_string(typeField, "Ampere");
-            haveDischargeRate = true;
-         }
-      }
-
-      if (isBattery && isPresent) {
-         /* Counts before any sensor-dependent check; an all-invalid pack
-          * still blocks publication. */
-         unitsPresent++;
-
-         /* Design for energy reference; present for I*V. */
-         intmax_t referenceVoltage = (designVoltage != 0) ? designVoltage : voltage;
-         intmax_t rateVoltage = (voltage != 0) ? voltage : designVoltage;
-
-         bool haveBatteryChargeRate = false;
-         bool haveBatteryDischargeRate = false;
-
-         bool batteryContributedEnergy = false;
-         bool batteryContributedCharge = false;
-
-         intmax_t batteryChargeRate = 0;
-         intmax_t batteryDischargeRate = 0;
-         intmax_t batteryEnergyRemain = 0;
-         intmax_t batteryEnergyFull = 0;
-         intmax_t batteryChargeRemain = 0;
-         intmax_t batteryChargeFull = 0;
-
-         if (haveCharge) {
-            if (chargeIsAmpHours) {
-               /* Charge fallback when voltage is unknown. */
-               if (maxCharge > 0) {
-                  batteryChargeRemain = MINIMUM(curCharge, maxCharge);
-                  batteryChargeFull = maxCharge;
-                  batteryContributedCharge = true;
-               }
-               if (referenceVoltage > 0 && maxCharge > 0) {
-                  batteryEnergyRemain = curCharge * referenceVoltage / 1000000;
-                  batteryEnergyFull = maxCharge * referenceVoltage / 1000000;
-                  batteryContributedEnergy = true;
-               }
-            } else if (maxCharge > 0) {
-               /* Watt-hour battery: energy only. */
-               batteryEnergyRemain = curCharge;
-               batteryEnergyFull = maxCharge;
-               batteryContributedEnergy = true;
-            }
-         }
-
-         /* envsys rates are magnitudes; reject negative sentinels. */
-         if (haveChargeRate && chargeRate >= 0) {
-            if (chargeRateIsAmps) {
-               if (chargeRate == 0) {
-                  /* I=0 ⇒ 0 W known. */
-                  haveBatteryChargeRate = true;
-               } else if (rateVoltage > 0) {
-                  batteryChargeRate = chargeRate * rateVoltage / 1000000;
-                  haveBatteryChargeRate = true;
-               }
-            } else {
-               batteryChargeRate = chargeRate;
-               haveBatteryChargeRate = true;
-            }
-         }
-
-         if (haveDischargeRate && dischargeRate >= 0) {
-            if (dischargeRateIsAmps) {
-               if (dischargeRate == 0) {
-                  /* I=0 ⇒ 0 W known. */
-                  haveBatteryDischargeRate = true;
-               } else if (rateVoltage > 0) {
-                  batteryDischargeRate = dischargeRate * rateVoltage / 1000000;
-                  haveBatteryDischargeRate = true;
-               }
-            } else {
-               batteryDischargeRate = dischargeRate;
-               haveBatteryDischargeRate = true;
-            }
-         }
-
-         if (batteryContributedEnergy) {
-            totalEnergyRemain += MINIMUM(batteryEnergyRemain, batteryEnergyFull);
-            totalEnergyFull += batteryEnergyFull;
-         }
-         if (batteryContributedCharge) {
-            totalChargeRemain += batteryChargeRemain;
-            totalChargeFull += batteryChargeFull;
-         }
-         if (batteryContributedEnergy)
-            unitsContributingEnergy++;
-         if (batteryContributedCharge)
-            unitsContributingCharge++;
-
-         /* Rate contribution independent of capacity contribution. */
-         if (haveBatteryChargeRate || haveBatteryDischargeRate) {
-            totalPower += batteryDischargeRate - batteryChargeRate;
-            unitsContributingPower++;
-         }
-      }
+      if (isBattery && nbat < ENVSYS_MAX_BATTERIES)
+         raws[nbat++] = raw;
 
       /* Invalid connected sensor leaves AC at AC_ERROR. */
-      if (isACAdapter && haveConnected && info->ac != AC_PRESENT) {
+      if (isACAdapter && haveConnected && info->ac != AC_PRESENT)
          info->ac = isConnected ? AC_PRESENT : AC_ABSENT;
-      }
    }
+   if (devIter != NULL)
+      prop_object_iterator_release(devIter);
 
-   /* Energy ratio preferred; mixing µWh and µAh would be invalid. */
-   if (unitsPresent > 0 && unitsContributingEnergy == unitsPresent && totalEnergyFull > 0) {
-      info->percent = ((double) totalEnergyRemain * 100.0) / (double) totalEnergyFull;
-      if (totalEnergyRemain >= totalEnergyFull)
-         info->percent = 100.0;
-   } else if (unitsPresent > 0 && unitsContributingCharge == unitsPresent && totalChargeFull > 0) {
-      info->percent = ((double) totalChargeRemain * 100.0) / (double) totalChargeFull;
-      if (totalChargeRemain >= totalChargeFull)
-         info->percent = 100.0;
-   }
+   close(fd);
 
-   if (unitsPresent > 0 && unitsContributingEnergy == unitsPresent && totalEnergyFull > 0) {
-      info->energyCurr = (double) totalEnergyRemain / 1000000.0;
-      info->energyFull = (double) totalEnergyFull / 1000000.0;
-   }
-
-   if (unitsPresent > 0 && unitsContributingPower == unitsPresent) {
-      info->powerCurr = (double) totalPower / 1000000.0;
-   }
-
-error:
-   if (fd != -1)
-      close(fd);
+   Battery_aggregate(raws, nbat, info);
 }

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -615,10 +615,10 @@ void Platform_getBattery(BatteryInfo* info) {
       return;
    }
 
-   /* Sized dynamically; xRealloc never returns NULL. */
+   /* Sized dynamically; xMallocArray / xReallocArray refuse on overflow. */
    size_t cap = 4;
    size_t nbat = 0;
-   BatteryRaw* raws = xMalloc(cap * sizeof(BatteryRaw));
+   BatteryRaw* raws = xMallocArray(cap, sizeof(BatteryRaw));
 
    prop_object_iterator_t devIter = prop_dictionary_iterator(dict);
    prop_object_t device;
@@ -641,7 +641,7 @@ void Platform_getBattery(BatteryInfo* info) {
       if (isBattery) {
          if (nbat == cap) {
             cap *= 2;
-            raws = xRealloc(raws, cap * sizeof(BatteryRaw));
+            raws = xReallocArray(raws, cap, sizeof(BatteryRaw));
          }
          raws[nbat++] = raw;
       }

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -533,8 +533,19 @@ void Platform_getBattery(BatteryInfo* info) {
          prop_object_t maxValue = prop_dictionary_get(fields, "max-value");
          prop_object_t descField = prop_dictionary_get(fields, "description");
          prop_object_t typeField = prop_dictionary_get(fields, "type");
+         prop_object_t stateField = prop_dictionary_get(fields, "state");
 
          if (descField == NULL || curValue == NULL)
+            continue;
+
+         /* Reject sensors the kernel has flagged invalid: when an ACPI
+            battery's _BST returns an unknown rate, sysmon still publishes
+            the "charge rate" / "discharge rate" sensors with a sentinel
+            cur-value and state="invalid". Trusting that cur-value would
+            surface bogus signed power readings. The same rule applies to
+            every other sensor we read (charge, voltage, present, ...) —
+            an invalid state means cur-value is meaningless. */
+         if (stateField != NULL && prop_string_equals_string(stateField, "invalid"))
             continue;
 
          if (prop_string_equals_string(descField, "connected")) {

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -637,7 +637,15 @@ void Platform_getBattery(BatteryInfo* info) {
             }
          }
 
-         if (haveChargeRate) {
+         /* envsys "charge rate" / "discharge rate" are unsigned magnitudes
+          * (the sign is encoded by which sensor name is used, not by the
+          * cur-value). Some drivers publish a negative cur-value as a
+          * sentinel for "unknown" while leaving the sensor state at
+          * "valid", so the state="invalid" filter does not catch it.
+          * Reject negative rates so an unknown reading leaves the rate
+          * unpublished rather than producing a wrong-sign or near-zero
+          * power total. */
+         if (haveChargeRate && chargeRate >= 0) {
             if (chargeRateIsAmps) {
                if (chargeRate == 0) {
                   /* Zero current is a known 0 W reading regardless of
@@ -653,7 +661,7 @@ void Platform_getBattery(BatteryInfo* info) {
             }
          }
 
-         if (haveDischargeRate) {
+         if (haveDischargeRate && dischargeRate >= 0) {
             if (dischargeRateIsAmps) {
                if (dischargeRate == 0) {
                   /* Zero current is a known 0 W reading regardless of

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -450,11 +450,20 @@ void Platform_getBattery(BatteryInfo* info) {
    prop_dictionary_t dict, fields, props;
    prop_object_t device, class;
 
-   intmax_t totalCharge = 0;
-   intmax_t totalCapacity = 0;
-   intmax_t totalChargeOnlyRemain = 0;
-   intmax_t totalChargeOnlyFull = 0;
-   bool haveChargeOnlyBattery = false;
+   /* Parallel accumulators with per-unit contribution tracking so the percent
+      calculation can pick a dimensionally-consistent ratio. A battery exposing
+      Ampere-hour charge with voltage contributes to BOTH energy totals (raw
+      charge converted to µWh) AND charge totals (raw µAh); a charge-only
+      battery without voltage contributes only to charge totals; an energy
+      battery (Watt-hour units) contributes only to energy totals. */
+   intmax_t totalEnergyRemain = 0;     /* µWh */
+   intmax_t totalEnergyFull = 0;
+   intmax_t totalChargeRemain = 0;     /* µAh */
+   intmax_t totalChargeFull = 0;
+
+   int unitsTotal = 0;
+   int unitsContributingEnergy = 0;
+   int unitsContributingCharge = 0;
 
    bool havePower = false;
    intmax_t totalPower = 0;
@@ -563,31 +572,41 @@ void Platform_getBattery(BatteryInfo* info) {
          bool haveBatteryChargeRate = false;
          bool haveBatteryDischargeRate = false;
 
-         bool haveBatteryCharge = false;
+         bool batteryContributedEnergy = false;
+         bool batteryContributedCharge = false;
 
          intmax_t batteryChargeRate = 0;
          intmax_t batteryDischargeRate = 0;
-         intmax_t batteryCharge = 0;
-         intmax_t batteryCapacity = 0;
-
-         bool chargeOnlyBattery = false;
+         intmax_t batteryEnergyRemain = 0;
+         intmax_t batteryEnergyFull = 0;
+         intmax_t batteryChargeRemain = 0;
+         intmax_t batteryChargeFull = 0;
 
          if (haveCharge) {
             if (chargeIsAmpHours) {
-               if (batteryVoltage > 0) {
-                  batteryCharge = curCharge * batteryVoltage / 1000000;
-                  batteryCapacity = maxCharge * batteryVoltage / 1000000;
-                  haveBatteryCharge = true;
-               } else if (maxCharge > 0) {
-                  /* No voltage available to convert Ah to Wh; accumulate raw
-                     charge so the percentage is still computable. The energy
-                     fields are not contributed to for this battery. */
-                  chargeOnlyBattery = true;
+               /* Always contribute to the raw charge accumulator so a
+                  voltage-less sibling pack does not make the charge total
+                  incomplete; the charge ratio is the dimensionally-correct
+                  fallback when not every battery has voltage. */
+               if (maxCharge > 0) {
+                  intmax_t clampedCharge = curCharge > maxCharge ? maxCharge : curCharge;
+                  batteryChargeRemain = clampedCharge;
+                  batteryChargeFull = maxCharge;
+                  batteryContributedCharge = true;
                }
-            } else {
-               batteryCharge = curCharge;
-               batteryCapacity = maxCharge;
-               haveBatteryCharge = true;
+               /* Contribute to the energy accumulator only when voltage is
+                  available to convert µAh to µWh. */
+               if (batteryVoltage > 0 && maxCharge > 0) {
+                  batteryEnergyRemain = curCharge * batteryVoltage / 1000000;
+                  batteryEnergyFull = maxCharge * batteryVoltage / 1000000;
+                  batteryContributedEnergy = true;
+               }
+            } else if (maxCharge > 0) {
+               /* Watt-hour battery: contributes only to the energy
+                  accumulator. Charge counters are not exposed. */
+               batteryEnergyRemain = curCharge;
+               batteryEnergyFull = maxCharge;
+               batteryContributedEnergy = true;
             }
          }
 
@@ -615,14 +634,21 @@ void Platform_getBattery(BatteryInfo* info) {
             }
          }
 
-         if (haveBatteryCharge) {
-            totalCharge += batteryCharge;
-            totalCapacity += batteryCapacity;
-         } else if (chargeOnlyBattery) {
-            intmax_t clampedCharge = curCharge > maxCharge ? maxCharge : curCharge;
-            totalChargeOnlyRemain += clampedCharge;
-            totalChargeOnlyFull += maxCharge;
-            haveChargeOnlyBattery = true;
+         if (batteryContributedEnergy) {
+            intmax_t clampedEnergy = batteryEnergyRemain > batteryEnergyFull ? batteryEnergyFull : batteryEnergyRemain;
+            totalEnergyRemain += clampedEnergy;
+            totalEnergyFull += batteryEnergyFull;
+         }
+         if (batteryContributedCharge) {
+            totalChargeRemain += batteryChargeRemain;
+            totalChargeFull += batteryChargeFull;
+         }
+         if (batteryContributedEnergy || batteryContributedCharge) {
+            unitsTotal++;
+            if (batteryContributedEnergy)
+               unitsContributingEnergy++;
+            if (batteryContributedCharge)
+               unitsContributingCharge++;
          }
 
          if (haveBatteryChargeRate || haveBatteryDischargeRate) {
@@ -636,24 +662,27 @@ void Platform_getBattery(BatteryInfo* info) {
       }
    }
 
-   /* Combine energy-based and charge-only accumulators for the percentage so
-      that batteries lacking voltage still contribute. Mixing units across the
-      two pools is dimensionally inexact but matches pre-PR behaviour and
-      keeps the meter functional rather than reporting N/A. */
-   intmax_t combinedRemain = totalCharge + totalChargeOnlyRemain;
-   intmax_t combinedFull = totalCapacity + totalChargeOnlyFull;
-   if (combinedFull > 0) {
-      info->percent = ((double) combinedRemain * 100.0) / (double) combinedFull;
-      if (combinedRemain >= combinedFull)
+   /* Pick a dimensionally-consistent ratio: prefer the energy accumulator
+      when every contributing battery reached it (best precision because
+      individual cell capacities scale with voltage); fall back to the raw
+      charge accumulator when every battery hit that path; otherwise leave
+      percent NaN rather than mix µWh and µAh totals. */
+   if (unitsTotal > 0 && unitsContributingEnergy == unitsTotal && totalEnergyFull > 0) {
+      info->percent = ((double) totalEnergyRemain * 100.0) / (double) totalEnergyFull;
+      if (totalEnergyRemain >= totalEnergyFull)
          info->percent = 100.0;
+   } else if (unitsTotal > 0 && unitsContributingCharge == unitsTotal && totalChargeFull > 0) {
+      info->percent = ((double) totalChargeRemain * 100.0) / (double) totalChargeFull;
+      if (totalChargeRemain >= totalChargeFull)
+         info->percent = 100.0;
+   }
 
-      /* Only publish Wh fields when every contributing battery had energy
-         data; otherwise the totals would be a mix of Wh and Ah and would
-         violate the BatteryInfo Wh contract. */
-      if (!haveChargeOnlyBattery && totalCapacity > 0) {
-         info->energyCurr = (double) totalCharge / 1000000.0;
-         info->energyFull = (double) totalCapacity / 1000000.0;
-      }
+   /* Only publish Wh fields when every contributing battery reached the
+      energy accumulator; otherwise the total would silently omit a pack
+      and violate the BatteryInfo Wh contract. */
+   if (unitsTotal > 0 && unitsContributingEnergy == unitsTotal && totalEnergyFull > 0) {
+      info->energyCurr = (double) totalEnergyRemain / 1000000.0;
+      info->energyFull = (double) totalEnergyFull / 1000000.0;
    }
 
    if (havePower) {

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -450,12 +450,7 @@ void Platform_getBattery(BatteryInfo* info) {
    prop_dictionary_t dict, fields, props;
    prop_object_t device, class;
 
-   /* Parallel accumulators with per-unit contribution tracking so the percent
-      calculation can pick a dimensionally-consistent ratio. A battery exposing
-      Ampere-hour charge with voltage contributes to BOTH energy totals (raw
-      charge converted to µWh) AND charge totals (raw µAh); a charge-only
-      battery without voltage contributes only to charge totals; an energy
-      battery (Watt-hour units) contributes only to energy totals. */
+   /* charge+voltage batteries contribute to BOTH accumulators. */
    intmax_t totalEnergyRemain = 0;     /* µWh */
    intmax_t totalEnergyFull = 0;
    intmax_t totalChargeRemain = 0;     /* µAh */
@@ -539,13 +534,7 @@ void Platform_getBattery(BatteryInfo* info) {
          if (descField == NULL || curValue == NULL)
             continue;
 
-         /* Reject sensors the kernel has flagged invalid: when an ACPI
-            battery's _BST returns an unknown rate, sysmon still publishes
-            the "charge rate" / "discharge rate" sensors with a sentinel
-            cur-value and state="invalid". Trusting that cur-value would
-            surface bogus signed power readings. The same rule applies to
-            every other sensor we read (charge, voltage, present, ...) —
-            an invalid state means cur-value is meaningless. */
+         /* Reject sensors the kernel marks invalid. */
          if (stateField != NULL && prop_string_equals_string(stateField, "invalid"))
             continue;
 
@@ -580,19 +569,11 @@ void Platform_getBattery(BatteryInfo* info) {
       }
 
       if (isBattery && isPresent) {
-         /* Count every present battery slot before any sensor-dependent
-            contribution check. A battery whose sensors were entirely
-            flagged invalid still counts as present, so the aggregate
-            stays incomplete and percent/energy/power publication is
-            suppressed rather than silently dropping that pack. */
+         /* Counts before any sensor-dependent check; an all-invalid pack
+          * still blocks publication. */
          unitsPresent++;
 
-         /* Use design voltage to convert charge into energy: the present
-          * voltage drifts as the pack charges and discharges, which would
-          * skew batteryEnergyFull over time. Fall back to the present
-          * voltage only if design voltage isn't exposed. Conversely, use
-          * the present voltage for instantaneous charge/discharge rate
-          * conversions (P = I * V), falling back to design if needed. */
+         /* Design for energy reference; present for I*V. */
          intmax_t referenceVoltage = (designVoltage != 0) ? designVoltage : voltage;
          intmax_t rateVoltage = (voltage != 0) ? voltage : designVoltage;
 
@@ -611,45 +592,31 @@ void Platform_getBattery(BatteryInfo* info) {
 
          if (haveCharge) {
             if (chargeIsAmpHours) {
-               /* Always contribute to the raw charge accumulator so a
-                  voltage-less sibling pack does not make the charge total
-                  incomplete; the charge ratio is the dimensionally-correct
-                  fallback when not every battery has voltage. */
+               /* Charge fallback when voltage is unknown. */
                if (maxCharge > 0) {
                   intmax_t clampedCharge = curCharge > maxCharge ? maxCharge : curCharge;
                   batteryChargeRemain = clampedCharge;
                   batteryChargeFull = maxCharge;
                   batteryContributedCharge = true;
                }
-               /* Contribute to the energy accumulator only when voltage is
-                  available to convert µAh to µWh. */
                if (referenceVoltage > 0 && maxCharge > 0) {
                   batteryEnergyRemain = curCharge * referenceVoltage / 1000000;
                   batteryEnergyFull = maxCharge * referenceVoltage / 1000000;
                   batteryContributedEnergy = true;
                }
             } else if (maxCharge > 0) {
-               /* Watt-hour battery: contributes only to the energy
-                  accumulator. Charge counters are not exposed. */
+               /* Watt-hour battery: energy only. */
                batteryEnergyRemain = curCharge;
                batteryEnergyFull = maxCharge;
                batteryContributedEnergy = true;
             }
          }
 
-         /* envsys "charge rate" / "discharge rate" are unsigned magnitudes
-          * (the sign is encoded by which sensor name is used, not by the
-          * cur-value). Some drivers publish a negative cur-value as a
-          * sentinel for "unknown" while leaving the sensor state at
-          * "valid", so the state="invalid" filter does not catch it.
-          * Reject negative rates so an unknown reading leaves the rate
-          * unpublished rather than producing a wrong-sign or near-zero
-          * power total. */
+         /* envsys rates are magnitudes; reject negative sentinels. */
          if (haveChargeRate && chargeRate >= 0) {
             if (chargeRateIsAmps) {
                if (chargeRate == 0) {
-                  /* Zero current is a known 0 W reading regardless of
-                   * voltage availability: I * V = 0 when I is zero. */
+                  /* I=0 ⇒ 0 W known. */
                   haveBatteryChargeRate = true;
                } else if (rateVoltage > 0) {
                   batteryChargeRate = chargeRate * rateVoltage / 1000000;
@@ -664,8 +631,7 @@ void Platform_getBattery(BatteryInfo* info) {
          if (haveDischargeRate && dischargeRate >= 0) {
             if (dischargeRateIsAmps) {
                if (dischargeRate == 0) {
-                  /* Zero current is a known 0 W reading regardless of
-                   * voltage availability: I * V = 0 when I is zero. */
+                  /* I=0 ⇒ 0 W known. */
                   haveBatteryDischargeRate = true;
                } else if (rateVoltage > 0) {
                   batteryDischargeRate = dischargeRate * rateVoltage / 1000000;
@@ -691,38 +657,20 @@ void Platform_getBattery(BatteryInfo* info) {
          if (batteryContributedCharge)
             unitsContributingCharge++;
 
-         /* Rate contribution is independent of energy/charge contribution.
-          * A battery that exposes only a charge/discharge rate sensor
-          * (no charge counter, or charge data marked invalid) still
-          * contributes a usable power reading; gating unitsContributingPower
-          * on energy/charge would suppress info->powerCurr precisely for
-          * those rate-only batteries even though totalPower already
-          * includes the contribution. Mirror the Linux Class L pattern:
-          * count toward unitsContributingPower whenever a valid rate was
-          * read. */
+         /* Rate contribution independent of capacity contribution. */
          if (haveBatteryChargeRate || haveBatteryDischargeRate) {
             totalPower += batteryDischargeRate - batteryChargeRate;
             unitsContributingPower++;
          }
       }
 
-      /* Only publish AC_PRESENT/AC_ABSENT when we actually read a valid
-         "connected" sample. If the connected sensor exists but was rejected
-         by the state="invalid" filter above, leave info->ac as AC_ERROR
-         rather than misreporting an unknown state as "running on battery". */
+      /* Invalid connected sensor leaves AC at AC_ERROR. */
       if (isACAdapter && haveConnected && info->ac != AC_PRESENT) {
          info->ac = isConnected ? AC_PRESENT : AC_ABSENT;
       }
    }
 
-   /* Require every PRESENT battery to have contributed; a battery whose
-      sensors were entirely flagged invalid still counts as present, so the
-      aggregate stays incomplete and the percent/energy/power publication
-      is suppressed. Prefer the energy accumulator when every present
-      battery reached it (best precision because individual cell capacities
-      scale with voltage); fall back to the raw charge accumulator when
-      every battery hit that path; otherwise leave percent NaN rather than
-      mix µWh and µAh totals. */
+   /* Energy ratio preferred; mixing µWh and µAh would be invalid. */
    if (unitsPresent > 0 && unitsContributingEnergy == unitsPresent && totalEnergyFull > 0) {
       info->percent = ((double) totalEnergyRemain * 100.0) / (double) totalEnergyFull;
       if (totalEnergyRemain >= totalEnergyFull)
@@ -733,21 +681,11 @@ void Platform_getBattery(BatteryInfo* info) {
          info->percent = 100.0;
    }
 
-   /* Require every PRESENT battery to have contributed; a battery whose
-      sensors were entirely flagged invalid still counts as present, so the
-      aggregate stays incomplete and the energy publication is suppressed
-      rather than silently omitting a pack and violating the BatteryInfo
-      Wh contract. */
    if (unitsPresent > 0 && unitsContributingEnergy == unitsPresent && totalEnergyFull > 0) {
       info->energyCurr = (double) totalEnergyRemain / 1000000.0;
       info->energyFull = (double) totalEnergyFull / 1000000.0;
    }
 
-   /* Require every PRESENT battery to have contributed; a battery whose
-      sensors were entirely flagged invalid still counts as present, so the
-      aggregate stays incomplete and the power publication is suppressed
-      rather than omitting a sibling pack's draw and understating the true
-      whole-pack power. */
    if (unitsPresent > 0 && unitsContributingPower == unitsPresent) {
       info->powerCurr = (double) totalPower / 1000000.0;
    }

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -461,7 +461,7 @@ void Platform_getBattery(BatteryInfo* info) {
    intmax_t totalChargeRemain = 0;     /* µAh */
    intmax_t totalChargeFull = 0;
 
-   int unitsTotal = 0;
+   int unitsPresent = 0;
    int unitsContributingEnergy = 0;
    int unitsContributingCharge = 0;
    int unitsContributingPower = 0;
@@ -580,6 +580,13 @@ void Platform_getBattery(BatteryInfo* info) {
       }
 
       if (isBattery && isPresent) {
+         /* Count every present battery slot before any sensor-dependent
+            contribution check. A battery whose sensors were entirely
+            flagged invalid still counts as present, so the aggregate
+            stays incomplete and percent/energy/power publication is
+            suppressed rather than silently dropping that pack. */
+         unitsPresent++;
+
          /* Use design voltage to convert charge into energy: the present
           * voltage drifts as the pack charges and discharges, which would
           * skew batteryEnergyFull over time. Fall back to the present
@@ -671,13 +678,10 @@ void Platform_getBattery(BatteryInfo* info) {
             totalChargeRemain += batteryChargeRemain;
             totalChargeFull += batteryChargeFull;
          }
-         if (batteryContributedEnergy || batteryContributedCharge) {
-            unitsTotal++;
-            if (batteryContributedEnergy)
-               unitsContributingEnergy++;
-            if (batteryContributedCharge)
-               unitsContributingCharge++;
-         }
+         if (batteryContributedEnergy)
+            unitsContributingEnergy++;
+         if (batteryContributedCharge)
+            unitsContributingCharge++;
 
          if (haveBatteryChargeRate || haveBatteryDischargeRate) {
             totalPower += batteryDischargeRate - batteryChargeRate;
@@ -695,33 +699,40 @@ void Platform_getBattery(BatteryInfo* info) {
       }
    }
 
-   /* Pick a dimensionally-consistent ratio: prefer the energy accumulator
-      when every contributing battery reached it (best precision because
-      individual cell capacities scale with voltage); fall back to the raw
-      charge accumulator when every battery hit that path; otherwise leave
-      percent NaN rather than mix µWh and µAh totals. */
-   if (unitsTotal > 0 && unitsContributingEnergy == unitsTotal && totalEnergyFull > 0) {
+   /* Require every PRESENT battery to have contributed; a battery whose
+      sensors were entirely flagged invalid still counts as present, so the
+      aggregate stays incomplete and the percent/energy/power publication
+      is suppressed. Prefer the energy accumulator when every present
+      battery reached it (best precision because individual cell capacities
+      scale with voltage); fall back to the raw charge accumulator when
+      every battery hit that path; otherwise leave percent NaN rather than
+      mix µWh and µAh totals. */
+   if (unitsPresent > 0 && unitsContributingEnergy == unitsPresent && totalEnergyFull > 0) {
       info->percent = ((double) totalEnergyRemain * 100.0) / (double) totalEnergyFull;
       if (totalEnergyRemain >= totalEnergyFull)
          info->percent = 100.0;
-   } else if (unitsTotal > 0 && unitsContributingCharge == unitsTotal && totalChargeFull > 0) {
+   } else if (unitsPresent > 0 && unitsContributingCharge == unitsPresent && totalChargeFull > 0) {
       info->percent = ((double) totalChargeRemain * 100.0) / (double) totalChargeFull;
       if (totalChargeRemain >= totalChargeFull)
          info->percent = 100.0;
    }
 
-   /* Only publish Wh fields when every contributing battery reached the
-      energy accumulator; otherwise the total would silently omit a pack
-      and violate the BatteryInfo Wh contract. */
-   if (unitsTotal > 0 && unitsContributingEnergy == unitsTotal && totalEnergyFull > 0) {
+   /* Require every PRESENT battery to have contributed; a battery whose
+      sensors were entirely flagged invalid still counts as present, so the
+      aggregate stays incomplete and the energy publication is suppressed
+      rather than silently omitting a pack and violating the BatteryInfo
+      Wh contract. */
+   if (unitsPresent > 0 && unitsContributingEnergy == unitsPresent && totalEnergyFull > 0) {
       info->energyCurr = (double) totalEnergyRemain / 1000000.0;
       info->energyFull = (double) totalEnergyFull / 1000000.0;
    }
 
-   /* Publish aggregate power only when every counted battery contributed
-      power. Otherwise totalPower would omit a sibling pack's draw and be
-      published as the whole-pack rate, understating the true power. */
-   if (unitsTotal > 0 && unitsContributingPower == unitsTotal) {
+   /* Require every PRESENT battery to have contributed; a battery whose
+      sensors were entirely flagged invalid still counts as present, so the
+      aggregate stays incomplete and the power publication is suppressed
+      rather than omitting a sibling pack's draw and understating the true
+      whole-pack power. */
+   if (unitsPresent > 0 && unitsContributingPower == unitsPresent) {
       info->powerCurr = (double) totalPower / 1000000.0;
    }
 

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -464,8 +464,8 @@ void Platform_getBattery(BatteryInfo* info) {
    int unitsTotal = 0;
    int unitsContributingEnergy = 0;
    int unitsContributingCharge = 0;
+   int unitsContributingPower = 0;
 
-   bool havePower = false;
    intmax_t totalPower = 0;
 
    *info = (BatteryInfo) {
@@ -653,7 +653,8 @@ void Platform_getBattery(BatteryInfo* info) {
 
          if (haveBatteryChargeRate || haveBatteryDischargeRate) {
             totalPower += batteryDischargeRate - batteryChargeRate;
-            havePower = true;
+            if (batteryContributedEnergy || batteryContributedCharge)
+               unitsContributingPower++;
          }
       }
 
@@ -685,7 +686,10 @@ void Platform_getBattery(BatteryInfo* info) {
       info->energyFull = (double) totalEnergyFull / 1000000.0;
    }
 
-   if (havePower) {
+   /* Publish aggregate power only when every counted battery contributed
+      power. Otherwise totalPower would omit a sibling pack's draw and be
+      published as the whole-pack rate, understating the true power. */
+   if (unitsTotal > 0 && unitsContributingPower == unitsTotal) {
       info->powerCurr = (double) totalPower / 1000000.0;
    }
 

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -619,6 +619,7 @@ void Platform_getBattery(BatteryInfo* info) {
 
    BatteryRaw raws[ENVSYS_MAX_BATTERIES];
    size_t nbat = 0;
+   bool batteryOverflow = false;
 
    prop_object_iterator_t devIter = prop_dictionary_iterator(dict);
    prop_object_t device;
@@ -638,8 +639,12 @@ void Platform_getBattery(BatteryInfo* info) {
       bool isBattery = parseEnvsysBattery(fieldsIter, &raw, &isACAdapter, &haveConnected, &isConnected);
       prop_object_iterator_release(fieldsIter);
 
-      if (isBattery && nbat < ENVSYS_MAX_BATTERIES)
-         raws[nbat++] = raw;
+      if (isBattery) {
+         if (nbat >= ENVSYS_MAX_BATTERIES)
+            batteryOverflow = true;
+         else
+            raws[nbat++] = raw;
+      }
 
       /* Invalid connected sensor leaves AC at AC_ERROR. */
       if (isACAdapter && haveConnected && info->ac != AC_PRESENT)
@@ -649,6 +654,10 @@ void Platform_getBattery(BatteryInfo* info) {
       prop_object_iterator_release(devIter);
 
    close(fd);
+
+   /* Refuse partial aggregation on overflow; percent stays NaN. */
+   if (batteryOverflow)
+      return;
 
    Battery_aggregate(raws, nbat, info);
 }

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -502,6 +502,7 @@ void Platform_getBattery(BatteryInfo* info) {
       /* only assume battery is not present if explicitly stated */
       intmax_t isPresent = 1;
       intmax_t isConnected = 0;
+      bool haveConnected = false;
       intmax_t curCharge = 0;
       intmax_t maxCharge = 0;
       intmax_t chargeRate = 0;
@@ -550,6 +551,7 @@ void Platform_getBattery(BatteryInfo* info) {
 
          if (prop_string_equals_string(descField, "connected")) {
             isConnected = prop_number_signed_value(curValue);
+            haveConnected = true;
          } else if (prop_string_equals_string(descField, "present")) {
             isPresent = prop_number_signed_value(curValue);
          } else if (prop_string_equals_string(descField, "voltage")) {
@@ -684,7 +686,11 @@ void Platform_getBattery(BatteryInfo* info) {
          }
       }
 
-      if (isACAdapter && info->ac != AC_PRESENT) {
+      /* Only publish AC_PRESENT/AC_ABSENT when we actually read a valid
+         "connected" sample. If the connected sensor exists but was rejected
+         by the state="invalid" filter above, leave info->ac as AC_ERROR
+         rather than misreporting an unknown state as "running on battery". */
+      if (isACAdapter && haveConnected && info->ac != AC_PRESENT) {
          info->ac = isConnected ? AC_PRESENT : AC_ABSENT;
       }
    }

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -691,10 +691,18 @@ void Platform_getBattery(BatteryInfo* info) {
          if (batteryContributedCharge)
             unitsContributingCharge++;
 
+         /* Rate contribution is independent of energy/charge contribution.
+          * A battery that exposes only a charge/discharge rate sensor
+          * (no charge counter, or charge data marked invalid) still
+          * contributes a usable power reading; gating unitsContributingPower
+          * on energy/charge would suppress info->powerCurr precisely for
+          * those rate-only batteries even though totalPower already
+          * includes the contribution. Mirror the Linux Class L pattern:
+          * count toward unitsContributingPower whenever a valid rate was
+          * read. */
          if (haveBatteryChargeRate || haveBatteryDischargeRate) {
             totalPower += batteryDischargeRate - batteryChargeRate;
-            if (batteryContributedEnergy || batteryContributedCharge)
-               unitsContributingPower++;
+            unitsContributingPower++;
          }
       }
 

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -452,6 +452,9 @@ void Platform_getBattery(BatteryInfo* info) {
 
    intmax_t totalCharge = 0;
    intmax_t totalCapacity = 0;
+   intmax_t totalChargeOnlyRemain = 0;
+   intmax_t totalChargeOnlyFull = 0;
+   bool haveChargeOnlyBattery = false;
 
    bool havePower = false;
    intmax_t totalPower = 0;
@@ -567,12 +570,19 @@ void Platform_getBattery(BatteryInfo* info) {
          intmax_t batteryCharge = 0;
          intmax_t batteryCapacity = 0;
 
+         bool chargeOnlyBattery = false;
+
          if (haveCharge) {
             if (chargeIsAmpHours) {
                if (batteryVoltage > 0) {
                   batteryCharge = curCharge * batteryVoltage / 1000000;
                   batteryCapacity = maxCharge * batteryVoltage / 1000000;
                   haveBatteryCharge = true;
+               } else if (maxCharge > 0) {
+                  /* No voltage available to convert Ah to Wh; accumulate raw
+                     charge so the percentage is still computable. The energy
+                     fields are not contributed to for this battery. */
+                  chargeOnlyBattery = true;
                }
             } else {
                batteryCharge = curCharge;
@@ -608,6 +618,11 @@ void Platform_getBattery(BatteryInfo* info) {
          if (haveBatteryCharge) {
             totalCharge += batteryCharge;
             totalCapacity += batteryCapacity;
+         } else if (chargeOnlyBattery) {
+            intmax_t clampedCharge = curCharge > maxCharge ? maxCharge : curCharge;
+            totalChargeOnlyRemain += clampedCharge;
+            totalChargeOnlyFull += maxCharge;
+            haveChargeOnlyBattery = true;
          }
 
          if (haveBatteryChargeRate || haveBatteryDischargeRate) {
@@ -621,13 +636,24 @@ void Platform_getBattery(BatteryInfo* info) {
       }
    }
 
-   if (totalCapacity > 0) {
-      info->percent = ((double) totalCharge * 100.0) / (double) totalCapacity;
-      if (totalCharge >= totalCapacity)
+   /* Combine energy-based and charge-only accumulators for the percentage so
+      that batteries lacking voltage still contribute. Mixing units across the
+      two pools is dimensionally inexact but matches pre-PR behaviour and
+      keeps the meter functional rather than reporting N/A. */
+   intmax_t combinedRemain = totalCharge + totalChargeOnlyRemain;
+   intmax_t combinedFull = totalCapacity + totalChargeOnlyFull;
+   if (combinedFull > 0) {
+      info->percent = ((double) combinedRemain * 100.0) / (double) combinedFull;
+      if (combinedRemain >= combinedFull)
          info->percent = 100.0;
 
-      info->energyCurr = (double) totalCharge / 1000000.0;
-      info->energyFull = (double) totalCapacity / 1000000.0;
+      /* Only publish Wh fields when every contributing battery had energy
+         data; otherwise the totals would be a mix of Wh and Ah and would
+         violate the BatteryInfo Wh contract. */
+      if (!haveChargeOnlyBattery && totalCapacity > 0) {
+         info->energyCurr = (double) totalCharge / 1000000.0;
+         info->energyFull = (double) totalCapacity / 1000000.0;
+      }
    }
 
    if (havePower) {

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -567,7 +567,14 @@ void Platform_getBattery(BatteryInfo* info) {
       }
 
       if (isBattery && isPresent) {
-         intmax_t batteryVoltage = (voltage != 0) ? voltage : designVoltage;
+         /* Use design voltage to convert charge into energy: the present
+          * voltage drifts as the pack charges and discharges, which would
+          * skew batteryEnergyFull over time. Fall back to the present
+          * voltage only if design voltage isn't exposed. Conversely, use
+          * the present voltage for instantaneous charge/discharge rate
+          * conversions (P = I * V), falling back to design if needed. */
+         intmax_t referenceVoltage = (designVoltage != 0) ? designVoltage : voltage;
+         intmax_t rateVoltage = (voltage != 0) ? voltage : designVoltage;
 
          bool haveBatteryChargeRate = false;
          bool haveBatteryDischargeRate = false;
@@ -596,9 +603,9 @@ void Platform_getBattery(BatteryInfo* info) {
                }
                /* Contribute to the energy accumulator only when voltage is
                   available to convert µAh to µWh. */
-               if (batteryVoltage > 0 && maxCharge > 0) {
-                  batteryEnergyRemain = curCharge * batteryVoltage / 1000000;
-                  batteryEnergyFull = maxCharge * batteryVoltage / 1000000;
+               if (referenceVoltage > 0 && maxCharge > 0) {
+                  batteryEnergyRemain = curCharge * referenceVoltage / 1000000;
+                  batteryEnergyFull = maxCharge * referenceVoltage / 1000000;
                   batteryContributedEnergy = true;
                }
             } else if (maxCharge > 0) {
@@ -612,8 +619,8 @@ void Platform_getBattery(BatteryInfo* info) {
 
          if (haveChargeRate) {
             if (chargeRateIsAmps) {
-               if (batteryVoltage > 0) {
-                  batteryChargeRate = chargeRate * batteryVoltage / 1000000;
+               if (rateVoltage > 0) {
+                  batteryChargeRate = chargeRate * rateVoltage / 1000000;
                   haveBatteryChargeRate = true;
                }
             } else {
@@ -624,8 +631,8 @@ void Platform_getBattery(BatteryInfo* info) {
 
          if (haveDischargeRate) {
             if (dischargeRateIsAmps) {
-               if (batteryVoltage > 0) {
-                  batteryDischargeRate = dischargeRate * batteryVoltage / 1000000;
+               if (rateVoltage > 0) {
+                  batteryDischargeRate = dischargeRate * rateVoltage / 1000000;
                   haveBatteryDischargeRate = true;
                }
             } else {

--- a/netbsd/Platform.c
+++ b/netbsd/Platform.c
@@ -619,7 +619,11 @@ void Platform_getBattery(BatteryInfo* info) {
 
          if (haveChargeRate) {
             if (chargeRateIsAmps) {
-               if (rateVoltage > 0) {
+               if (chargeRate == 0) {
+                  /* Zero current is a known 0 W reading regardless of
+                   * voltage availability: I * V = 0 when I is zero. */
+                  haveBatteryChargeRate = true;
+               } else if (rateVoltage > 0) {
                   batteryChargeRate = chargeRate * rateVoltage / 1000000;
                   haveBatteryChargeRate = true;
                }
@@ -631,7 +635,11 @@ void Platform_getBattery(BatteryInfo* info) {
 
          if (haveDischargeRate) {
             if (dischargeRateIsAmps) {
-               if (rateVoltage > 0) {
+               if (dischargeRate == 0) {
+                  /* Zero current is a known 0 W reading regardless of
+                   * voltage availability: I * V = 0 when I is zero. */
+                  haveBatteryDischargeRate = true;
+               } else if (rateVoltage > 0) {
                   batteryDischargeRate = dischargeRate * rateVoltage / 1000000;
                   haveBatteryDischargeRate = true;
                }

--- a/netbsd/Platform.h
+++ b/netbsd/Platform.h
@@ -77,7 +77,7 @@ bool Platform_getDiskIO(DiskIOData* data);
 
 bool Platform_getNetworkIO(NetworkIOData* data);
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC);
+void Platform_getBattery(BatteryInfo* info);
 
 static inline void Platform_getHostname(char* buffer, size_t size) {
    Generic_hostname(buffer, size);

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -383,6 +383,7 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .powerCurr = NAN,
       .energyCurr = NAN,
       .energyFull = NAN,
    };
@@ -392,9 +393,11 @@ void Platform_getBattery(BatteryInfo* info) {
    if (found) {
       bool haveTotalFull = false;
       bool haveTotalRemain = false;
+      bool haveTotalPower = false;
 
       int64_t totalFull = 0;
       int64_t totalRemain = 0;
+      int64_t totalPower = 0;
 
       /* See "sys/dev/acpi/acpibat.c" of OpenBSD source code for the indices
          of the last field. */
@@ -429,6 +432,27 @@ void Platform_getBattery(BatteryInfo* info) {
 
          info->energyCurr = (double) totalRemain / 1000000.0;
          info->energyFull = (double) totalFull / 1000000.0;
+      }
+
+      mib[3] = SENSOR_INTEGER;
+      mib[4] = 0; /* "battery state" */
+      int64_t batteryState = 0;
+      if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1)
+         batteryState = s.value;
+
+      mib[3] = SENSOR_WATTS;
+      mib[4] = 0; /* "rate" */
+      if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1) {
+         int64_t batteryPower = s.value;
+         if (batteryState & 0x02)
+            batteryPower = -batteryPower;
+
+         totalPower += batteryPower;
+         haveTotalPower = true;
+      }
+
+      if (haveTotalPower) {
+         info->powerCurr = (double) totalPower / 1000000.0;
       }
    }
 

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -373,16 +373,20 @@ static bool findDevice(const char* name, int* mib, struct sensordev* snsrdev, si
    }
 }
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC) {
+void Platform_getBattery(BatteryInfo* info) {
    int mib[] = {CTL_HW, HW_SENSORS, 0, 0, 0};
    struct sensor s;
    size_t slen = sizeof(struct sensor);
    struct sensordev snsrdev;
    size_t sdlen = sizeof(struct sensordev);
 
+   *info = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
+
    bool found = findDevice("acpibat0", mib, &snsrdev, &sdlen);
 
-   *percent = NAN;
    if (found) {
       /* See "sys/dev/acpi/acpibat.c" of OpenBSD source code for the indices
          of the last field. */
@@ -396,23 +400,21 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
          mib[4] = 3; /* "remaining capacity" */
          if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1) {
             double charge = s.value;
-            *percent = 100 * (charge / last_full_capacity);
-            if (charge >= last_full_capacity) {
-               *percent = 100;
-            }
+            info->percent = 100 * (charge / last_full_capacity);
+            if (charge >= last_full_capacity)
+               info->percent = 100;
          }
       }
    }
 
    found = findDevice("acpiac0", mib, &snsrdev, &sdlen);
 
-   *isOnAC = AC_ERROR;
    if (found) {
       /* See "sys/dev/acpi/acpiac.c" of OpenBSD source code.
          There is only one "sensor" for this device. */
       mib[3] = SENSOR_INDICATOR;
       mib[4] = 0; /* "power supply" (status indicator) */
       if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1)
-         *isOnAC = s.value != 0 ? AC_PRESENT : AC_ABSENT;
+         info->ac = s.value != 0 ? AC_PRESENT : AC_ABSENT;
    }
 }

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -383,6 +383,8 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 
    bool found = findDevice("acpibat0", mib, &snsrdev, &sdlen);
@@ -403,6 +405,8 @@ void Platform_getBattery(BatteryInfo* info) {
             info->percent = 100 * (charge / last_full_capacity);
             if (charge >= last_full_capacity)
                info->percent = 100;
+            info->energyCurr = charge;
+            info->energyFull = last_full_capacity;
          }
       }
    }

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -390,24 +390,45 @@ void Platform_getBattery(BatteryInfo* info) {
    bool found = findDevice("acpibat0", mib, &snsrdev, &sdlen);
 
    if (found) {
+      bool haveTotalFull = false;
+      bool haveTotalRemain = false;
+
+      int64_t totalFull = 0;
+      int64_t totalRemain = 0;
+
       /* See "sys/dev/acpi/acpibat.c" of OpenBSD source code for the indices
          of the last field. */
       mib[3] = SENSOR_WATTHOUR;
       mib[4] = 0; /* "last full capacity" */
-      double last_full_capacity = 0;
+      bool haveBatteryFull = false;
+      int64_t batteryFull = 0;
       if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1)
-         last_full_capacity = s.value;
-      if (last_full_capacity > 0) {
+         batteryFull = s.value;
+
+      if (batteryFull > 0)
+         haveBatteryFull = true;
+
+      if (haveBatteryFull) {
          mib[3] = SENSOR_WATTHOUR;
          mib[4] = 3; /* "remaining capacity" */
          if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1) {
-            double charge = s.value;
-            info->percent = 100 * (charge / last_full_capacity);
-            if (charge >= last_full_capacity)
-               info->percent = 100;
-            info->energyCurr = charge;
-            info->energyFull = last_full_capacity;
+            int64_t batteryRemain = s.value;
+            if (batteryRemain >= 0) {
+               totalRemain += batteryRemain;
+               totalFull += batteryFull;
+               haveTotalRemain = true;
+               haveTotalFull = true;
+            }
          }
+      }
+
+      if (haveTotalRemain && haveTotalFull && totalFull > 0) {
+         info->percent = ((double) totalRemain * 100.0) / (double) totalFull;
+         if (totalRemain >= totalFull)
+            info->percent = 100;
+
+         info->energyCurr = (double) totalRemain / 1000000.0;
+         info->energyFull = (double) totalFull / 1000000.0;
       }
    }
 

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -445,10 +445,43 @@ void Platform_getBattery(BatteryInfo* info) {
       if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1 && (s.flags & SENSOR_FUNKNOWN) == 0)
          batteryState = s.value;
 
+      /* OpenBSD acpibat publishes the rate sensor as either SENSOR_WATTS
+       * (mW firmware) or SENSOR_AMPS (mA firmware). Try Watts first; if
+       * that's absent or unknown, fall back to Amps × Volts. The voltage
+       * sensor is exposed as SENSOR_VOLTS_DC[1] (present voltage). All
+       * sensor values are in 10^-6 SI units, so amps×volts produces
+       * 10^-12 W; dividing by 10^6 gives µW that the publication block
+       * below converts to W. */
+      bool haveRate = false;
+      int64_t batteryPower = 0;
+
       mib[3] = SENSOR_WATTS;
       mib[4] = 0; /* "rate" */
       if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1 && (s.flags & SENSOR_FUNKNOWN) == 0) {
-         int64_t batteryPower = s.value;
+         batteryPower = s.value;
+         haveRate = true;
+      }
+
+      if (!haveRate) {
+         mib[3] = SENSOR_AMPS;
+         mib[4] = 0; /* "rate" (mA firmware) */
+         struct sensor amps;
+         size_t alen = sizeof(struct sensor);
+         if (sysctl(mib, 5, &amps, &alen, NULL, 0) != -1 && (amps.flags & SENSOR_FUNKNOWN) == 0) {
+            mib[3] = SENSOR_VOLTS_DC;
+            mib[4] = 1; /* present voltage */
+            struct sensor volts;
+            size_t vlen = sizeof(struct sensor);
+            if (sysctl(mib, 5, &volts, &vlen, NULL, 0) != -1
+                  && (volts.flags & SENSOR_FUNKNOWN) == 0
+                  && volts.value > 0) {
+               batteryPower = ((int64_t) amps.value * (int64_t) volts.value) / 1000000;
+               haveRate = true;
+            }
+         }
+      }
+
+      if (haveRate) {
          if (batteryState & 0x02)
             batteryPower = -batteryPower;
 

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -471,7 +471,7 @@ void Platform_getBattery(BatteryInfo* info) {
          size_t alen = sizeof(struct sensor);
          if (sysctl(mib, 5, &amps, &alen, NULL, 0) != -1 && (amps.flags & SENSOR_FUNKNOWN) == 0) {
             mib[3] = SENSOR_VOLTS_DC;
-            mib[4] = 1; /* present voltage */
+            mib[4] = 0; /* the single voltage sensor acpibat exposes */
             struct sensor volts;
             size_t vlen = sizeof(struct sensor);
             if (sysctl(mib, 5, &volts, &vlen, NULL, 0) != -1

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -395,9 +395,9 @@ void Platform_getBattery(BatteryInfo* info) {
       bool haveTotalRemain = false;
       bool haveTotalPower = false;
 
-      int64_t totalFull = 0;
-      int64_t totalRemain = 0;
-      int64_t totalPower = 0;
+      int64_t totalFull = 0;     /* µWh */
+      int64_t totalRemain = 0;   /* µWh */
+      int64_t totalPower = 0;    /* µW */
 
       /* See sys/dev/acpi/acpibat.c. FUNKNOWN means cur-value is meaningless. */
       mib[3] = SENSOR_WATTHOUR;
@@ -426,7 +426,7 @@ void Platform_getBattery(BatteryInfo* info) {
 
       if (haveTotalRemain && haveTotalFull && totalFull > 0) {
          /* Clamp remain <= full (firmware may report remain > last-full). */
-         int64_t clampedRemain = totalRemain > totalFull ? totalFull : totalRemain;
+         int64_t clampedRemain = MINIMUM(totalRemain, totalFull);
          info->percent = ((double) clampedRemain * 100.0) / (double) totalFull;
 
          info->energyCurr = (double) clampedRemain / 1000000.0;

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -470,13 +470,35 @@ void Platform_getBattery(BatteryInfo* info) {
          struct sensor amps;
          size_t alen = sizeof(struct sensor);
          if (sysctl(mib, 5, &amps, &alen, NULL, 0) != -1 && (amps.flags & SENSOR_FUNKNOWN) == 0) {
-            mib[3] = SENSOR_VOLTS_DC;
-            mib[4] = 0; /* the single voltage sensor acpibat exposes */
+            /* Per BatteryMeter.h's voltage convention: instantaneous I*V
+             * power wants the present terminal voltage. acpibat exposes
+             * SENSOR_VOLTS_DC[0] = design voltage, SENSOR_VOLTS_DC[1] =
+             * present voltage. Try the present voltage first; fall back
+             * to design only if the present sensor is missing or
+             * FUNKNOWN-flagged. */
             struct sensor volts;
             size_t vlen = sizeof(struct sensor);
+            bool haveVolts = false;
+
+            mib[3] = SENSOR_VOLTS_DC;
+            mib[4] = 1; /* present voltage */
             if (sysctl(mib, 5, &volts, &vlen, NULL, 0) != -1
                   && (volts.flags & SENSOR_FUNKNOWN) == 0
                   && volts.value > 0) {
+               haveVolts = true;
+            }
+
+            if (!haveVolts) {
+               mib[4] = 0; /* design voltage fallback */
+               vlen = sizeof(struct sensor);
+               if (sysctl(mib, 5, &volts, &vlen, NULL, 0) != -1
+                     && (volts.flags & SENSOR_FUNKNOWN) == 0
+                     && volts.value > 0) {
+                  haveVolts = true;
+               }
+            }
+
+            if (haveVolts) {
                batteryPower = ((int64_t) amps.value * (int64_t) volts.value) / 1000000;
                haveRate = true;
             }

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -431,11 +431,13 @@ void Platform_getBattery(BatteryInfo* info) {
       }
 
       if (haveTotalRemain && haveTotalFull && totalFull > 0) {
-         info->percent = ((double) totalRemain * 100.0) / (double) totalFull;
-         if (totalRemain >= totalFull)
-            info->percent = 100;
+         /* Clamp curr to full before publishing: a quirky firmware can
+          * report remaining > last-full, which would let info->energyCurr
+          * exceed info->energyFull and percent exceed 100. */
+         int64_t clampedRemain = totalRemain > totalFull ? totalFull : totalRemain;
+         info->percent = ((double) clampedRemain * 100.0) / (double) totalFull;
 
-         info->energyCurr = (double) totalRemain / 1000000.0;
+         info->energyCurr = (double) clampedRemain / 1000000.0;
          info->energyFull = (double) totalFull / 1000000.0;
       }
 

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -400,12 +400,17 @@ void Platform_getBattery(BatteryInfo* info) {
       int64_t totalPower = 0;
 
       /* See "sys/dev/acpi/acpibat.c" of OpenBSD source code for the indices
-         of the last field. */
+         of the last field.
+
+         OpenBSD acpibat can return a successful sysctl with the
+         SENSOR_FUNKNOWN flag set and a meaningless zero value when the
+         kernel cannot determine the underlying _BST/_BIF field.  Treat
+         such readings as missing rather than as a known zero. */
       mib[3] = SENSOR_WATTHOUR;
       mib[4] = 0; /* "last full capacity" */
       bool haveBatteryFull = false;
       int64_t batteryFull = 0;
-      if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1)
+      if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1 && (s.flags & SENSOR_FUNKNOWN) == 0)
          batteryFull = s.value;
 
       if (batteryFull > 0)
@@ -414,7 +419,7 @@ void Platform_getBattery(BatteryInfo* info) {
       if (haveBatteryFull) {
          mib[3] = SENSOR_WATTHOUR;
          mib[4] = 3; /* "remaining capacity" */
-         if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1) {
+         if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1 && (s.flags & SENSOR_FUNKNOWN) == 0) {
             int64_t batteryRemain = s.value;
             if (batteryRemain >= 0) {
                totalRemain += batteryRemain;
@@ -437,12 +442,12 @@ void Platform_getBattery(BatteryInfo* info) {
       mib[3] = SENSOR_INTEGER;
       mib[4] = 0; /* "battery state" */
       int64_t batteryState = 0;
-      if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1)
+      if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1 && (s.flags & SENSOR_FUNKNOWN) == 0)
          batteryState = s.value;
 
       mib[3] = SENSOR_WATTS;
       mib[4] = 0; /* "rate" */
-      if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1) {
+      if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1 && (s.flags & SENSOR_FUNKNOWN) == 0) {
          int64_t batteryPower = s.value;
          if (batteryState & 0x02)
             batteryPower = -batteryPower;
@@ -460,10 +465,11 @@ void Platform_getBattery(BatteryInfo* info) {
 
    if (found) {
       /* See "sys/dev/acpi/acpiac.c" of OpenBSD source code.
-         There is only one "sensor" for this device. */
+         There is only one "sensor" for this device.  As with acpibat, an
+         FUNKNOWN reading must not be promoted to AC_ABSENT. */
       mib[3] = SENSOR_INDICATOR;
       mib[4] = 0; /* "power supply" (status indicator) */
-      if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1)
+      if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1 && (s.flags & SENSOR_FUNKNOWN) == 0)
          info->ac = s.value != 0 ? AC_PRESENT : AC_ABSENT;
    }
 }

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -399,13 +399,7 @@ void Platform_getBattery(BatteryInfo* info) {
       int64_t totalRemain = 0;
       int64_t totalPower = 0;
 
-      /* See "sys/dev/acpi/acpibat.c" of OpenBSD source code for the indices
-         of the last field.
-
-         OpenBSD acpibat can return a successful sysctl with the
-         SENSOR_FUNKNOWN flag set and a meaningless zero value when the
-         kernel cannot determine the underlying _BST/_BIF field.  Treat
-         such readings as missing rather than as a known zero. */
+      /* See sys/dev/acpi/acpibat.c. FUNKNOWN means cur-value is meaningless. */
       mib[3] = SENSOR_WATTHOUR;
       mib[4] = 0; /* "last full capacity" */
       bool haveBatteryFull = false;
@@ -431,9 +425,7 @@ void Platform_getBattery(BatteryInfo* info) {
       }
 
       if (haveTotalRemain && haveTotalFull && totalFull > 0) {
-         /* Clamp curr to full before publishing: a quirky firmware can
-          * report remaining > last-full, which would let info->energyCurr
-          * exceed info->energyFull and percent exceed 100. */
+         /* Clamp remain <= full (firmware may report remain > last-full). */
          int64_t clampedRemain = totalRemain > totalFull ? totalFull : totalRemain;
          info->percent = ((double) clampedRemain * 100.0) / (double) totalFull;
 
@@ -447,13 +439,7 @@ void Platform_getBattery(BatteryInfo* info) {
       if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1 && (s.flags & SENSOR_FUNKNOWN) == 0)
          batteryState = s.value;
 
-      /* OpenBSD acpibat publishes the rate sensor as either SENSOR_WATTS
-       * (mW firmware) or SENSOR_AMPS (mA firmware). Try Watts first; if
-       * that's absent or unknown, fall back to Amps × Volts. The voltage
-       * sensor is exposed as SENSOR_VOLTS_DC[1] (present voltage). All
-       * sensor values are in 10^-6 SI units, so amps×volts produces
-       * 10^-12 W; dividing by 10^6 gives µW that the publication block
-       * below converts to W. */
+      /* Watts first; fall back to amps × volts on mA firmware. */
       bool haveRate = false;
       int64_t batteryPower = 0;
 
@@ -470,12 +456,7 @@ void Platform_getBattery(BatteryInfo* info) {
          struct sensor amps;
          size_t alen = sizeof(struct sensor);
          if (sysctl(mib, 5, &amps, &alen, NULL, 0) != -1 && (amps.flags & SENSOR_FUNKNOWN) == 0) {
-            /* Per BatteryMeter.h's voltage convention: instantaneous I*V
-             * power wants the present terminal voltage. acpibat exposes
-             * SENSOR_VOLTS_DC[0] = design voltage, SENSOR_VOLTS_DC[1] =
-             * present voltage. Try the present voltage first; fall back
-             * to design only if the present sensor is missing or
-             * FUNKNOWN-flagged. */
+            /* VOLTS_DC[1]=present, [0]=design; prefer present for I*V. */
             struct sensor volts;
             size_t vlen = sizeof(struct sensor);
             bool haveVolts = false;
@@ -506,10 +487,7 @@ void Platform_getBattery(BatteryInfo* info) {
       }
 
       if (haveRate) {
-         /* htop convention: positive=discharging, negative=charging. ACPI
-          * state bit 0x01 = discharging, 0x02 = charging. Some firmware
-          * sets both bits; the kernel resolves to discharging in that
-          * case, so only negate when 0x02 is set and 0x01 is clear. */
+         /* Negate only when CHARGING set and DISCHARG clear. */
          if ((batteryState & 0x02) && !(batteryState & 0x01))
             batteryPower = -batteryPower;
 
@@ -525,9 +503,7 @@ void Platform_getBattery(BatteryInfo* info) {
    found = findDevice("acpiac0", mib, &snsrdev, &sdlen);
 
    if (found) {
-      /* See "sys/dev/acpi/acpiac.c" of OpenBSD source code.
-         There is only one "sensor" for this device.  As with acpibat, an
-         FUNKNOWN reading must not be promoted to AC_ABSENT. */
+      /* See sys/dev/acpi/acpiac.c; FUNKNOWN must not become AC_ABSENT. */
       mib[3] = SENSOR_INDICATOR;
       mib[4] = 0; /* "power supply" (status indicator) */
       if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1 && (s.flags & SENSOR_FUNKNOWN) == 0)

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -26,6 +26,7 @@ in the source distribution for its full text.
 #include <sys/types.h>
 #include <uvm/uvmexp.h>
 
+#include "Battery.h"
 #include "CPUMeter.h"
 #include "DateTimeMeter.h"
 #include "FileDescriptorMeter.h"
@@ -373,10 +374,64 @@ static bool findDevice(const char* name, int* mib, struct sensordev* snsrdev, si
    }
 }
 
+/* Read one numeric sensor (typed and indexed by mib[3..4]) into out_ptr.
+ * Returns false when the sensor is missing or marked FUNKNOWN. */
+static bool readSensor(int* mib, int type, int idx, struct sensor* out) {
+   size_t len = sizeof(*out);
+   mib[3] = type;
+   mib[4] = idx;
+   if (sysctl(mib, 5, out, &len, NULL, 0) == -1)
+      return false;
+   if (out->flags & SENSOR_FUNKNOWN)
+      return false;
+   return true;
+}
+
+static bool parseAcpibatBattery(int* mib, BatteryRaw* out) {
+   *out = (BatteryRaw){
+      .level = NAN,
+      .energyFull = NAN, .energyNow = NAN,
+      .chargeFull = NAN, .chargeNow = NAN,
+      .voltageNow = NAN, .voltageDesign = NAN,
+      .current = NAN, .power = NAN,
+   };
+
+   /* See sys/dev/acpi/acpibat.c for the sensor layout. */
+   struct sensor s;
+
+   /* VOLTS_DC[0]=design, [1]=present. */
+   if (readSensor(mib, SENSOR_VOLTS_DC, 0, &s) && s.value > 0)
+      out->voltageDesign = (double) s.value / 1000000.0;
+   if (readSensor(mib, SENSOR_VOLTS_DC, 1, &s) && s.value > 0)
+      out->voltageNow = (double) s.value / 1000000.0;
+
+   if (readSensor(mib, SENSOR_WATTHOUR, 0, &s) && s.value > 0)
+      out->energyFull = (double) s.value / 1000000.0;
+   if (readSensor(mib, SENSOR_WATTHOUR, 3, &s) && s.value >= 0)
+      out->energyNow = (double) s.value / 1000000.0;
+
+   /* INTEGER[0]=battery state mask: 0x01 DISCHARG, 0x02 CHARGING. */
+   int64_t batteryState = 0;
+   if (readSensor(mib, SENSOR_INTEGER, 0, &s))
+      batteryState = s.value;
+
+   bool charging = (batteryState & 0x02) && !(batteryState & 0x01);
+   double sign = charging ? -1.0 : 1.0;
+
+   /* Watts first; fall back to amps × volts on mA-reporting firmware. */
+   if (readSensor(mib, SENSOR_WATTS, 0, &s)) {
+      out->power = sign * ((double) s.value / 1000000.0);
+   } else if (readSensor(mib, SENSOR_AMPS, 0, &s)) {
+      out->current = sign * ((double) s.value / 1000000.0);
+   }
+
+   /* Returning true even when only voltage was readable lets the
+    * aggregator's NaN-handling decide what (if anything) to publish. */
+   return true;
+}
+
 void Platform_getBattery(BatteryInfo* info) {
    int mib[] = {CTL_HW, HW_SENSORS, 0, 0, 0};
-   struct sensor s;
-   size_t slen = sizeof(struct sensor);
    struct sensordev snsrdev;
    size_t sdlen = sizeof(struct sensordev);
 
@@ -388,125 +443,16 @@ void Platform_getBattery(BatteryInfo* info) {
       .energyFull = NAN,
    };
 
-   bool found = findDevice("acpibat0", mib, &snsrdev, &sdlen);
-
-   if (found) {
-      bool haveTotalFull = false;
-      bool haveTotalRemain = false;
-      bool haveTotalPower = false;
-
-      int64_t totalFull = 0;     /* µWh */
-      int64_t totalRemain = 0;   /* µWh */
-      int64_t totalPower = 0;    /* µW */
-
-      /* See sys/dev/acpi/acpibat.c. FUNKNOWN means cur-value is meaningless. */
-      mib[3] = SENSOR_WATTHOUR;
-      mib[4] = 0; /* "last full capacity" */
-      bool haveBatteryFull = false;
-      int64_t batteryFull = 0;
-      if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1 && (s.flags & SENSOR_FUNKNOWN) == 0)
-         batteryFull = s.value;
-
-      if (batteryFull > 0)
-         haveBatteryFull = true;
-
-      if (haveBatteryFull) {
-         mib[3] = SENSOR_WATTHOUR;
-         mib[4] = 3; /* "remaining capacity" */
-         if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1 && (s.flags & SENSOR_FUNKNOWN) == 0) {
-            int64_t batteryRemain = s.value;
-            if (batteryRemain >= 0) {
-               totalRemain += batteryRemain;
-               totalFull += batteryFull;
-               haveTotalRemain = true;
-               haveTotalFull = true;
-            }
-         }
-      }
-
-      if (haveTotalRemain && haveTotalFull && totalFull > 0) {
-         /* Clamp remain <= full (firmware may report remain > last-full). */
-         int64_t clampedRemain = MINIMUM(totalRemain, totalFull);
-         info->percent = ((double) clampedRemain * 100.0) / (double) totalFull;
-
-         info->energyCurr = (double) clampedRemain / 1000000.0;
-         info->energyFull = (double) totalFull / 1000000.0;
-      }
-
-      mib[3] = SENSOR_INTEGER;
-      mib[4] = 0; /* "battery state" */
-      int64_t batteryState = 0;
-      if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1 && (s.flags & SENSOR_FUNKNOWN) == 0)
-         batteryState = s.value;
-
-      /* Watts first; fall back to amps × volts on mA firmware. */
-      bool haveRate = false;
-      int64_t batteryPower = 0;
-
-      mib[3] = SENSOR_WATTS;
-      mib[4] = 0; /* "rate" */
-      if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1 && (s.flags & SENSOR_FUNKNOWN) == 0) {
-         batteryPower = s.value;
-         haveRate = true;
-      }
-
-      if (!haveRate) {
-         mib[3] = SENSOR_AMPS;
-         mib[4] = 0; /* "rate" (mA firmware) */
-         struct sensor amps;
-         size_t alen = sizeof(struct sensor);
-         if (sysctl(mib, 5, &amps, &alen, NULL, 0) != -1 && (amps.flags & SENSOR_FUNKNOWN) == 0) {
-            /* VOLTS_DC[1]=present, [0]=design; prefer present for I*V. */
-            struct sensor volts;
-            size_t vlen = sizeof(struct sensor);
-            bool haveVolts = false;
-
-            mib[3] = SENSOR_VOLTS_DC;
-            mib[4] = 1; /* present voltage */
-            if (sysctl(mib, 5, &volts, &vlen, NULL, 0) != -1
-                  && (volts.flags & SENSOR_FUNKNOWN) == 0
-                  && volts.value > 0) {
-               haveVolts = true;
-            }
-
-            if (!haveVolts) {
-               mib[4] = 0; /* design voltage fallback */
-               vlen = sizeof(struct sensor);
-               if (sysctl(mib, 5, &volts, &vlen, NULL, 0) != -1
-                     && (volts.flags & SENSOR_FUNKNOWN) == 0
-                     && volts.value > 0) {
-                  haveVolts = true;
-               }
-            }
-
-            if (haveVolts) {
-               batteryPower = ((int64_t) amps.value * (int64_t) volts.value) / 1000000;
-               haveRate = true;
-            }
-         }
-      }
-
-      if (haveRate) {
-         /* Negate only when CHARGING set and DISCHARG clear. */
-         if ((batteryState & 0x02) && !(batteryState & 0x01))
-            batteryPower = -batteryPower;
-
-         totalPower += batteryPower;
-         haveTotalPower = true;
-      }
-
-      if (haveTotalPower) {
-         info->powerCurr = (double) totalPower / 1000000.0;
-      }
+   if (findDevice("acpibat0", mib, &snsrdev, &sdlen)) {
+      BatteryRaw raw;
+      if (parseAcpibatBattery(mib, &raw))
+         Battery_aggregate(&raw, 1, info);
    }
 
-   found = findDevice("acpiac0", mib, &snsrdev, &sdlen);
-
-   if (found) {
+   if (findDevice("acpiac0", mib, &snsrdev, &sdlen)) {
       /* See sys/dev/acpi/acpiac.c; FUNKNOWN must not become AC_ABSENT. */
-      mib[3] = SENSOR_INDICATOR;
-      mib[4] = 0; /* "power supply" (status indicator) */
-      if (sysctl(mib, 5, &s, &slen, NULL, 0) != -1 && (s.flags & SENSOR_FUNKNOWN) == 0)
+      struct sensor s;
+      if (readSensor(mib, SENSOR_INDICATOR, 0, &s))
          info->ac = s.value != 0 ? AC_PRESENT : AC_ABSENT;
    }
 }

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -484,7 +484,11 @@ void Platform_getBattery(BatteryInfo* info) {
       }
 
       if (haveRate) {
-         if (batteryState & 0x02)
+         /* htop convention: positive=discharging, negative=charging. ACPI
+          * state bit 0x01 = discharging, 0x02 = charging. Some firmware
+          * sets both bits; the kernel resolves to discharging in that
+          * case, so only negate when 0x02 is set and 0x01 is clear. */
+         if ((batteryState & 0x02) && !(batteryState & 0x01))
             batteryPower = -batteryPower;
 
          totalPower += batteryPower;

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -69,7 +69,7 @@ bool Platform_getDiskIO(DiskIOData* data);
 
 bool Platform_getNetworkIO(NetworkIOData* data);
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC);
+void Platform_getBattery(BatteryInfo* info);
 
 static inline void Platform_getHostname(char* buffer, size_t size) {
    Generic_hostname(buffer, size);

--- a/pcp/Metric.c
+++ b/pcp/Metric.c
@@ -56,6 +56,9 @@ pmAtomValue* Metric_values(Metric metric, pmAtomValue* atom, int count, int type
 }
 
 int Metric_instanceCount(Metric metric) {
+   if (pcp->result == NULL)
+      return 0;
+
    pmValueSet* vset = pcp->result->vset[metric];
    if (vset)
       return vset->numval;
@@ -63,6 +66,9 @@ int Metric_instanceCount(Metric metric) {
 }
 
 int Metric_instanceOffset(Metric metric, int inst) {
+   if (pcp->result == NULL)
+      return 0;
+
    pmValueSet* vset = pcp->result->vset[metric];
    if (!vset || vset->numval <= 0)
       return 0;

--- a/pcp/Metric.h
+++ b/pcp/Metric.h
@@ -107,6 +107,7 @@ typedef enum Metric_ {
    PCP_MEM_ZSWAPPED,            /* mem.util.zswapped */
    PCP_VFS_FILES_COUNT,         /* vfs.files.count */
    PCP_VFS_FILES_MAX,           /* vfs.files.max */
+   PCP_DENKI_POWER_NOW,         /* denki.bat.power_now */
    PCP_DENKI_ENERGY_NOW,        /* denki.bat.energy_now */
    PCP_DENKI_ENERGY_FULL,       /* denki.bat.capacity */
 

--- a/pcp/Metric.h
+++ b/pcp/Metric.h
@@ -107,6 +107,8 @@ typedef enum Metric_ {
    PCP_MEM_ZSWAPPED,            /* mem.util.zswapped */
    PCP_VFS_FILES_COUNT,         /* vfs.files.count */
    PCP_VFS_FILES_MAX,           /* vfs.files.max */
+   PCP_DENKI_ENERGY_NOW,        /* denki.bat.energy_now */
+   PCP_DENKI_ENERGY_FULL,       /* denki.bat.capacity */
 
    PCP_PROC_PID,                /* proc.psinfo.pid */
    PCP_PROC_PPID,               /* proc.psinfo.ppid */

--- a/pcp/Metric.h
+++ b/pcp/Metric.h
@@ -109,7 +109,7 @@ typedef enum Metric_ {
    PCP_VFS_FILES_MAX,           /* vfs.files.max */
    PCP_DENKI_POWER_NOW,         /* denki.bat.power_now */
    PCP_DENKI_ENERGY_NOW,        /* denki.bat.energy_now */
-   PCP_DENKI_ENERGY_FULL,       /* denki.bat.capacity */
+   PCP_DENKI_CAPACITY,          /* denki.bat.capacity (percent, 0-100) */
 
    PCP_PROC_PID,                /* proc.psinfo.pid */
    PCP_PROC_PPID,               /* proc.psinfo.ppid */

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -867,6 +867,8 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 }
 

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -234,6 +234,8 @@ static const char* Platform_metricNames[] = {
    [PCP_MEM_ZSWAPPED] = "mem.util.zswapped",
    [PCP_VFS_FILES_COUNT] = "vfs.files.count",
    [PCP_VFS_FILES_MAX] = "vfs.files.max",
+   [PCP_DENKI_ENERGY_NOW] = "denki.bat.energy_now",
+   [PCP_DENKI_ENERGY_FULL] = "denki.bat.capacity",
 
    [PCP_PROC_PID] = "proc.psinfo.pid",
    [PCP_PROC_PPID] = "proc.psinfo.ppid",
@@ -864,12 +866,37 @@ void Platform_getFileDescriptors(double* used, double* max) {
 }
 
 void Platform_getBattery(BatteryInfo* info) {
-   *info = (BatteryInfo) {
-      .ac = AC_ERROR,
-      .percent = NAN,
-      .energyCurr = NAN,
-      .energyFull = NAN,
-   };
+   info->ac = AC_ERROR;
+   info->percent = NAN;
+   info->energyCurr = NAN;
+   info->energyFull = NAN;
+
+   if (Metric_desc(PCP_DENKI_ENERGY_NOW) == NULL)
+      return;
+
+   int i, count = Metric_instanceCount(PCP_DENKI_ENERGY_NOW);
+   if (count < 1) {
+      info->ac = AC_PRESENT;
+      return;
+   }
+
+   pmAtomValue* batteryEnergyCurr = xCalloc(count, sizeof(pmAtomValue));
+   pmAtomValue* batteryEnergyFull = xCalloc(count, sizeof(pmAtomValue));
+   if (Metric_values(PCP_DENKI_ENERGY_NOW, batteryEnergyCurr, count, PM_TYPE_DOUBLE) &&
+       Metric_values(PCP_DENKI_ENERGY_FULL, batteryEnergyFull, count, PM_TYPE_DOUBLE)) {
+      info->energyCurr = 0.0;
+      info->energyFull = 0.0;
+      for (i = 0; i < count; i++) {
+         info->energyCurr += CLAMP(batteryEnergyCurr[i].d, 0, batteryEnergyFull[i].d);
+         info->energyFull += isNonnegative(batteryEnergyFull[i].d) ? batteryEnergyFull[i].d : 0;
+      }
+
+      if (info->energyFull > 0) {
+         info->percent = CLAMP((info->energyCurr / info->energyFull) * 100.0, 0.0, 100.0);
+      }
+   }
+   free(batteryEnergyCurr);
+   free(batteryEnergyFull);
 }
 
 const char* Platform_getFailedState(void) {

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -234,6 +234,7 @@ static const char* Platform_metricNames[] = {
    [PCP_MEM_ZSWAPPED] = "mem.util.zswapped",
    [PCP_VFS_FILES_COUNT] = "vfs.files.count",
    [PCP_VFS_FILES_MAX] = "vfs.files.max",
+   [PCP_DENKI_POWER_NOW] = "denki.bat.power_now",
    [PCP_DENKI_ENERGY_NOW] = "denki.bat.energy_now",
    [PCP_DENKI_ENERGY_FULL] = "denki.bat.capacity",
 
@@ -868,6 +869,7 @@ void Platform_getFileDescriptors(double* used, double* max) {
 void Platform_getBattery(BatteryInfo* info) {
    info->ac = AC_ERROR;
    info->percent = NAN;
+   info->powerCurr = NAN;
    info->energyCurr = NAN;
    info->energyFull = NAN;
 
@@ -897,6 +899,19 @@ void Platform_getBattery(BatteryInfo* info) {
    }
    free(batteryEnergyCurr);
    free(batteryEnergyFull);
+
+   pmAtomValue* batteryPowerCurr = xCalloc(count, sizeof(pmAtomValue));
+   if (Metric_values(PCP_DENKI_POWER_NOW, batteryPowerCurr, count, PM_TYPE_DOUBLE)) {
+      info->powerCurr = 0.0;
+      for (i = 0; i < count; i++) {
+         info->powerCurr += batteryPowerCurr[i].d;
+      }
+   }
+   free(batteryPowerCurr);
+
+   if (info->powerCurr < 0) {
+      info->ac = AC_ABSENT;
+   }
 }
 
 const char* Platform_getFailedState(void) {

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -863,9 +863,11 @@ void Platform_getFileDescriptors(double* used, double* max) {
       *max = value.l;
 }
 
-void Platform_getBattery(double* level, ACPresence* isOnAC) {
-   *level = NAN;
-   *isOnAC = AC_ERROR;
+void Platform_getBattery(BatteryInfo* info) {
+   *info = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
 }
 
 const char* Platform_getFailedState(void) {

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -888,8 +888,11 @@ void Platform_getBattery(BatteryInfo* info) {
    int count = Metric_instanceCount(PCP_DENKI_CAPACITY);
    if (count < 1)
       return;
+   /* Refuse partial aggregation when more battery instances are reported
+    * than the fixed buffer holds; percent stays NaN rather than under-
+    * counted. */
    if (count > DENKI_MAX_BATTERIES)
-      count = DENKI_MAX_BATTERIES;
+      return;
 
    BatteryRaw raws[DENKI_MAX_BATTERIES];
    int instIds[DENKI_MAX_BATTERIES];

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -1013,8 +1013,12 @@ void Platform_getBattery(BatteryInfo* info) {
          }
          totalPower += atom.d;
       }
-      if (allMatched && aggregateComplete)
-         info->powerCurr = totalPower;
+      if (allMatched && aggregateComplete) {
+         /* denki.bat.power_now is the raw sysfs power_now value in
+          * microwatts; BatteryInfo.powerCurr contracts to watts. Divide
+          * before publishing, matching the linux/freebsd conversion. */
+         info->powerCurr = totalPower / 1000000.0;
+      }
    }
 
    free(batteryInst);

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -461,7 +461,6 @@ bool Platform_init(void) {
     * is visible at the call site of Platform_getBattery and survives any
     * future refactor of the bulk-enable loop. */
    Metric_enable(PCP_DENKI_CAPACITY, true);
-   Metric_enable(PCP_DENKI_ENERGY_NOW, true);
    Metric_enable(PCP_DENKI_POWER_NOW, true);
 
    /* enable metrics for all dynamic columns (including those from dynamic screens) */
@@ -928,47 +927,26 @@ void Platform_getBattery(BatteryInfo* info) {
    }
    bool haveCapacity = capacityCount > 0;
 
-   /* denki.bat.energy_now is optional and ambiguous: the denki PMDA can back
-    * this metric with sysfs ENERGY_NOW (Wh, true energy) OR sysfs CHARGE_NOW
-    * (uAh / mAh, charge -- NOT energy). The metric descriptor does not
-    * disclose which backing source was used, so we cannot distinguish the
-    * two from the metric alone. BatteryMeter.h contracts info->energyCurr
-    * to be in Wh, so we deliberately do NOT publish info->energyCurr from
-    * PCP -- it stays NaN (the default set above). The denki PMDA also does
-    * not expose a corresponding ENERGY_FULL metric, so info->energyFull
-    * likewise stays NaN.
+   /* denki.bat.energy_now is intentionally unused.
     *
-    * We still read these values for the energy-weighted percent calculation
-    * below: on a single host all denki instances share the same backing
-    * source (whichever the kernel exposes for that battery class), so the
-    * intra-host ratio energy_now / inferred_full is dimensionally consistent
-    * even when the unit is charge rather than energy. Percent is unitless,
-    * so the result is meaningful regardless of which sysfs field backs the
-    * metric. The variable retains the "Energy" name to match the metric id,
-    * but readers should treat its values as opaque samples whose unit may
-    * be Wh or charge. */
-   pmAtomValue* batteryEnergyCurr = NULL;
-   bool haveEnergy = false;
-   if (Metric_desc(PCP_DENKI_ENERGY_NOW) != NULL && haveCapacity) {
-      batteryEnergyCurr = xCalloc(capacityCount, sizeof(pmAtomValue));
-      /* Look up energy_now per capacity instance id. If any capacity
-       * instance has no matching energy_now value, leave haveEnergy=false
-       * so we fall back to the simple unweighted capacity average rather
-       * than producing a result misaligned by instance id. */
-      bool allMatched = true;
-      for (int i = 0; i < capacityCount; i++) {
-         pmAtomValue atom;
-         if (Metric_instance(PCP_DENKI_ENERGY_NOW, batteryInst[i], 0, &atom, PM_TYPE_DOUBLE) == NULL) {
-            allMatched = false;
-            break;
-         }
-         batteryEnergyCurr[i] = atom;
-      }
-      if (allMatched) {
-         haveEnergy = true;
-         /* info->energyCurr intentionally NOT set: see comment above. */
-      }
-   }
+    * BatteryMeter.h contracts info->energyCurr to be in Wh, but the denki
+    * PMDA can back denki.bat.energy_now with sysfs ENERGY_NOW (Wh, true
+    * energy) OR sysfs CHARGE_NOW (uAh / mAh, charge -- NOT energy), and
+    * the metric descriptor does not disclose which backing source was
+    * used. info->energyCurr therefore stays NaN (the default set above);
+    * the denki PMDA also does not expose a corresponding ENERGY_FULL
+    * metric, so info->energyFull likewise stays NaN.
+    *
+    * We previously also used these samples for an energy-weighted percent
+    * across multiple batteries, on the assumption that all denki instances
+    * on one host share a single backing source. That assumption is wrong:
+    * the kernel can back ENERGY_NOW for one battery and CHARGE_NOW for
+    * another on the same host (different battery class drivers), so
+    * summing eNow / (cap/100) across instances mixes Wh and mAh and
+    * yields a meaningless ratio. We cannot detect homogeneity from PCP,
+    * so the only safe behaviour for multi-battery hosts is the unweighted
+    * capacity average. The energy_now metric is therefore not enabled or
+    * read here. */
 
    if (haveCapacity) {
       if (capacityCount == 1) {
@@ -976,59 +954,22 @@ void Platform_getBattery(BatteryInfo* info) {
          if (isNonnegative(batteryCapacity[0].d))
             info->percent = CLAMP(batteryCapacity[0].d, 0.0, 100.0);
       } else {
-         /* Multi-battery aggregation. Energy-weighted is preferred for
-          * unequal-sized batteries (e.g. 90Wh@50% + 10Wh@100% should report
-          * 55%, not 75%), but inferring per-instance full energy from
-          * energy_now / (capacity/100) requires capacity > 0. If any
-          * instance is depleted we cannot infer its size, so fall back to
-          * a simple unweighted capacity average -- less accurate when
-          * batteries differ in size, but it correctly handles 0% values
-          * (equal batteries at 0% and 100% report 50%, not 100%; all at
-          * 0% report 0%, not NaN). */
-         bool anyZeroCapacity = false;
+         /* Multi-battery: unweighted capacity average. An energy-weighted
+          * average would be more accurate for unequal-sized batteries
+          * (e.g. 90Wh@50% + 10Wh@100% should report 55%, not 75%), but it
+          * requires that every instance's energy_now sample share a unit.
+          * The denki PMDA does not guarantee that across a host (see the
+          * comment above), so we always use the unweighted average here. */
+         double total = 0.0;
+         int valid = 0;
          for (int i = 0; i < capacityCount; i++) {
-            /* "Capacity is exactly zero": nonnegative (rules out NaN and
-             * negatives) and not positive. Avoids -Wfloat-equal. */
-            if (isNonnegative(batteryCapacity[i].d) && !isPositive(batteryCapacity[i].d)) {
-               anyZeroCapacity = true;
-               break;
+            if (isNonnegative(batteryCapacity[i].d)) {
+               total += CLAMP(batteryCapacity[i].d, 0.0, 100.0);
+               valid++;
             }
          }
-         if (haveEnergy && !anyZeroCapacity) {
-            /* Energy-weighted: every instance has cap > 0 so per-instance
-             * full energy is well-defined. batteryEnergyCurr[i] is the
-             * energy_now sample for the SAME instance id as
-             * batteryCapacity[i] (joined via Metric_instance above), not
-             * merely the same array offset. */
-            double totalEnergyNow = 0.0;
-            double totalEnergyFull = 0.0;
-            for (int i = 0; i < capacityCount; i++) {
-               double cap = batteryCapacity[i].d;
-               double eNow = batteryEnergyCurr[i].d;
-               if (isNonnegative(cap) && cap > 0.0 && isNonnegative(eNow)) {
-                  double eFull = eNow / (cap / 100.0);
-                  totalEnergyNow += eNow;
-                  totalEnergyFull += eFull;
-               }
-            }
-            if (totalEnergyFull > 0.0) {
-               info->percent = CLAMP((totalEnergyNow / totalEnergyFull) * 100.0, 0.0, 100.0);
-            }
-         } else {
-            /* Unweighted average: used when energy_now is unavailable,
-             * partially-reported (instance mismatch), or any instance is
-             * depleted (so we cannot infer its size). */
-            double total = 0.0;
-            int valid = 0;
-            for (int i = 0; i < capacityCount; i++) {
-               if (isNonnegative(batteryCapacity[i].d)) {
-                  total += batteryCapacity[i].d;
-                  valid++;
-               }
-            }
-            if (valid > 0) {
-               info->percent = CLAMP(total / valid, 0.0, 100.0);
-            }
+         if (valid > 0) {
+            info->percent = total / valid;
          }
       }
    }
@@ -1054,7 +995,6 @@ void Platform_getBattery(BatteryInfo* info) {
          info->powerCurr = totalPower;
    }
 
-   free(batteryEnergyCurr);
    free(batteryInst);
    free(batteryCapacity);
 

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -234,6 +234,10 @@ static const char* Platform_metricNames[] = {
    [PCP_MEM_ZSWAPPED] = "mem.util.zswapped",
    [PCP_VFS_FILES_COUNT] = "vfs.files.count",
    [PCP_VFS_FILES_MAX] = "vfs.files.max",
+   /* The denki.bat.* metrics are optional - they require the denki PMDA.
+    * pmLookupName tolerates missing individual metrics; Metric_desc()
+    * returns NULL at runtime if a metric was not resolved, which the
+    * battery code uses to short-circuit the path. */
    [PCP_DENKI_POWER_NOW] = "denki.bat.power_now",
    [PCP_DENKI_ENERGY_NOW] = "denki.bat.energy_now",
    [PCP_DENKI_CAPACITY] = "denki.bat.capacity",

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -928,10 +928,25 @@ void Platform_getBattery(BatteryInfo* info) {
    }
    bool haveCapacity = capacityCount > 0;
 
-   /* denki.bat.energy_now (sysfs ENERGY_NOW, Wh) is optional. The denki PMDA
-    * does not expose a corresponding ENERGY_FULL metric, so info->energyFull
-    * stays NaN; we read energy_now both to populate info->energyCurr and to
-    * infer per-instance full-charge energy for a capacity-weighted average. */
+   /* denki.bat.energy_now is optional and ambiguous: the denki PMDA can back
+    * this metric with sysfs ENERGY_NOW (Wh, true energy) OR sysfs CHARGE_NOW
+    * (uAh / mAh, charge -- NOT energy). The metric descriptor does not
+    * disclose which backing source was used, so we cannot distinguish the
+    * two from the metric alone. BatteryMeter.h contracts info->energyCurr
+    * to be in Wh, so we deliberately do NOT publish info->energyCurr from
+    * PCP -- it stays NaN (the default set above). The denki PMDA also does
+    * not expose a corresponding ENERGY_FULL metric, so info->energyFull
+    * likewise stays NaN.
+    *
+    * We still read these values for the energy-weighted percent calculation
+    * below: on a single host all denki instances share the same backing
+    * source (whichever the kernel exposes for that battery class), so the
+    * intra-host ratio energy_now / inferred_full is dimensionally consistent
+    * even when the unit is charge rather than energy. Percent is unitless,
+    * so the result is meaningful regardless of which sysfs field backs the
+    * metric. The variable retains the "Energy" name to match the metric id,
+    * but readers should treat its values as opaque samples whose unit may
+    * be Wh or charge. */
    pmAtomValue* batteryEnergyCurr = NULL;
    bool haveEnergy = false;
    if (Metric_desc(PCP_DENKI_ENERGY_NOW) != NULL && haveCapacity) {
@@ -941,7 +956,6 @@ void Platform_getBattery(BatteryInfo* info) {
        * so we fall back to the simple unweighted capacity average rather
        * than producing a result misaligned by instance id. */
       bool allMatched = true;
-      double total = 0.0;
       for (int i = 0; i < capacityCount; i++) {
          pmAtomValue atom;
          if (Metric_instance(PCP_DENKI_ENERGY_NOW, batteryInst[i], 0, &atom, PM_TYPE_DOUBLE) == NULL) {
@@ -949,12 +963,10 @@ void Platform_getBattery(BatteryInfo* info) {
             break;
          }
          batteryEnergyCurr[i] = atom;
-         if (isNonnegative(atom.d))
-            total += atom.d;
       }
       if (allMatched) {
          haveEnergy = true;
-         info->energyCurr = total;
+         /* info->energyCurr intentionally NOT set: see comment above. */
       }
    }
 

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -886,30 +886,20 @@ void Platform_getBattery(BatteryInfo* info) {
       return;
    }
 
-   /* denki.bat.capacity is the sysfs CAPACITY field (percent, 0-100).
-    * Average across battery instances to produce an overall percent. */
+   /* denki.bat.capacity is the sysfs CAPACITY field (percent, 0-100). */
    pmAtomValue* batteryCapacity = xCalloc(count, sizeof(pmAtomValue));
-   if (Metric_values(PCP_DENKI_CAPACITY, batteryCapacity, count, PM_TYPE_DOUBLE)) {
-      double total = 0.0;
-      int valid = 0;
-      for (i = 0; i < count; i++) {
-         if (isNonnegative(batteryCapacity[i].d)) {
-            total += batteryCapacity[i].d;
-            valid++;
-         }
-      }
-      if (valid > 0) {
-         info->percent = CLAMP(total / valid, 0.0, 100.0);
-      }
-   }
-   free(batteryCapacity);
+   bool haveCapacity = Metric_values(PCP_DENKI_CAPACITY, batteryCapacity, count, PM_TYPE_DOUBLE) != NULL;
 
-   /* denki.bat.energy_now (sysfs ENERGY_NOW, Wh) is optional and only
-    * populates info->energyCurr; the denki PMDA does not expose a
-    * corresponding ENERGY_FULL metric, so info->energyFull stays NaN. */
+   /* denki.bat.energy_now (sysfs ENERGY_NOW, Wh) is optional. The denki PMDA
+    * does not expose a corresponding ENERGY_FULL metric, so info->energyFull
+    * stays NaN; we read energy_now both to populate info->energyCurr and to
+    * infer per-instance full-charge energy for a capacity-weighted average. */
+   pmAtomValue* batteryEnergyCurr = NULL;
+   bool haveEnergy = false;
    if (Metric_desc(PCP_DENKI_ENERGY_NOW) != NULL) {
-      pmAtomValue* batteryEnergyCurr = xCalloc(count, sizeof(pmAtomValue));
+      batteryEnergyCurr = xCalloc(count, sizeof(pmAtomValue));
       if (Metric_values(PCP_DENKI_ENERGY_NOW, batteryEnergyCurr, count, PM_TYPE_DOUBLE)) {
+         haveEnergy = true;
          double total = 0.0;
          for (i = 0; i < count; i++) {
             if (isNonnegative(batteryEnergyCurr[i].d))
@@ -917,8 +907,52 @@ void Platform_getBattery(BatteryInfo* info) {
          }
          info->energyCurr = total;
       }
-      free(batteryEnergyCurr);
    }
+
+   if (haveCapacity) {
+      if (count == 1) {
+         /* Single battery: use its capacity directly; no aggregation needed. */
+         if (isNonnegative(batteryCapacity[0].d))
+            info->percent = CLAMP(batteryCapacity[0].d, 0.0, 100.0);
+      } else if (haveEnergy) {
+         /* Multi-battery: weight by inferred per-instance full energy
+          * (energy_now / (capacity/100)). This yields the correct overall
+          * percent for unequal-sized batteries, e.g. 90Wh@50% + 10Wh@100%
+          * reports 55%, not the 75% a simple average would give. */
+         double totalEnergyNow = 0.0;
+         double totalEnergyFull = 0.0;
+         for (i = 0; i < count; i++) {
+            double cap = batteryCapacity[i].d;
+            double eNow = batteryEnergyCurr[i].d;
+            if (isNonnegative(cap) && cap > 0.0 && isNonnegative(eNow)) {
+               double eFull = eNow / (cap / 100.0);
+               totalEnergyNow += eNow;
+               totalEnergyFull += eFull;
+            }
+         }
+         if (totalEnergyFull > 0.0) {
+            info->percent = CLAMP((totalEnergyNow / totalEnergyFull) * 100.0, 0.0, 100.0);
+         }
+      } else {
+         /* Multi-battery with no energy_now: fall back to a simple average.
+          * This is inaccurate when batteries have unequal capacities, but
+          * without per-instance energy data we cannot infer their sizes. */
+         double total = 0.0;
+         int valid = 0;
+         for (i = 0; i < count; i++) {
+            if (isNonnegative(batteryCapacity[i].d)) {
+               total += batteryCapacity[i].d;
+               valid++;
+            }
+         }
+         if (valid > 0) {
+            info->percent = CLAMP(total / valid, 0.0, 100.0);
+         }
+      }
+   }
+
+   free(batteryCapacity);
+   free(batteryEnergyCurr);
 
    if (Metric_desc(PCP_DENKI_POWER_NOW) != NULL) {
       pmAtomValue* batteryPowerCurr = xCalloc(count, sizeof(pmAtomValue));
@@ -931,9 +965,10 @@ void Platform_getBattery(BatteryInfo* info) {
       free(batteryPowerCurr);
    }
 
-   if (info->powerCurr < 0) {
-      info->ac = AC_ABSENT;
-   }
+   /* The denki PMDA does not expose AC adapter state, and denki.bat.power_now
+    * is a magnitude (sysfs POWER_NOW is non-negative) rather than a signed
+    * power flow, so we cannot infer charging vs. discharging from its sign.
+    * Leave info->ac as AC_ERROR ("AC unknown") rather than guessing wrong. */
 }
 
 const char* Platform_getFailedState(void) {

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -234,10 +234,7 @@ static const char* Platform_metricNames[] = {
    [PCP_MEM_ZSWAPPED] = "mem.util.zswapped",
    [PCP_VFS_FILES_COUNT] = "vfs.files.count",
    [PCP_VFS_FILES_MAX] = "vfs.files.max",
-   /* The denki.bat.* metrics are optional - they require the denki PMDA.
-    * pmLookupName tolerates missing individual metrics; Metric_desc()
-    * returns NULL at runtime if a metric was not resolved, which the
-    * battery code uses to short-circuit the path. */
+   /* denki PMDA optional; Metric_desc()==NULL short-circuits in battery code. */
    [PCP_DENKI_POWER_NOW] = "denki.bat.power_now",
    [PCP_DENKI_ENERGY_NOW] = "denki.bat.energy_now",
    [PCP_DENKI_CAPACITY] = "denki.bat.capacity",
@@ -453,13 +450,7 @@ bool Platform_init(void) {
    Metric_enable(PCP_UNAME_MACHINE, true);
    Metric_enable(PCP_UNAME_DISTRO, true);
 
-   /* Battery (denki PMDA, optional). Machine_scan only re-enables metrics
-    * with index >= PCP_PROC_PID; everything below that index is enabled
-    * once here in Platform_init and stays enabled for every subsequent
-    * Metric_fetch. The bulk loop further down (`metric < PCP_PROC_PID`)
-    * already covers these, but enable them explicitly so the dependency
-    * is visible at the call site of Platform_getBattery and survives any
-    * future refactor of the bulk-enable loop. */
+   /* Battery (denki PMDA, optional). Explicit enables for visibility. */
    Metric_enable(PCP_DENKI_CAPACITY, true);
    Metric_enable(PCP_DENKI_POWER_NOW, true);
 
@@ -892,34 +883,12 @@ void Platform_getBattery(BatteryInfo* info) {
 
    int count = Metric_instanceCount(PCP_DENKI_CAPACITY);
    if (count < 1) {
-      /* No battery instances. The denki PMDA does not expose AC adapter
-       * state, so absence of batteries does not imply AC presence (e.g. a
-       * desktop with denki loaded but no batteries). Leave info->ac at its
-       * initial AC_ERROR ("AC unknown") rather than claiming AC_PRESENT. */
+      /* denki has no AC sensor; absence of batteries ≠ AC_PRESENT. */
       return;
    }
 
-   /* PCP value sets are keyed by instance id, not array offset. The denki
-    * PMDA can return different instance counts (or different instance sets)
-    * for capacity vs. energy_now vs. power_now -- e.g. a battery present in
-    * sysfs CAPACITY but not yet in ENERGY_NOW. Joining the per-metric arrays
-    * by array offset would silently mismatch the instances. We therefore
-    * walk the capacity metric with Metric_iterate to get authoritative
-    * (instid, offset) pairs, then look up the matching instances in the
-    * other denki metrics with Metric_instance.
-    *
-    * Metric_iterate signals that PCP knows about an instance, but the
-    * subsequent Metric_instance lookup can still fail (transient state, an
-    * instance disappearing between metric refreshes). Silently skipping
-    * such an instance shrinks capacityCount and lets the publication path
-    * report a partial aggregate as if it were whole-pack -- e.g. on a
-    * 2-battery host where one Metric_instance fails, the remaining
-    * battery's percent would be published as the system value. The
-    * aggregateComplete flag tracks whether every iterated instance was
-    * successfully read; if any read failed we conservatively mark the
-    * aggregate incomplete (we don't know which instance dropped out) and
-    * the publication block leaves info->percent and info->powerCurr at
-    * NaN rather than overriding with a partial sum. */
+   /* Join metrics by instance id (not array offset). aggregateComplete
+    * clears on any Metric_instance failure to avoid partial aggregates. */
 
    /* denki.bat.capacity is the sysfs CAPACITY field (percent, 0-100). */
    pmAtomValue* batteryCapacity = xCalloc(count, sizeof(pmAtomValue));
@@ -933,8 +902,7 @@ void Platform_getBattery(BatteryInfo* info) {
             break;
          pmAtomValue atom;
          if (Metric_instance(PCP_DENKI_CAPACITY, instid, offset, &atom, PM_TYPE_DOUBLE) == NULL) {
-            /* We can't tell which instance failed, so mark the aggregate
-             * incomplete and let the publication block fall back to NaN. */
+            /* Unknown which instance dropped; aggregate is incomplete. */
             aggregateComplete = false;
             continue;
          }
@@ -945,50 +913,16 @@ void Platform_getBattery(BatteryInfo* info) {
    }
    bool haveCapacity = capacityCount > 0;
 
-   /* denki.bat.energy_now is intentionally unused.
-    *
-    * BatteryMeter.h contracts info->energyCurr to be in Wh, but the denki
-    * PMDA can back denki.bat.energy_now with sysfs ENERGY_NOW (Wh, true
-    * energy) OR sysfs CHARGE_NOW (uAh / mAh, charge -- NOT energy), and
-    * the metric descriptor does not disclose which backing source was
-    * used. info->energyCurr therefore stays NaN (the default set above);
-    * the denki PMDA also does not expose a corresponding ENERGY_FULL
-    * metric, so info->energyFull likewise stays NaN.
-    *
-    * We previously also used these samples for an energy-weighted percent
-    * across multiple batteries, on the assumption that all denki instances
-    * on one host share a single backing source. That assumption is wrong:
-    * the kernel can back ENERGY_NOW for one battery and CHARGE_NOW for
-    * another on the same host (different battery class drivers), so
-    * summing eNow / (cap/100) across instances mixes Wh and mAh and
-    * yields a meaningless ratio. We cannot detect homogeneity from PCP,
-    * so the only safe behaviour for multi-battery hosts is the unweighted
-    * capacity average. The energy_now metric is therefore not enabled or
-    * read here. */
+   /* energy_now unused: denki may back it with µAh or µWh per instance,
+    * indistinguishably. info->energyCurr/Full stay NaN. */
 
    if (haveCapacity && aggregateComplete) {
       if (capacityCount == 1) {
-         /* Single battery: use its capacity directly; no aggregation needed.
-          * aggregateComplete still matters here -- a 2-battery host where
-          * one Metric_instance failed would otherwise reach this branch
-          * with capacityCount == 1 and publish that battery's percent as
-          * the whole-pack value. */
          if (isNonnegative(batteryCapacity[0].d))
             info->percent = CLAMP(batteryCapacity[0].d, 0.0, 100.0);
       } else {
-         /* Multi-battery: unweighted capacity average. An energy-weighted
-          * average would be more accurate for unequal-sized batteries
-          * (e.g. 90Wh@50% + 10Wh@100% should report 55%, not 75%), but it
-          * requires that every instance's energy_now sample share a unit.
-          * The denki PMDA does not guarantee that across a host (see the
-          * comment above), so we always use the unweighted average here. */
-         /* Require every capacity instance to report a usable value
-          * before averaging. Skipping an unknown/negative sample (sysfs
-          * CAPACITY=-1, NaN propagation through PCP, etc.) and averaging
-          * only the remaining instances would publish a partial pack
-          * percentage as if it covered the whole pack — the same silent-
-          * drop pattern that aggregateComplete already guards against
-          * elsewhere in this function. */
+         /* Unweighted average; mixed Wh/mAh backing prevents weighting.
+          * Any invalid sample blocks publication. */
          double total = 0.0;
          bool allValid = true;
          for (int i = 0; i < capacityCount; i++) {
@@ -1022,11 +956,7 @@ void Platform_getBattery(BatteryInfo* info) {
          totalPower += atom.d;
       }
       if (allMatched && aggregateComplete) {
-         /* denki.bat.power_now is published by the denki PMDA in
-          * watts (the PMDA divides the raw sysfs power_now microwatt
-          * value by 1e6 and labels the metric with units "watt"; see
-          * pcp/src/pmdas/denki/denki.c). Assign the summed double
-          * directly, matching BatteryInfo.powerCurr's contract. */
+         /* denki PMDA already exposes power_now in watts. */
          info->powerCurr = totalPower;
       }
    }
@@ -1034,10 +964,7 @@ void Platform_getBattery(BatteryInfo* info) {
    free(batteryInst);
    free(batteryCapacity);
 
-   /* The denki PMDA does not expose AC adapter state, and denki.bat.power_now
-    * is a magnitude (sysfs POWER_NOW is non-negative) rather than a signed
-    * power flow, so we cannot infer charging vs. discharging from its sign.
-    * Leave info->ac as AC_ERROR ("AC unknown") rather than guessing wrong. */
+   /* denki has no AC sensor; info->ac stays AC_ERROR. */
 }
 
 const char* Platform_getFailedState(void) {

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -882,7 +882,10 @@ void Platform_getBattery(BatteryInfo* info) {
 
    int i, count = Metric_instanceCount(PCP_DENKI_CAPACITY);
    if (count < 1) {
-      info->ac = AC_PRESENT;
+      /* No battery instances. The denki PMDA does not expose AC adapter
+       * state, so absence of batteries does not imply AC presence (e.g. a
+       * desktop with denki loaded but no batteries). Leave info->ac at its
+       * initial AC_ERROR ("AC unknown") rather than claiming AC_PRESENT. */
       return;
    }
 
@@ -914,39 +917,56 @@ void Platform_getBattery(BatteryInfo* info) {
          /* Single battery: use its capacity directly; no aggregation needed. */
          if (isNonnegative(batteryCapacity[0].d))
             info->percent = CLAMP(batteryCapacity[0].d, 0.0, 100.0);
-      } else if (haveEnergy) {
-         /* Multi-battery: weight by inferred per-instance full energy
-          * (energy_now / (capacity/100)). This yields the correct overall
-          * percent for unequal-sized batteries, e.g. 90Wh@50% + 10Wh@100%
-          * reports 55%, not the 75% a simple average would give. */
-         double totalEnergyNow = 0.0;
-         double totalEnergyFull = 0.0;
-         for (i = 0; i < count; i++) {
-            double cap = batteryCapacity[i].d;
-            double eNow = batteryEnergyCurr[i].d;
-            if (isNonnegative(cap) && cap > 0.0 && isNonnegative(eNow)) {
-               double eFull = eNow / (cap / 100.0);
-               totalEnergyNow += eNow;
-               totalEnergyFull += eFull;
-            }
-         }
-         if (totalEnergyFull > 0.0) {
-            info->percent = CLAMP((totalEnergyNow / totalEnergyFull) * 100.0, 0.0, 100.0);
-         }
       } else {
-         /* Multi-battery with no energy_now: fall back to a simple average.
-          * This is inaccurate when batteries have unequal capacities, but
-          * without per-instance energy data we cannot infer their sizes. */
-         double total = 0.0;
-         int valid = 0;
+         /* Multi-battery aggregation. Energy-weighted is preferred for
+          * unequal-sized batteries (e.g. 90Wh@50% + 10Wh@100% should report
+          * 55%, not 75%), but inferring per-instance full energy from
+          * energy_now / (capacity/100) requires capacity > 0. If any
+          * instance is depleted we cannot infer its size, so fall back to
+          * a simple unweighted capacity average — less accurate when
+          * batteries differ in size, but it correctly handles 0% values
+          * (equal batteries at 0% and 100% report 50%, not 100%; all at
+          * 0% report 0%, not NaN). */
+         bool anyZeroCapacity = false;
          for (i = 0; i < count; i++) {
-            if (isNonnegative(batteryCapacity[i].d)) {
-               total += batteryCapacity[i].d;
-               valid++;
+            /* "Capacity is exactly zero": nonnegative (rules out NaN and
+             * negatives) and not positive. Avoids -Wfloat-equal. */
+            if (isNonnegative(batteryCapacity[i].d) && !isPositive(batteryCapacity[i].d)) {
+               anyZeroCapacity = true;
+               break;
             }
          }
-         if (valid > 0) {
-            info->percent = CLAMP(total / valid, 0.0, 100.0);
+         if (haveEnergy && !anyZeroCapacity) {
+            /* Energy-weighted: every instance has cap > 0 so per-instance
+             * full energy is well-defined. */
+            double totalEnergyNow = 0.0;
+            double totalEnergyFull = 0.0;
+            for (i = 0; i < count; i++) {
+               double cap = batteryCapacity[i].d;
+               double eNow = batteryEnergyCurr[i].d;
+               if (isNonnegative(cap) && cap > 0.0 && isNonnegative(eNow)) {
+                  double eFull = eNow / (cap / 100.0);
+                  totalEnergyNow += eNow;
+                  totalEnergyFull += eFull;
+               }
+            }
+            if (totalEnergyFull > 0.0) {
+               info->percent = CLAMP((totalEnergyNow / totalEnergyFull) * 100.0, 0.0, 100.0);
+            }
+         } else {
+            /* Unweighted average: used when energy_now is unavailable or
+             * any instance is depleted (so we cannot infer its size). */
+            double total = 0.0;
+            int valid = 0;
+            for (i = 0; i < count; i++) {
+               if (isNonnegative(batteryCapacity[i].d)) {
+                  total += batteryCapacity[i].d;
+                  valid++;
+               }
+            }
+            if (valid > 0) {
+               info->percent = CLAMP(total / valid, 0.0, 100.0);
+            }
          }
       }
    }

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -453,6 +453,17 @@ bool Platform_init(void) {
    Metric_enable(PCP_UNAME_MACHINE, true);
    Metric_enable(PCP_UNAME_DISTRO, true);
 
+   /* Battery (denki PMDA, optional). Machine_scan only re-enables metrics
+    * with index >= PCP_PROC_PID; everything below that index is enabled
+    * once here in Platform_init and stays enabled for every subsequent
+    * Metric_fetch. The bulk loop further down (`metric < PCP_PROC_PID`)
+    * already covers these, but enable them explicitly so the dependency
+    * is visible at the call site of Platform_getBattery and survives any
+    * future refactor of the bulk-enable loop. */
+   Metric_enable(PCP_DENKI_CAPACITY, true);
+   Metric_enable(PCP_DENKI_ENERGY_NOW, true);
+   Metric_enable(PCP_DENKI_POWER_NOW, true);
+
    /* enable metrics for all dynamic columns (including those from dynamic screens) */
    Metric metric = Metric_fromId(pcp->columns.offset);
    for (; metric < pcp->columns.offset + pcp->columns.count; metric++)
@@ -880,7 +891,7 @@ void Platform_getBattery(BatteryInfo* info) {
    if (Metric_desc(PCP_DENKI_CAPACITY) == NULL)
       return;
 
-   int i, count = Metric_instanceCount(PCP_DENKI_CAPACITY);
+   int count = Metric_instanceCount(PCP_DENKI_CAPACITY);
    if (count < 1) {
       /* No battery instances. The denki PMDA does not expose AC adapter
        * state, so absence of batteries does not imply AC presence (e.g. a
@@ -889,9 +900,33 @@ void Platform_getBattery(BatteryInfo* info) {
       return;
    }
 
+   /* PCP value sets are keyed by instance id, not array offset. The denki
+    * PMDA can return different instance counts (or different instance sets)
+    * for capacity vs. energy_now vs. power_now -- e.g. a battery present in
+    * sysfs CAPACITY but not yet in ENERGY_NOW. Joining the per-metric arrays
+    * by array offset would silently mismatch the instances. We therefore
+    * walk the capacity metric with Metric_iterate to get authoritative
+    * (instid, offset) pairs, then look up the matching instances in the
+    * other denki metrics with Metric_instance. */
+
    /* denki.bat.capacity is the sysfs CAPACITY field (percent, 0-100). */
    pmAtomValue* batteryCapacity = xCalloc(count, sizeof(pmAtomValue));
-   bool haveCapacity = Metric_values(PCP_DENKI_CAPACITY, batteryCapacity, count, PM_TYPE_DOUBLE) != NULL;
+   int* batteryInst = xCalloc(count, sizeof(int));
+   int capacityCount = 0;
+   {
+      int instid = -1, offset = -1;
+      while (Metric_iterate(PCP_DENKI_CAPACITY, &instid, &offset, sizeof(pmAtomValue))) {
+         if (capacityCount >= count)
+            break;
+         pmAtomValue atom;
+         if (Metric_instance(PCP_DENKI_CAPACITY, instid, offset, &atom, PM_TYPE_DOUBLE) == NULL)
+            continue;
+         batteryCapacity[capacityCount] = atom;
+         batteryInst[capacityCount] = instid;
+         capacityCount++;
+      }
+   }
+   bool haveCapacity = capacityCount > 0;
 
    /* denki.bat.energy_now (sysfs ENERGY_NOW, Wh) is optional. The denki PMDA
     * does not expose a corresponding ENERGY_FULL metric, so info->energyFull
@@ -899,21 +934,32 @@ void Platform_getBattery(BatteryInfo* info) {
     * infer per-instance full-charge energy for a capacity-weighted average. */
    pmAtomValue* batteryEnergyCurr = NULL;
    bool haveEnergy = false;
-   if (Metric_desc(PCP_DENKI_ENERGY_NOW) != NULL) {
-      batteryEnergyCurr = xCalloc(count, sizeof(pmAtomValue));
-      if (Metric_values(PCP_DENKI_ENERGY_NOW, batteryEnergyCurr, count, PM_TYPE_DOUBLE)) {
-         haveEnergy = true;
-         double total = 0.0;
-         for (i = 0; i < count; i++) {
-            if (isNonnegative(batteryEnergyCurr[i].d))
-               total += batteryEnergyCurr[i].d;
+   if (Metric_desc(PCP_DENKI_ENERGY_NOW) != NULL && haveCapacity) {
+      batteryEnergyCurr = xCalloc(capacityCount, sizeof(pmAtomValue));
+      /* Look up energy_now per capacity instance id. If any capacity
+       * instance has no matching energy_now value, leave haveEnergy=false
+       * so we fall back to the simple unweighted capacity average rather
+       * than producing a result misaligned by instance id. */
+      bool allMatched = true;
+      double total = 0.0;
+      for (int i = 0; i < capacityCount; i++) {
+         pmAtomValue atom;
+         if (Metric_instance(PCP_DENKI_ENERGY_NOW, batteryInst[i], 0, &atom, PM_TYPE_DOUBLE) == NULL) {
+            allMatched = false;
+            break;
          }
+         batteryEnergyCurr[i] = atom;
+         if (isNonnegative(atom.d))
+            total += atom.d;
+      }
+      if (allMatched) {
+         haveEnergy = true;
          info->energyCurr = total;
       }
    }
 
    if (haveCapacity) {
-      if (count == 1) {
+      if (capacityCount == 1) {
          /* Single battery: use its capacity directly; no aggregation needed. */
          if (isNonnegative(batteryCapacity[0].d))
             info->percent = CLAMP(batteryCapacity[0].d, 0.0, 100.0);
@@ -923,12 +969,12 @@ void Platform_getBattery(BatteryInfo* info) {
           * 55%, not 75%), but inferring per-instance full energy from
           * energy_now / (capacity/100) requires capacity > 0. If any
           * instance is depleted we cannot infer its size, so fall back to
-          * a simple unweighted capacity average — less accurate when
+          * a simple unweighted capacity average -- less accurate when
           * batteries differ in size, but it correctly handles 0% values
           * (equal batteries at 0% and 100% report 50%, not 100%; all at
           * 0% report 0%, not NaN). */
          bool anyZeroCapacity = false;
-         for (i = 0; i < count; i++) {
+         for (int i = 0; i < capacityCount; i++) {
             /* "Capacity is exactly zero": nonnegative (rules out NaN and
              * negatives) and not positive. Avoids -Wfloat-equal. */
             if (isNonnegative(batteryCapacity[i].d) && !isPositive(batteryCapacity[i].d)) {
@@ -938,10 +984,13 @@ void Platform_getBattery(BatteryInfo* info) {
          }
          if (haveEnergy && !anyZeroCapacity) {
             /* Energy-weighted: every instance has cap > 0 so per-instance
-             * full energy is well-defined. */
+             * full energy is well-defined. batteryEnergyCurr[i] is the
+             * energy_now sample for the SAME instance id as
+             * batteryCapacity[i] (joined via Metric_instance above), not
+             * merely the same array offset. */
             double totalEnergyNow = 0.0;
             double totalEnergyFull = 0.0;
-            for (i = 0; i < count; i++) {
+            for (int i = 0; i < capacityCount; i++) {
                double cap = batteryCapacity[i].d;
                double eNow = batteryEnergyCurr[i].d;
                if (isNonnegative(cap) && cap > 0.0 && isNonnegative(eNow)) {
@@ -954,11 +1003,12 @@ void Platform_getBattery(BatteryInfo* info) {
                info->percent = CLAMP((totalEnergyNow / totalEnergyFull) * 100.0, 0.0, 100.0);
             }
          } else {
-            /* Unweighted average: used when energy_now is unavailable or
-             * any instance is depleted (so we cannot infer its size). */
+            /* Unweighted average: used when energy_now is unavailable,
+             * partially-reported (instance mismatch), or any instance is
+             * depleted (so we cannot infer its size). */
             double total = 0.0;
             int valid = 0;
-            for (i = 0; i < count; i++) {
+            for (int i = 0; i < capacityCount; i++) {
                if (isNonnegative(batteryCapacity[i].d)) {
                   total += batteryCapacity[i].d;
                   valid++;
@@ -971,19 +1021,27 @@ void Platform_getBattery(BatteryInfo* info) {
       }
    }
 
-   free(batteryCapacity);
-   free(batteryEnergyCurr);
-
-   if (Metric_desc(PCP_DENKI_POWER_NOW) != NULL) {
-      pmAtomValue* batteryPowerCurr = xCalloc(count, sizeof(pmAtomValue));
-      if (Metric_values(PCP_DENKI_POWER_NOW, batteryPowerCurr, count, PM_TYPE_DOUBLE)) {
-         info->powerCurr = 0.0;
-         for (i = 0; i < count; i++) {
-            info->powerCurr += batteryPowerCurr[i].d;
-         }
+   if (Metric_desc(PCP_DENKI_POWER_NOW) != NULL && haveCapacity) {
+      /* Sum power_now across the same battery instances we saw for
+       * capacity, again joining by instance id rather than array offset.
+       * Skip instances missing from power_now rather than counting them
+       * as 0 (a missing sample is not the same as a zero sample). */
+      double totalPower = 0.0;
+      bool anyPower = false;
+      for (int i = 0; i < capacityCount; i++) {
+         pmAtomValue atom;
+         if (Metric_instance(PCP_DENKI_POWER_NOW, batteryInst[i], 0, &atom, PM_TYPE_DOUBLE) == NULL)
+            continue;
+         totalPower += atom.d;
+         anyPower = true;
       }
-      free(batteryPowerCurr);
+      if (anyPower)
+         info->powerCurr = totalPower;
    }
+
+   free(batteryEnergyCurr);
+   free(batteryInst);
+   free(batteryCapacity);
 
    /* The denki PMDA does not expose AC adapter state, and denki.bat.power_now
     * is a magnitude (sysfs POWER_NOW is non-negative) rather than a signed

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -906,20 +906,38 @@ void Platform_getBattery(BatteryInfo* info) {
     * by array offset would silently mismatch the instances. We therefore
     * walk the capacity metric with Metric_iterate to get authoritative
     * (instid, offset) pairs, then look up the matching instances in the
-    * other denki metrics with Metric_instance. */
+    * other denki metrics with Metric_instance.
+    *
+    * Metric_iterate signals that PCP knows about an instance, but the
+    * subsequent Metric_instance lookup can still fail (transient state, an
+    * instance disappearing between metric refreshes). Silently skipping
+    * such an instance shrinks capacityCount and lets the publication path
+    * report a partial aggregate as if it were whole-pack -- e.g. on a
+    * 2-battery host where one Metric_instance fails, the remaining
+    * battery's percent would be published as the system value. The
+    * aggregateComplete flag tracks whether every iterated instance was
+    * successfully read; if any read failed we conservatively mark the
+    * aggregate incomplete (we don't know which instance dropped out) and
+    * the publication block leaves info->percent and info->powerCurr at
+    * NaN rather than overriding with a partial sum. */
 
    /* denki.bat.capacity is the sysfs CAPACITY field (percent, 0-100). */
    pmAtomValue* batteryCapacity = xCalloc(count, sizeof(pmAtomValue));
    int* batteryInst = xCalloc(count, sizeof(int));
    int capacityCount = 0;
+   bool aggregateComplete = true;
    {
       int instid = -1, offset = -1;
       while (Metric_iterate(PCP_DENKI_CAPACITY, &instid, &offset, sizeof(pmAtomValue))) {
          if (capacityCount >= count)
             break;
          pmAtomValue atom;
-         if (Metric_instance(PCP_DENKI_CAPACITY, instid, offset, &atom, PM_TYPE_DOUBLE) == NULL)
+         if (Metric_instance(PCP_DENKI_CAPACITY, instid, offset, &atom, PM_TYPE_DOUBLE) == NULL) {
+            /* We can't tell which instance failed, so mark the aggregate
+             * incomplete and let the publication block fall back to NaN. */
+            aggregateComplete = false;
             continue;
+         }
          batteryCapacity[capacityCount] = atom;
          batteryInst[capacityCount] = instid;
          capacityCount++;
@@ -948,9 +966,13 @@ void Platform_getBattery(BatteryInfo* info) {
     * capacity average. The energy_now metric is therefore not enabled or
     * read here. */
 
-   if (haveCapacity) {
+   if (haveCapacity && aggregateComplete) {
       if (capacityCount == 1) {
-         /* Single battery: use its capacity directly; no aggregation needed. */
+         /* Single battery: use its capacity directly; no aggregation needed.
+          * aggregateComplete still matters here -- a 2-battery host where
+          * one Metric_instance failed would otherwise reach this branch
+          * with capacityCount == 1 and publish that battery's percent as
+          * the whole-pack value. */
          if (isNonnegative(batteryCapacity[0].d))
             info->percent = CLAMP(batteryCapacity[0].d, 0.0, 100.0);
       } else {
@@ -991,7 +1013,7 @@ void Platform_getBattery(BatteryInfo* info) {
          }
          totalPower += atom.d;
       }
-      if (allMatched)
+      if (allMatched && aggregateComplete)
          info->powerCurr = totalPower;
    }
 

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -236,7 +236,7 @@ static const char* Platform_metricNames[] = {
    [PCP_VFS_FILES_MAX] = "vfs.files.max",
    [PCP_DENKI_POWER_NOW] = "denki.bat.power_now",
    [PCP_DENKI_ENERGY_NOW] = "denki.bat.energy_now",
-   [PCP_DENKI_ENERGY_FULL] = "denki.bat.capacity",
+   [PCP_DENKI_CAPACITY] = "denki.bat.capacity",
 
    [PCP_PROC_PID] = "proc.psinfo.pid",
    [PCP_PROC_PPID] = "proc.psinfo.ppid",
@@ -873,41 +873,59 @@ void Platform_getBattery(BatteryInfo* info) {
    info->energyCurr = NAN;
    info->energyFull = NAN;
 
-   if (Metric_desc(PCP_DENKI_ENERGY_NOW) == NULL)
+   if (Metric_desc(PCP_DENKI_CAPACITY) == NULL)
       return;
 
-   int i, count = Metric_instanceCount(PCP_DENKI_ENERGY_NOW);
+   int i, count = Metric_instanceCount(PCP_DENKI_CAPACITY);
    if (count < 1) {
       info->ac = AC_PRESENT;
       return;
    }
 
-   pmAtomValue* batteryEnergyCurr = xCalloc(count, sizeof(pmAtomValue));
-   pmAtomValue* batteryEnergyFull = xCalloc(count, sizeof(pmAtomValue));
-   if (Metric_values(PCP_DENKI_ENERGY_NOW, batteryEnergyCurr, count, PM_TYPE_DOUBLE) &&
-       Metric_values(PCP_DENKI_ENERGY_FULL, batteryEnergyFull, count, PM_TYPE_DOUBLE)) {
-      info->energyCurr = 0.0;
-      info->energyFull = 0.0;
+   /* denki.bat.capacity is the sysfs CAPACITY field (percent, 0-100).
+    * Average across battery instances to produce an overall percent. */
+   pmAtomValue* batteryCapacity = xCalloc(count, sizeof(pmAtomValue));
+   if (Metric_values(PCP_DENKI_CAPACITY, batteryCapacity, count, PM_TYPE_DOUBLE)) {
+      double total = 0.0;
+      int valid = 0;
       for (i = 0; i < count; i++) {
-         info->energyCurr += CLAMP(batteryEnergyCurr[i].d, 0, batteryEnergyFull[i].d);
-         info->energyFull += isNonnegative(batteryEnergyFull[i].d) ? batteryEnergyFull[i].d : 0;
+         if (isNonnegative(batteryCapacity[i].d)) {
+            total += batteryCapacity[i].d;
+            valid++;
+         }
       }
-
-      if (info->energyFull > 0) {
-         info->percent = CLAMP((info->energyCurr / info->energyFull) * 100.0, 0.0, 100.0);
+      if (valid > 0) {
+         info->percent = CLAMP(total / valid, 0.0, 100.0);
       }
    }
-   free(batteryEnergyCurr);
-   free(batteryEnergyFull);
+   free(batteryCapacity);
 
-   pmAtomValue* batteryPowerCurr = xCalloc(count, sizeof(pmAtomValue));
-   if (Metric_values(PCP_DENKI_POWER_NOW, batteryPowerCurr, count, PM_TYPE_DOUBLE)) {
-      info->powerCurr = 0.0;
-      for (i = 0; i < count; i++) {
-         info->powerCurr += batteryPowerCurr[i].d;
+   /* denki.bat.energy_now (sysfs ENERGY_NOW, Wh) is optional and only
+    * populates info->energyCurr; the denki PMDA does not expose a
+    * corresponding ENERGY_FULL metric, so info->energyFull stays NaN. */
+   if (Metric_desc(PCP_DENKI_ENERGY_NOW) != NULL) {
+      pmAtomValue* batteryEnergyCurr = xCalloc(count, sizeof(pmAtomValue));
+      if (Metric_values(PCP_DENKI_ENERGY_NOW, batteryEnergyCurr, count, PM_TYPE_DOUBLE)) {
+         double total = 0.0;
+         for (i = 0; i < count; i++) {
+            if (isNonnegative(batteryEnergyCurr[i].d))
+               total += batteryEnergyCurr[i].d;
+         }
+         info->energyCurr = total;
       }
+      free(batteryEnergyCurr);
    }
-   free(batteryPowerCurr);
+
+   if (Metric_desc(PCP_DENKI_POWER_NOW) != NULL) {
+      pmAtomValue* batteryPowerCurr = xCalloc(count, sizeof(pmAtomValue));
+      if (Metric_values(PCP_DENKI_POWER_NOW, batteryPowerCurr, count, PM_TYPE_DOUBLE)) {
+         info->powerCurr = 0.0;
+         for (i = 0; i < count; i++) {
+            info->powerCurr += batteryPowerCurr[i].d;
+         }
+      }
+      free(batteryPowerCurr);
+   }
 
    if (info->powerCurr < 0) {
       info->ac = AC_ABSENT;

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -982,16 +982,24 @@ void Platform_getBattery(BatteryInfo* info) {
           * requires that every instance's energy_now sample share a unit.
           * The denki PMDA does not guarantee that across a host (see the
           * comment above), so we always use the unweighted average here. */
+         /* Require every capacity instance to report a usable value
+          * before averaging. Skipping an unknown/negative sample (sysfs
+          * CAPACITY=-1, NaN propagation through PCP, etc.) and averaging
+          * only the remaining instances would publish a partial pack
+          * percentage as if it covered the whole pack — the same silent-
+          * drop pattern that aggregateComplete already guards against
+          * elsewhere in this function. */
          double total = 0.0;
-         int valid = 0;
+         bool allValid = true;
          for (int i = 0; i < capacityCount; i++) {
-            if (isNonnegative(batteryCapacity[i].d)) {
-               total += CLAMP(batteryCapacity[i].d, 0.0, 100.0);
-               valid++;
+            if (!isNonnegative(batteryCapacity[i].d)) {
+               allValid = false;
+               break;
             }
+            total += CLAMP(batteryCapacity[i].d, 0.0, 100.0);
          }
-         if (valid > 0) {
-            info->percent = total / valid;
+         if (allValid) {
+            info->percent = total / capacityCount;
          }
       }
    }

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -17,6 +17,7 @@ in the source distribution for its full text.
 #include <string.h>
 #include <unistd.h>
 
+#include "Battery.h"
 #include "BatteryMeter.h"
 #include "CPUMeter.h"
 #include "DateTimeMeter.h"
@@ -871,100 +872,68 @@ void Platform_getFileDescriptors(double* used, double* max) {
       *max = value.l;
 }
 
+#define DENKI_MAX_BATTERIES 32
+
 void Platform_getBattery(BatteryInfo* info) {
    info->ac = AC_ERROR;
    info->percent = NAN;
    info->powerCurr = NAN;
    info->energyCurr = NAN;
    info->energyFull = NAN;
+   /* denki has no AC sensor; info->ac stays AC_ERROR. */
 
    if (Metric_desc(PCP_DENKI_CAPACITY) == NULL)
       return;
 
    int count = Metric_instanceCount(PCP_DENKI_CAPACITY);
-   if (count < 1) {
-      /* denki has no AC sensor; absence of batteries ≠ AC_PRESENT. */
+   if (count < 1)
       return;
+   if (count > DENKI_MAX_BATTERIES)
+      count = DENKI_MAX_BATTERIES;
+
+   BatteryRaw raws[DENKI_MAX_BATTERIES];
+   int instIds[DENKI_MAX_BATTERIES];
+   size_t nbat = 0;
+
+   /* Join metrics by instance id (not array offset). A failed
+    * Metric_instance leaves the corresponding BatteryRaw with NaN
+    * fields so the aggregator's all-or-nothing gates close. */
+   int instid = -1, offset = -1;
+   while (Metric_iterate(PCP_DENKI_CAPACITY, &instid, &offset, sizeof(pmAtomValue))
+          && nbat < (size_t) count) {
+      raws[nbat] = (BatteryRaw){
+         .level = NAN,
+         .energyFull = NAN, .energyNow = NAN,
+         .chargeFull = NAN, .chargeNow = NAN,
+         .voltageNow = NAN, .voltageDesign = NAN,
+         .current = NAN, .power = NAN,
+      };
+      instIds[nbat] = instid;
+
+      pmAtomValue atom;
+      if (Metric_instance(PCP_DENKI_CAPACITY, instid, offset, &atom, PM_TYPE_DOUBLE) != NULL
+            && isNonnegative(atom.d)) {
+         raws[nbat].level = CLAMP(atom.d, 0.0, 100.0);
+      }
+      nbat++;
    }
 
-   /* Join metrics by instance id (not array offset). aggregateComplete
-    * clears on any Metric_instance failure to avoid partial aggregates. */
-
-   /* denki.bat.capacity is the sysfs CAPACITY field (percent, 0-100). */
-   pmAtomValue* batteryCapacity = xCalloc(count, sizeof(pmAtomValue));
-   int* batteryInst = xCalloc(count, sizeof(int));
-   int capacityCount = 0;
-   bool aggregateComplete = true;
-   {
-      int instid = -1, offset = -1;
-      while (Metric_iterate(PCP_DENKI_CAPACITY, &instid, &offset, sizeof(pmAtomValue))) {
-         if (capacityCount >= count)
-            break;
+   /* power_now is in Watts (PMDA divides by 1e6 internally and strips sign);
+    * each capacity instance must have a matching power sample, otherwise
+    * partial sums would misrepresent whole-pack power on multi-battery
+    * systems. */
+   if (Metric_desc(PCP_DENKI_POWER_NOW) != NULL) {
+      for (size_t i = 0; i < nbat; i++) {
          pmAtomValue atom;
-         if (Metric_instance(PCP_DENKI_CAPACITY, instid, offset, &atom, PM_TYPE_DOUBLE) == NULL) {
-            /* Unknown which instance dropped; aggregate is incomplete. */
-            aggregateComplete = false;
-            continue;
-         }
-         batteryCapacity[capacityCount] = atom;
-         batteryInst[capacityCount] = instid;
-         capacityCount++;
-      }
-   }
-   bool haveCapacity = capacityCount > 0;
-
-   /* energy_now unused: denki may back it with µAh or µWh per instance,
-    * indistinguishably. info->energyCurr/Full stay NaN. */
-
-   if (haveCapacity && aggregateComplete) {
-      if (capacityCount == 1) {
-         if (isNonnegative(batteryCapacity[0].d))
-            info->percent = CLAMP(batteryCapacity[0].d, 0.0, 100.0);
-      } else {
-         /* Unweighted average; mixed Wh/mAh backing prevents weighting.
-          * Any invalid sample blocks publication. */
-         double total = 0.0;
-         bool allValid = true;
-         for (int i = 0; i < capacityCount; i++) {
-            if (!isNonnegative(batteryCapacity[i].d)) {
-               allValid = false;
-               break;
-            }
-            total += CLAMP(batteryCapacity[i].d, 0.0, 100.0);
-         }
-         if (allValid) {
-            info->percent = total / capacityCount;
-         }
+         if (Metric_instance(PCP_DENKI_POWER_NOW, instIds[i], 0, &atom, PM_TYPE_DOUBLE) != NULL)
+            raws[i].power = atom.d;
       }
    }
 
-   if (Metric_desc(PCP_DENKI_POWER_NOW) != NULL && haveCapacity) {
-      /* Sum power_now across the same battery instances we saw for
-       * capacity, again joining by instance id rather than array offset.
-       * Require every capacity instance to have a matching power_now
-       * sample: a partial sum across only the reporting instances would
-       * misrepresent whole-pack power on multi-battery systems (e.g.
-       * publishing one battery's draw as if it were the total). */
-      double totalPower = 0.0;
-      bool allMatched = true;
-      for (int i = 0; i < capacityCount; i++) {
-         pmAtomValue atom;
-         if (Metric_instance(PCP_DENKI_POWER_NOW, batteryInst[i], 0, &atom, PM_TYPE_DOUBLE) == NULL) {
-            allMatched = false;
-            break;
-         }
-         totalPower += atom.d;
-      }
-      if (allMatched && aggregateComplete) {
-         /* denki PMDA already exposes power_now in watts. */
-         info->powerCurr = totalPower;
-      }
-   }
+   /* energy_now intentionally unread: denki may back it with µAh or µWh per
+    * instance, indistinguishably. Leave energy axis NaN. */
 
-   free(batteryInst);
-   free(batteryCapacity);
-
-   /* denki has no AC sensor; info->ac stays AC_ERROR. */
+   Battery_aggregate(raws, nbat, info);
 }
 
 const char* Platform_getFailedState(void) {

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -1024,18 +1024,21 @@ void Platform_getBattery(BatteryInfo* info) {
    if (Metric_desc(PCP_DENKI_POWER_NOW) != NULL && haveCapacity) {
       /* Sum power_now across the same battery instances we saw for
        * capacity, again joining by instance id rather than array offset.
-       * Skip instances missing from power_now rather than counting them
-       * as 0 (a missing sample is not the same as a zero sample). */
+       * Require every capacity instance to have a matching power_now
+       * sample: a partial sum across only the reporting instances would
+       * misrepresent whole-pack power on multi-battery systems (e.g.
+       * publishing one battery's draw as if it were the total). */
       double totalPower = 0.0;
-      bool anyPower = false;
+      bool allMatched = true;
       for (int i = 0; i < capacityCount; i++) {
          pmAtomValue atom;
-         if (Metric_instance(PCP_DENKI_POWER_NOW, batteryInst[i], 0, &atom, PM_TYPE_DOUBLE) == NULL)
-            continue;
+         if (Metric_instance(PCP_DENKI_POWER_NOW, batteryInst[i], 0, &atom, PM_TYPE_DOUBLE) == NULL) {
+            allMatched = false;
+            break;
+         }
          totalPower += atom.d;
-         anyPower = true;
       }
-      if (anyPower)
+      if (allMatched)
          info->powerCurr = totalPower;
    }
 

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -872,8 +872,6 @@ void Platform_getFileDescriptors(double* used, double* max) {
       *max = value.l;
 }
 
-#define DENKI_MAX_BATTERIES 32
-
 void Platform_getBattery(BatteryInfo* info) {
    info->ac = AC_ERROR;
    info->percent = NAN;
@@ -888,14 +886,10 @@ void Platform_getBattery(BatteryInfo* info) {
    int count = Metric_instanceCount(PCP_DENKI_CAPACITY);
    if (count < 1)
       return;
-   /* Refuse partial aggregation when more battery instances are reported
-    * than the fixed buffer holds; percent stays NaN rather than under-
-    * counted. */
-   if (count > DENKI_MAX_BATTERIES)
-      return;
 
-   BatteryRaw raws[DENKI_MAX_BATTERIES];
-   int instIds[DENKI_MAX_BATTERIES];
+   /* Sized to the PMDA-reported instance count; xMalloc never returns NULL. */
+   BatteryRaw* raws = xMalloc((size_t) count * sizeof(BatteryRaw));
+   int* instIds = xMalloc((size_t) count * sizeof(int));
    size_t nbat = 0;
 
    /* Join metrics by instance id (not array offset). A failed
@@ -937,6 +931,8 @@ void Platform_getBattery(BatteryInfo* info) {
     * instance, indistinguishably. Leave energy axis NaN. */
 
    Battery_aggregate(raws, nbat, info);
+   free(instIds);
+   free(raws);
 }
 
 const char* Platform_getFailedState(void) {

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -1014,10 +1014,12 @@ void Platform_getBattery(BatteryInfo* info) {
          totalPower += atom.d;
       }
       if (allMatched && aggregateComplete) {
-         /* denki.bat.power_now is the raw sysfs power_now value in
-          * microwatts; BatteryInfo.powerCurr contracts to watts. Divide
-          * before publishing, matching the linux/freebsd conversion. */
-         info->powerCurr = totalPower / 1000000.0;
+         /* denki.bat.power_now is published by the denki PMDA in
+          * watts (the PMDA divides the raw sysfs power_now microwatt
+          * value by 1e6 and labels the metric with units "watt"; see
+          * pcp/src/pmdas/denki/denki.c). Assign the summed double
+          * directly, matching BatteryInfo.powerCurr's contract. */
+         info->powerCurr = totalPower;
       }
    }
 

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -887,9 +887,10 @@ void Platform_getBattery(BatteryInfo* info) {
    if (count < 1)
       return;
 
-   /* Sized to the PMDA-reported instance count; xMalloc never returns NULL. */
-   BatteryRaw* raws = xMalloc((size_t) count * sizeof(BatteryRaw));
-   int* instIds = xMalloc((size_t) count * sizeof(int));
+   /* Sized to the PMDA-reported instance count; xMallocArray traps on
+    * size_t overflow if a bogus PMDA reports an absurd count. */
+   BatteryRaw* raws = xMallocArray((size_t) count, sizeof(BatteryRaw));
+   int* instIds = xMallocArray((size_t) count, sizeof(int));
    size_t nbat = 0;
 
    /* Join metrics by instance id (not array offset). A failed

--- a/pcp/Platform.h
+++ b/pcp/Platform.h
@@ -121,7 +121,7 @@ bool Platform_getDiskIO(DiskIOData* data);
 
 bool Platform_getNetworkIO(NetworkIOData* data);
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC);
+void Platform_getBattery(BatteryInfo* info);
 
 void Platform_getHostname(char* buffer, size_t size);
 

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -346,5 +346,7 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 }

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -342,7 +342,9 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    return false;
 }
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC) {
-   *percent = NAN;
-   *isOnAC = AC_ERROR;
+void Platform_getBattery(BatteryInfo* info) {
+   *info = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
 }

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -346,6 +346,7 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .powerCurr = NAN,
       .energyCurr = NAN,
       .energyFull = NAN,
    };

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -97,7 +97,7 @@ bool Platform_getDiskIO(DiskIOData* data);
 
 bool Platform_getNetworkIO(NetworkIOData* data);
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC);
+void Platform_getBattery(BatteryInfo* info);
 
 static inline void Platform_getHostname(char* buffer, size_t size) {
    Generic_hostname(buffer, size);

--- a/unsupported/Platform.c
+++ b/unsupported/Platform.c
@@ -170,6 +170,8 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .energyCurr = NAN,
+      .energyFull = NAN,
    };
 }
 

--- a/unsupported/Platform.c
+++ b/unsupported/Platform.c
@@ -166,9 +166,11 @@ bool Platform_getNetworkIO(NetworkIOData* data) {
    return false;
 }
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC) {
-   *percent = NAN;
-   *isOnAC = AC_ERROR;
+void Platform_getBattery(BatteryInfo* info) {
+   *info = (BatteryInfo) {
+      .ac = AC_ERROR,
+      .percent = NAN,
+   };
 }
 
 void Platform_getHostname(char* buffer, size_t size) {

--- a/unsupported/Platform.c
+++ b/unsupported/Platform.c
@@ -170,6 +170,7 @@ void Platform_getBattery(BatteryInfo* info) {
    *info = (BatteryInfo) {
       .ac = AC_ERROR,
       .percent = NAN,
+      .powerCurr = NAN,
       .energyCurr = NAN,
       .energyFull = NAN,
    };

--- a/unsupported/Platform.h
+++ b/unsupported/Platform.h
@@ -66,7 +66,7 @@ bool Platform_getDiskIO(DiskIOData* data);
 
 bool Platform_getNetworkIO(NetworkIOData* data);
 
-void Platform_getBattery(double* percent, ACPresence* isOnAC);
+void Platform_getBattery(BatteryInfo* info);
 
 void Platform_getHostname(char* buffer, size_t size);
 


### PR DESCRIPTION
I thought #1967 by @BenBE looked interesting so I threw some compute at it.

> [!CAUTION]
>  The code is not in a mergeable or proud state. I ran out of compute and switched tasks.

This branch extends #1967 and does roughly three main things:
- bug fixes (and probably creates a few)
- battery aggregate (readability, testability, composability)
- standardize units (R.I.P. Mars Climate Orbiter)

I ran this [skill ](https://github.com/corygabrielsen/skills/blob/master/loop-codex-review/SKILL.md) for 34 rounds of 10x fanout for a total of 340 `codex review` at high in Claude Code until I ran out of credits (in Claude not Codex, funny enough). This skill uses fixed point theory and compute to find reviewbot fixed points. After which, I read and evaluate the code myself.

It found a fixed point after about 20 rounds. At which point the code looked pretty repetitive so I had Claude reshape the code and improve the algebra. I didn't choose the symbol names but I noticed it renamed BatteryMeter to Battery which we might undo.

There's a `Battery_aggregate` to consolidate the invariants and ease readability. Reading #1967 there's some plans for more advanced metrics. I can help with the statistical algorithms if someone can specify requirements or dreams.

That's basically all I did. It was pretty hands off.

The code has excessive commenting and bugs. I'll use some more compute next week to find the fixed point and get rid of the verbose slop.

Happy to coordinate however you want best. Closed this, split it up, etc.

I was planning to write tests, but I don't know if there is a meta preference here. I was going to have docker simulate a bunch of stuff and check all the invariants for everything but I figured that was a bit opinionated. I don't know what tradeoffs you're juggling here. Notably, fanout full coverage of all invariants for all OS on every CI probably shows up on the $ sheet.