### PR TITLE
Panel: guard header draw against negative width

### DIFF
--- a/Panel.c
+++ b/Panel.c
@@ -255,7 +255,7 @@ void Panel_draw(Panel* this, bool force_redraw, bool focus, bool highlightSelect
    if (headerLen > 0) {
       attrset(header_attr);
       mvhline(y, x, ' ', this->w);
-      if (scrollH < headerLen) {
+      if (scrollH < headerLen && this->w > 0) {
          RichString_printoffnVal(this->header, y, x, scrollH,
             MINIMUM(headerLen - scrollH, this->w));
       }


### PR DESCRIPTION
I'm working on trying to understand the UI system. If this PR is too small, I can do larger ones.

---

On a narrow terminal `this->w` can go negative, making the count passed to `mvadd_wchnstr` negative; ncurses then writes the whole header, ignoring the panel width. The item-draw path already guards `amt > 0` — this applies the same guard to the header.

## AI disclosure

AI-assisted (`Assisted-by: Claude (Anthropic)`), per htop's AI-contributions policy. I reviewed it and take full responsibility.
