### PR TITLE
Harden control character filtering with C1 support

### DIFF
--- a/XUtils.h
+++ b/XUtils.h
@@ -135,12 +135,20 @@ static inline bool Char_isControl(char c) {
    return (unsigned char)c < ' ' || c == '\x7F';
 }
 
-/* Replace control characters (C0 and DEL) with a safe substitute. */
+static inline bool Char_isC1Control(char c, char next) {
+   return (unsigned char)c == 0xC2 && (unsigned char)next >= 0x80 && (unsigned char)next <= 0x9F;
+}
+
+/* Replace control characters (C0, DEL, and C1) with a safe substitute. */
 ATTR_NONNULL
 static inline void String_stripControlChars(char* s) {
-   for (; *s; s++) {
-      if (Char_isControl(*s))
-         *s = '?';
+   for (; s[0]; s++) {
+      if (Char_isControl(s[0])) {
+         s[0] = '?';
+      } else if (Char_isC1Control(s[0], s[1])) {
+         s[0] = s[1] = '?';
+         s++;
+      }
    }
 }
 


### PR DESCRIPTION
## Summary

Hardening follow-up to PR #2001 and GHSA-q64m-h5hc-c4qq:

- Add `Char_isC1Control()` helper to detect UTF-8 encoded C1 control characters (U+0080-U+009F, encoded as 0xC2 0x80-0x9F)
- Extend `String_stripControlChars()` to replace C1 two-byte sequences with `??`
- Apply C1 filtering in the non-wide RichString rendering path