### PR TITLE
Keep search selection followed on confirm

### DIFF
--- a/MainPanel.c
+++ b/MainPanel.c
@@ -99,15 +99,22 @@ static HandlerResult MainPanel_eventHandler(Panel* super, int ch) {
       reaction |= Action_setScreenTab(this->state, x);
       result = HANDLED;
    } else if (ch != ERR && this->inc->active) {
+      const bool wasSearch = !this->inc->active->isFilter;
       bool filterChanged = IncSet_handleKey(this->inc, ch, super, MainPanel_getValue, NULL);
       if (filterChanged) {
          host->activeTable->incFilter = IncSet_filter(this->inc);
          reaction = HTOP_REFRESH | HTOP_REDRAW_BAR;
       }
-      if (this->inc->found && this->inc->active && !this->inc->active->isFilter) {
+      /* Keep the active-search match separate from the Enter-confirm edge:
+       * IncSet_handleKey() may confirm the search and clear inc->active. */
+      const bool activeSearchMatch = this->inc->active && this->inc->found && !this->inc->active->isFilter;
+      const bool confirmedSearch = !this->inc->active && wasSearch && (ch == '\r' || ch == KEY_ENTER);
+      if (activeSearchMatch || confirmedSearch) {
          host->activeTable->following = MainPanel_selectedRow(this);
          Panel_setSelectionColor(super, PANEL_SELECTION_FOLLOW);
          reaction |= HTOP_KEEP_FOLLOWING;
+         if (confirmedSearch)
+            reaction |= HTOP_REFRESH;
       }
       result = HANDLED;
    } else if (ch == 27) {


### PR DESCRIPTION
## Summary

When confirming an active incremental search, keep the selected process as the table's followed row before refreshing the main panel.

This preserves the searched/selected row across the refresh that happens when leaving search mode, including sorted tree view setups where a rebuild can otherwise move the cursor to an unexpected row.

## Testing

- `./autogen.sh && ./configure`
- `make -j32`
- `make check`
- `git diff --check`

## AI disclosure

This patch was prepared with assistance from OpenAI Codex and reviewed before submission.
