### PR TITLE
Document DCO commit sign-off in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,3 +80,5 @@ The `pcp/` platform uses PMAPI to fetch metrics and supports dynamic column/mete
 ## AI Contributions Policy
 
 Disclose AI use via `Assisted-by:` or `Co-authored-by:` commit trailers. Contributor is fully responsible for quality and license compliance. See `docs/ai-contributions-policy.md`.
+
+Sign off commits with a `Signed-off-by:` trailer (`git commit -s`) to certify the [Developer Certificate of Origin](https://developercertificate.org/). Sign-off is distinct from AI disclosure: `Assisted-by:` records tool use; `Signed-off-by:` records human responsibility. An agent must not sign off on a contributor's behalf without confirmation.


### PR DESCRIPTION
It was noted in #1989 to include the Developer Certificate of Origin (DCO).

This commit adds that instruction to the `AGENTS.md`, so that agents do so proactively.

## AI disclosure

Developed with AI assistance (`Assisted-by: Claude (Anthropic)` and
`Assisted-by: OpenAI Codex`, recorded in the commit trailers) per htop's
AI-assisted contributions policy. I have reviewed and understand the change and take full responsibility for it.
