### PR TITLE
pcp: NULL-guard Metric_instanceCount/Offset

### DIFF
--- a/pcp/Metric.c
+++ b/pcp/Metric.c
@@ -56,6 +56,9 @@ pmAtomValue* Metric_values(Metric metric, pmAtomValue* atom, int count, int type
 }
 
 int Metric_instanceCount(Metric metric) {
+   if (pcp->result == NULL)
+      return 0;
+
    pmValueSet* vset = pcp->result->vset[metric];
    if (vset)
       return vset->numval;
@@ -63,6 +66,9 @@ int Metric_instanceCount(Metric metric) {
 }
 
 int Metric_instanceOffset(Metric metric, int inst) {
+   if (pcp->result == NULL)
+      return 0;
+
    pmValueSet* vset = pcp->result->vset[metric];
    if (!vset || vset->numval <= 0)
       return 0;


### PR DESCRIPTION
## What

`Metric_instanceCount()` and `Metric_instanceOffset()` in `pcp/Metric.c`
dereference `pcp->result->vset[metric]` without first checking whether
`pcp->result` is `NULL`.

## Why

`Metric_fetch()` frees and sets `pcp->result = NULL` before fetching, and
leaves it `NULL` if `pmFetch()` fails. The sibling accessors `Metric_values()`
and `Metric_iterate()` already guard against this, but these two do not — so a
meter that calls them (the per-CPU instance count in `PCPMachine.c`, or the
zram meter via `Platform_setZramValues()`) can dereference `NULL` on a redraw
following a failed fetch.

## Fix

Add the same early-return guard the sibling accessors already use:

    if (pcp->result == NULL)
       return 0;

## Testing

Built with `./configure --enable-pcp && make`; `pcp-htop` compiles cleanly
with no new warnings (including `-Wnull-dereference`).

## AI disclosure

Developed with AI assistance (`Assisted-by: Claude (Anthropic)` and
`Assisted-by: OpenAI Codex`, recorded in the commit trailers) per htop's
AI-assisted contributions policy. I have reviewed and understand the change
and take full responsibility for it.
