### PR TITLE
Properly handle potential NULL-deref issues

### DIFF
--- a/CommandLine.c
+++ b/CommandLine.c
@@ -214,6 +214,7 @@ static CommandLineStatus parseArguments(int argc, char** argv, CommandLineSettin
             }
             break;
          case 'd':
+            assert(optarg);
             if (sscanf(optarg, "%16d", &(flags->delay)) == 1) {
                if (flags->delay < 1)
                   flags->delay = 1;
@@ -225,6 +226,7 @@ static CommandLineStatus parseArguments(int argc, char** argv, CommandLineSettin
             }
             break;
          case 'n':
+            assert(optarg);
             if (sscanf(optarg, "%16d", &flags->iterationsRemaining) == 1) {
                if (flags->iterationsRemaining <= 0) {
                   fprintf(stderr, "Error: maximum iteration count must be positive.\n");

--- a/CommandLine.c
+++ b/CommandLine.c
@@ -189,7 +189,9 @@ static CommandLineStatus parseArguments(int argc, char** argv, CommandLineSettin
             printVersionFlag(program);
             return STATUS_OK_EXIT;
          case 's':
-            assert(optarg); /* please clang analyzer, cause optarg can be NULL in the 'u' case */
+            if (!optarg)
+               return STATUS_ERROR_EXIT;
+
             if (String_eq(optarg, "help")) {
                for (int j = 1; j < LAST_PROCESSFIELD; j++) {
                   const char* name = Process_fields[j].name;
@@ -214,7 +216,9 @@ static CommandLineStatus parseArguments(int argc, char** argv, CommandLineSettin
             }
             break;
          case 'd':
-            assert(optarg);
+            if (!optarg)
+               return STATUS_ERROR_EXIT;
+
             if (sscanf(optarg, "%16d", &(flags->delay)) == 1) {
                if (flags->delay < 1)
                   flags->delay = 1;
@@ -226,7 +230,9 @@ static CommandLineStatus parseArguments(int argc, char** argv, CommandLineSettin
             }
             break;
          case 'n':
-            assert(optarg);
+            if (!optarg)
+               return STATUS_ERROR_EXIT;
+
             if (sscanf(optarg, "%16d", &flags->iterationsRemaining) == 1) {
                if (flags->iterationsRemaining <= 0) {
                   fprintf(stderr, "Error: maximum iteration count must be positive.\n");
@@ -310,7 +316,9 @@ static CommandLineStatus parseArguments(int argc, char** argv, CommandLineSettin
             break;
          }
          case 'F':
-            assert(optarg);
+            if (!optarg)
+               return STATUS_ERROR_EXIT;
+
             if (optarg[0] == '\0' || optarg[0] == '|') {
                fprintf(stderr, "Error: invalid filter value \"%s\".\n", optarg);
                return STATUS_ERROR_EXIT;


### PR DESCRIPTION
While the value of optarg semantically is non-zero for required arguments, this isn't obvious for static code analyzers. Thus this PR first adds the missing asserts to make this consistent, before then upgrading those to full-on argument parsing failures.

Ref: Coverity issue CID 645928.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of command-line arguments for the sort-key, delay, max-iterations, and filter options. The app now checks that required values are provided and returns a clear error when arguments are missing, preventing crashes or undefined behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/htop-dev/htop/pull/1996)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->