### PR TITLE
Handle unavailable OOM scores as N/A

### DIFF
--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -11,6 +11,7 @@ in the source distribution for its full text.
 #include "linux/LinuxProcess.h"
 
 #include <assert.h>
+#include <limits.h>
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -296,7 +297,14 @@ static void LinuxProcess_rowWriteField(const Row* super, RichString* str, Proces
       xSnprintf(buffer, n, "%-*.*s ", Row_fieldWidths[CONTAINER], Row_fieldWidths[CONTAINER], lp->container_short ? lp->container_short : "N/A");
       RichString_appendWide(str, attr, buffer);
       return;
-   case OOM: xSnprintf(buffer, n, "%4u ", lp->oom); break;
+   case OOM:
+      if (lp->oom == UINT_MAX) {
+         attr = CRT_colors[PROCESS_SHADOW];
+         xSnprintf(buffer, n, " N/A ");
+      } else {
+         xSnprintf(buffer, n, "%4u ", lp->oom);
+      }
+      break;
    case IO_PRIORITY: {
       int klass = IOPriority_class(lp->ioPriority);
       if (klass == IOPRIO_CLASS_NONE) {

--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -1133,6 +1133,7 @@ static void LinuxProcessTable_readOomData(LinuxProcess* process, openat_arg_t pr
 
    char buffer[PROC_LINE_LENGTH + 1] = {0};
 
+   process->oom = UINT_MAX;
    ssize_t oomRead = Compat_readfileat(procFd, "oom_score", buffer, sizeof(buffer));
    if (oomRead < 1) {
       return;


### PR DESCRIPTION
Related to #322

This patch makes OOM score handling consistent with other unavailable process metrics.

Previously, if reading `/proc/<pid>/oom_score` failed, the function returned early without assigning an explicit unavailable state. Since `LinuxProcess` instances are zero-initialized via `xCalloc`, failed reads implicitly appeared as `0`, which is ambiguous because `0` is also a valid OOM score.

This change:

* initializes `process->oom` to `UINT_MAX` before attempting the read
* displays `N/A` when the OOM score is unavailable

This aligns OOM handling with existing sentinel-based unavailable-state handling used elsewhere in the codebase.
