### PR TITLE
linux: resolve actual executable path for Flatpak processes

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -346,6 +346,29 @@ void Process_makeCommandStr(Process* this, const Settings* settings) {
       }
       if (matchLen) {
          cmdlineBasenameLen = exeBasenameLen;
+      } else if (this->cmdline) {
+         /* Strip /proc pseudo-paths from merged command */
+         #define PATH_PROC_EXE_SELF "/proc/self/exe"
+         #define PATH_PROC_EXE_SELF_LEN (sizeof(PATH_PROC_EXE_SELF)-1)
+         #define PATH_PROC_EXE_THREAD "/proc/thread-self/exe"
+         #define PATH_PROC_EXE_THREAD_LEN (sizeof(PATH_PROC_EXE_THREAD)-1)
+
+         const size_t cmdlineLen = strlen(this->cmdline);
+         const char sep_self = cmdlineLen >= PATH_PROC_EXE_SELF_LEN ? this->cmdline[PATH_PROC_EXE_SELF_LEN] : 0;
+         const char sep_thread = cmdlineLen >= PATH_PROC_EXE_THREAD_LEN ? this->cmdline[PATH_PROC_EXE_THREAD_LEN] : 0;
+
+         if (String_startsWith(this->cmdline, PATH_PROC_EXE_SELF) &&
+            (sep_self == '\0' || sep_self == ' ' || sep_self == '\n')) {
+            matchLen = PATH_PROC_EXE_SELF_LEN;
+         } else if (String_startsWith(this->cmdline, PATH_PROC_EXE_THREAD) &&
+            (sep_thread == '\0' || sep_thread == ' ' || sep_thread == '\n')) {
+            matchLen = PATH_PROC_EXE_THREAD_LEN;
+         }
+
+         #undef PATH_PROC_EXE_THREAD
+         #undef PATH_PROC_EXE_SELF_LEN
+         #undef PATH_PROC_EXE_SELF
+         #undef PATH_PROC_EXE_THREAD_LEN
       }
    }
 


### PR DESCRIPTION
When applications (like Discord) are run within a Flatpak sandbox or similar environments, they are frequently executed internally via `/proc/self/exe` or `/proc/thread-self/exe`. Because htop reads the process command line literally from `/proc/[pid]/cmdline`, this results in the misleading basename "exe" being displayed and highlighted in the process list.

This commit intercepts cases where the command line begins with these pseudo-paths and dynamically substitutes them with the process's actual resolved executable path (which htop already obtains via `readlink` on `/proc/[pid]/exe`). This ensures htop correctly displays the underlying binary name (e.g., `discord`) while keeping the rest of the arguments perfectly intact.

Assisted-by: Antigravity AI