### PR TITLE
Fix security issues reported by AFINE Team

### DIFF
--- a/InfoScreen.c
+++ b/InfoScreen.c
@@ -59,6 +59,8 @@ void InfoScreen_drawTitled(InfoScreen* this, const char* fmt, ...) {
       memset(&title[COLS - 3], '.', 3);
    }
 
+   String_stripControlChars(title);
+
    attrset(CRT_colors[METER_TEXT]);
    mvhline(0, 0, ' ', COLS);
    mvaddstr(0, 0, title);

--- a/InfoScreen.c
+++ b/InfoScreen.c
@@ -55,7 +55,7 @@ void InfoScreen_drawTitled(InfoScreen* this, const char* fmt, ...) {
    int len = vsnprintf(title, sizeof(title), fmt, ap);
    va_end(ap);
 
-   if (len > COLS) {
+   if (len > COLS && COLS >= 3) {
       memset(&title[COLS - 3], '.', 3);
    }
 

--- a/RichString.c
+++ b/RichString.c
@@ -197,7 +197,7 @@ static inline int RichString_writeFromWide(RichString* this, int attrs, const ch
    size_t newLen = from + len;
    RichString_setLen(this, newLen);
    for (size_t i = from, j = 0; i < newLen; i++, j++) {
-      this->chptr[i] = (((unsigned char)data_c[j]) >= 32 ? ((unsigned char)data_c[j]) : '?') | attrs;
+      this->chptr[i] = (Char_isControl(data_c[j]) ? '?' : (unsigned char)data_c[j]) | attrs;
    }
    this->chptr[newLen] = 0;
 

--- a/RichString.c
+++ b/RichString.c
@@ -21,6 +21,8 @@ in the source distribution for its full text.
 
 #define charBytes(n) (sizeof(CharType) * (n))
 
+#define RICHSTRING_MAX_WIDE_LEN 0x8000
+
 static void RichString_extendLen(RichString* this, size_t len) {
    if (this->chptr == this->chstr) {
       // String is in internal buffer
@@ -101,6 +103,9 @@ static inline int RichString_writeFromWide(RichString* this, int attrs, const ch
    if (len < 1)
       return 0;
 
+   if (len > RICHSTRING_MAX_WIDE_LEN)
+      len = RICHSTRING_MAX_WIDE_LEN;
+
    wchar_t data[len];
    len = mbstowcs_nonfatal(data, data_c, len);
    if (len <= 0)
@@ -116,6 +121,9 @@ static inline int RichString_writeFromWide(RichString* this, int attrs, const ch
 }
 
 int RichString_appendnWideColumns(RichString* this, int attrs, const char* data_c, size_t len, int* columns) {
+   if (len > RICHSTRING_MAX_WIDE_LEN)
+      len = RICHSTRING_MAX_WIDE_LEN;
+
    wchar_t data[len];
    len = mbstowcs_nonfatal(data, data_c, len);
    if (len <= 0)

--- a/XUtils.h
+++ b/XUtils.h
@@ -131,6 +131,19 @@ static inline ssize_t full_write_str(int fd, const char* str) {
    return full_write(fd, str, strlen(str));
 }
 
+static inline bool Char_isControl(char c) {
+   return (unsigned char)c < ' ' || c == '\x7F';
+}
+
+/* Replace control characters (C0 and DEL) with a safe substitute. */
+ATTR_NONNULL
+static inline void String_stripControlChars(char* s) {
+   for (; *s; s++) {
+      if (Char_isControl(*s))
+         *s = '?';
+   }
+}
+
 /* Compares floating point values for ordering data entries. In this function,
    NaN is considered "less than" any other floating point value (regardless of
    sign), and two NaNs are considered "equal" regardless of payload. */


### PR DESCRIPTION
## Summary

- Cap VLA length in `RichString_writeFromWide()` and `RichString_appendnWideColumns()` to prevent stack exhaustion from processes with very long command lines (GHSA-mjc3-mc44-c23f)
- Guard title truncation in `InfoScreen_drawTitled()` against narrow terminal widths to prevent stack buffer underflow (GHSA-6f53-xw2h-ww59)
- Strip control characters from info screen titles before passing to `mvaddstr()` to prevent terminal escape sequence injection (GHSA-q64m-h5hc-c4qq)
- Add `Char_isControl()` and `String_stripControlChars()` helpers to XUtils, and use `Char_isControl()` in non-wide RichString rendering to also filter DEL (0x7F)

All three issues were reported by Michał Majchrowicz and Marcin Wyczechowski of the AFINE Team.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Addresses three GHSA security issues (GHSA-mjc3-mc44-c23f, GHSA-6f53-xw2h-ww59, GHSA-q64m-h5hc-c4qq) via targeted fixes to VLA handling, buffer bounds checking, and control character sanitization.

## Changes

**InfoScreen.c** (+3/-1): Adds bounds check `COLS >= 3` alongside length check before truncating with trailing dots, preventing stack buffer underflow when terminal width is very narrow. Introduces call to `String_stripControlChars()` to sanitize title strings before passing to `mvaddstr()`, blocking terminal escape sequence injection.

**RichString.c** (+9/-1): Introduces `RICHSTRING_MAX_WIDE_LEN` constant (0x8000 / 32KB) and caps VLA allocations in `RichString_writeFromWide()` and `RichString_appendnWideColumns()` to prevent stack exhaustion from processes with extremely long command lines. Replaces simple `>= 32` printable-byte check with `Char_isControl()` predicate in non-wide rendering path to also filter DEL character (0x7F), maintaining consistency with wide-character path using `iswprint()`.

**XUtils.h** (+13/-0): Adds two static inline helpers: `Char_isControl()` classifying control characters as those below space or equal to 0x7F, and `String_stripControlChars()` iterating through mutable strings to replace detected control characters with '?'.

## Assessment

Implementation is clean and logically organized. All three fixes are properly isolated by concern: VLA bounds in RichString for stack exhaustion, width validation in InfoScreen for buffer underflow, and control character filtering for injection prevention. Helper functions are positioned inline in headers for efficiency. Bounds enforcement uses reasonable limits (32KB for wide-character operations) and consistent filtering logic across code paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/htop-dev/htop/pull/2001?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->