### PR TITLE
helpers: fix kernel version parsing with error check

### DIFF
--- a/darwin/PlatformHelpers.c
+++ b/darwin/PlatformHelpers.c
@@ -30,7 +30,10 @@ void Platform_GetKernelVersion(KernelVersion* k) {
       size_t size = sizeof(str);
       int ret = sysctlbyname("kern.osrelease", str, &size, NULL, 0);
       if (ret == 0) {
-         sscanf(str, "%hd.%hd.%hd", &cachedKernelVersion.major, &cachedKernelVersion.minor, &cachedKernelVersion.patch);
+         int n = sscanf(str, "%hd.%hd.%hd", &cachedKernelVersion.major, &cachedKernelVersion.minor, &cachedKernelVersion.patch);
+         if (n != 3) {
+            cachedKernelVersion.major = cachedKernelVersion.minor = cachedKernelVersion.patch = -1;
+         }
       }
    }
    memcpy(k, &cachedKernelVersion, sizeof(cachedKernelVersion));


### PR DESCRIPTION
using sscanf without checking whether all expected values have been parsed successfully can lead to undefined behavior (UB). It is worth checking the sscanf return value here to make sure that all three numbers are received before using the results

Reference: https://stackoverflow.com/questions/61066625/sscanf-check-doesnt-work-when-given-more-input-than-required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes
Fixed kernel version parsing in `darwin/PlatformHelpers.c` by adding validation of the `sscanf` return value. The `Platform_GetKernelVersion` function now checks that all three version components (major, minor, patch) were successfully parsed before using them. If `sscanf` returns fewer than 3 matched values, the function resets the parsed fields to -1, preventing undefined behavior from partially-initialized data.

## Implementation Quality
The fix is narrow and focused. It leverages existing error handling infrastructure (the function already initializes the version to -1 on syscall failure) and applies the same pattern consistently. The additional validation adds 3 lines of logic (capture return value, conditional check, and reset on failure).

## Commit Structure
Single, focused commit addressing a specific correctness issue. The change scope matches the PR objective precisely.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/htop-dev/htop/pull/2000?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->