### PR TITLE
add Thinkpad fan module

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -204,6 +204,7 @@ linux_platform_headers = \
 	linux/ProcessField.h \
 	linux/SELinuxMeter.h \
 	linux/SystemdMeter.h \
+	linux/ThinkpadFan.h \
 	linux/ZramMeter.h \
 	linux/ZramStats.h \
 	linux/ZswapStats.h \
@@ -230,6 +231,7 @@ linux_platform_sources = \
 	linux/PressureStallMeter.c \
 	linux/SELinuxMeter.c \
 	linux/SystemdMeter.c \
+	linux/ThinkpadFan.c \
 	linux/ZramMeter.c \
 	zfs/ZfsArcMeter.c \
 	zfs/ZfsCompressedArcMeter.c

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -56,6 +56,7 @@ in the source distribution for its full text.
 #include "linux/OpenRCMeter.h"
 #include "linux/SELinuxMeter.h"
 #include "linux/SystemdMeter.h"
+#include "linux/ThinkpadFan.h"
 #include "linux/ZramMeter.h"
 #include "linux/ZramStats.h"
 #include "linux/ZswapStats.h"
@@ -277,6 +278,7 @@ const MeterClass* const Platform_meterTypes[] = {
    &OpenRCUserMeter_class,
    &FileDescriptorMeter_class,
    &GPUMeter_class,
+   &ThinkpadFanMeter_class,
    NULL
 };
 
@@ -989,6 +991,24 @@ void Platform_getBattery(double* percent, ACPresence* isOnAC) {
    Platform_Battery_cachePercent = *percent;
    Platform_Battery_cacheIsOnAC = *isOnAC;
    Platform_Battery_cacheTime = now;
+}
+
+int Platform_getThinkpadFan(void) {
+   char fandata[256];
+   ssize_t fanread = Compat_readfile(PROCDIR "/acpi/ibm/fan", fandata, sizeof(fandata));
+   if (fanread < 1)
+      return -1;
+
+   const char* speed = strstr(fandata, "speed:");
+   if (!speed)
+      return -1;
+
+   int rpm;
+   int n = sscanf(speed, "speed: %d", &rpm);
+   if (n != 1)
+      return -1;
+
+   return rpm;
 }
 
 void Platform_longOptionsUsage(const char* name)

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -94,6 +94,8 @@ bool Platform_getNetworkIO(NetworkIOData* data);
 
 void Platform_getBattery(double* percent, ACPresence* isOnAC);
 
+int Platform_getThinkpadFan(void);
+
 static inline void Platform_getHostname(char* buffer, size_t size) {
    Generic_hostname(buffer, size);
 }

--- a/linux/ThinkpadFan.c
+++ b/linux/ThinkpadFan.c
@@ -1,0 +1,44 @@
+/*
+htop - ThinkpadFan.c
+(C) 2026 Murad Karammaev
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include "config.h" // IWYU pragma: keep
+
+#include "linux/ThinkpadFan.h"
+
+#include "CRT.h"
+#include "Object.h"
+#include "XUtils.h"
+#include "linux/Platform.h"
+
+
+static const int ThinkpadFanMeter_attributes[] = {
+   METER_VALUE
+};
+
+static void ThinkpadFanMeter_updateValues(Meter* this) {
+   int fanspeed = Platform_getThinkpadFan();
+   if (fanspeed < 0)
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "N/A");
+   else
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%d RPM", fanspeed);
+}
+
+const MeterClass ThinkpadFanMeter_class = {
+   .super = {
+      .extends = Class(Meter),
+      .delete = Meter_delete
+   },
+   .updateValues = ThinkpadFanMeter_updateValues,
+   .defaultMode = TEXT_METERMODE,
+   .supportedModes = (1 << TEXT_METERMODE) | (1 << LED_METERMODE),
+   .maxItems = 0,
+   .total = 0.0,
+   .attributes = ThinkpadFanMeter_attributes,
+   .name = "ThinkpadFan",
+   .uiName = "Thinkpad fan speed",
+   .caption = "Thinkpad fan: ",
+};

--- a/linux/ThinkpadFan.h
+++ b/linux/ThinkpadFan.h
@@ -1,0 +1,15 @@
+#ifndef HEADER_ThinkpadFan
+#define HEADER_ThinkpadFan
+/*
+htop - ThinkpadFan.h
+(C) 2026 Murad Karammaev
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include "Meter.h"
+
+
+extern const MeterClass ThinkpadFanMeter_class;
+
+#endif


### PR DESCRIPTION
Thinkpad laptops running on Linux usually provide a `/proc/acpi/ibm/fan` file which allows users to read or control fan speed. I implemented a tiny module which exposes a Thinkpad fan speed meter.

What I tested manually:
- [x] this module correctly reports Thinkpad fan speed on Thinkpads
- [x] this module correctly reports N/A on non-Thinkpads
- [x] this module exposes data which correctly renders using both text and LED meter modes

Some important things to consider:
- there is an issue #1838 which requests a general feature of fan speed meters. I didn't implement it, because that would require more work :) Also it would require to put more thought into fan meter design, too. I think however that this tiny PR is a good starting point which gives us at least some fan speed module to begin designing this feature?
- I put this module source code and platform functions into `linux`, because, I think, Linux is the only platform which exposes this data using `/proc/acpi/ibm/fan` interface.
- Maybe there is a better CRT colour scheme for this module? I am new to htop so I did my best to pick something that makes sense.
- Maybe I could add more meter modes other than text and LED? Any thoughts?