### PR TITLE
Remove obsolete OpenVZ and VServer support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 env:
   # Enable format attributes in ncurses headers
   # Enable fortified memory/string handling

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,11 +72,11 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: ./configure --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-delayacct --enable-sensors --enable-capabilities --enable-backtrace --enable-demangling || ( cat config.log; exit 1; )
+      run: ./configure --enable-werror --enable-unicode --enable-hwloc --enable-delayacct --enable-sensors --enable-capabilities --enable-backtrace --enable-demangling || ( cat config.log; exit 1; )
     - name: Build
       run: make -k
     - name: Distcheck
-      run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-delayacct --enable-sensors --enable-capabilities --enable-backtrace --enable-demangling'
+      run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror --enable-unicode --enable-hwloc --enable-delayacct --enable-sensors --enable-capabilities --enable-backtrace --enable-demangling'
 
   build-ubuntu-latest-full-featured-clang:
     runs-on: ubuntu-latest
@@ -96,11 +96,11 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: ./configure --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-delayacct --enable-sensors --enable-capabilities --enable-backtrace --enable-demangling || ( cat config.log; exit 1; )
+      run: ./configure --enable-werror --enable-unicode --enable-hwloc --enable-delayacct --enable-sensors --enable-capabilities --enable-backtrace --enable-demangling || ( cat config.log; exit 1; )
     - name: Build
       run: make -k
     - name: Distcheck
-      run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-delayacct --enable-sensors --enable-capabilities --enable-backtrace --enable-demangling'
+      run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-werror --enable-unicode --enable-hwloc --enable-delayacct --enable-sensors --enable-capabilities --enable-backtrace --enable-demangling'
 
   build-ubuntu-latest-gcc-static:
     runs-on: ubuntu-latest
@@ -117,11 +117,11 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: ./configure --enable-static --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --disable-hwloc --disable-delayacct --enable-sensors --enable-capabilities || ( cat config.log; exit 1; )
+      run: ./configure --enable-static --enable-werror --enable-unicode --disable-hwloc --disable-delayacct --enable-sensors --enable-capabilities || ( cat config.log; exit 1; )
     - name: Build
       run: make -k
     - name: Distcheck
-      run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-static --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --disable-hwloc --disable-delayacct --enable-sensors --enable-capabilities'
+      run: make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-static --enable-werror --enable-unicode --disable-hwloc --disable-delayacct --enable-sensors --enable-capabilities'
 
   build-ubuntu-latest-pcp:
     # we want PCP v5.2.3+
@@ -173,7 +173,7 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: scan-build-22 -analyze-headers --status-bugs ./configure --enable-debug --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-delayacct --enable-sensors --enable-capabilities --enable-backtrace --enable-demangling || ( cat config.log; exit 1; )
+      run: scan-build-22 -analyze-headers --status-bugs ./configure --enable-debug --enable-werror --enable-unicode --enable-delayacct --enable-sensors --enable-capabilities --enable-backtrace --enable-demangling || ( cat config.log; exit 1; )
     - name: Build
       run: scan-build-22 -analyze-headers --status-bugs make -j"$(nproc)"
 
@@ -203,7 +203,7 @@ jobs:
     - name: Bootstrap
       run: ./autogen.sh
     - name: Configure
-      run: ./configure --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-delayacct --enable-sensors --enable-capabilities --enable-backtrace --enable-demangling || ( cat config.log; exit 1; )
+      run: ./configure --enable-werror --enable-unicode --enable-hwloc --enable-delayacct --enable-sensors --enable-capabilities --enable-backtrace --enable-demangling || ( cat config.log; exit 1; )
     - name: Build
       run: make -k
     - name: Run sanitized htop (1)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
       run: ./autogen.sh
 
     - name: Configure
-      run: ./configure --enable-werror --enable-openvz --enable-vserver --enable-ancient-vserver --enable-unicode --enable-hwloc --enable-delayacct --enable-sensors --enable-capabilities
+      run: ./configure --enable-werror --enable-unicode --enable-hwloc --enable-delayacct --enable-sensors --enable-capabilities
 
     - name: Build
       run: make

--- a/Makefile.am
+++ b/Makefile.am
@@ -525,7 +525,7 @@ coverage:
 	$(MAKE) all AM_CPPFLAGS="-fprofile-arcs -ftest-coverage" AM_LDFLAGS="-lgcov"
 
 cppcheck:
-	cppcheck -q -v . --enable=all -DHAVE_OPENVZ
+	cppcheck -q -v . --enable=all
 
 dist-hook: $(top_distdir)/configure
 	@if test "x$$FORCE_MAKE_DIST" != x || \

--- a/README.md
+++ b/README.md
@@ -158,15 +158,6 @@ To install on the local system run `make install`. By default `make install` ins
   * `--with-proc`:
     location of a Linux-compatible proc filesystem
     - default: */proc*
-  * `--enable-openvz`:
-    enable OpenVZ support
-    - default: *no*
-  * `--enable-vserver`:
-    enable VServer support
-    - default: *no*
-  * `--enable-ancient-vserver`:
-    enable ancient VServer support (implies `--enable-vserver`)
-    - default: *no*
   * `--enable-delayacct`:
     enable Linux delay accounting support
     - dependencies: *libnl-3-dev*(build-time) and *libnl-genl-3-dev*(build-time), at runtime *libnl-3* and *libnl-genl-3* are loaded via `dlopen(3)` if available and requested

--- a/configure.ac
+++ b/configure.ac
@@ -1510,52 +1510,6 @@ AC_DEFINE_UNQUOTED([PROCDIR], ["$with_proc"], [Path of proc filesystem.])
 
 
 AC_ARG_ENABLE(
-   [openvz],
-   [AS_HELP_STRING(
-      [--enable-openvz],
-      [enable OpenVZ support @<:@default=no@:>@]
-   )],
-   [],
-   [enable_openvz=no]
-)
-if test "x$enable_openvz" = xyes; then
-   AC_DEFINE([HAVE_OPENVZ], [1], [Define if openvz support enabled.])
-fi
-
-
-AC_ARG_ENABLE(
-   [vserver],
-   [AS_HELP_STRING(
-      [--enable-vserver],
-      [enable VServer support @<:@default=no@:>@]
-   )],
-   [],
-   [enable_vserver=no]
-)
-if test "x$enable_vserver" = xyes; then
-   AC_DEFINE([HAVE_VSERVER], [1], [Define if VServer support enabled.])
-fi
-
-
-AC_ARG_ENABLE(
-   [ancient_vserver],
-   [AS_HELP_STRING(
-      [--enable-ancient-vserver],
-      [enable ancient VServer support (implies --enable-vserver) @<:@default=no@:>@]
-   )],
-   [],
-   [enable_ancient_vserver=no]
-)
-if test "x$enable_ancient_vserver" = xyes; then
-   if test "x$enable_vserver" != xyes; then
-      enable_vserver=implied
-   fi
-   AC_DEFINE([HAVE_VSERVER], [1], [Define if VServer support enabled.])
-   AC_DEFINE([HAVE_ANCIENT_VSERVER], [1], [Define if ancient vserver support enabled.])
-fi
-
-
-AC_ARG_ENABLE(
    [capabilities],
    [AS_HELP_STRING(
       [--enable-capabilities],
@@ -1867,9 +1821,6 @@ AC_MSG_RESULT([
 
   platform:                  $my_htop_platform ($host_os)
   (Linux) proc directory:    $with_proc
-  (Linux) openvz:            $enable_openvz
-  (Linux) vserver:           $enable_vserver
-  (Linux) ancient vserver:   $enable_ancient_vserver
   (Linux) delay accounting:  $enable_delayacct
   (Linux) sensors:           $enable_sensors
   (Linux) capabilities:      $enable_capabilities

--- a/htop.1.in
+++ b/htop.1.in
@@ -536,15 +536,6 @@ The number of Light-Weight Processes (=threads) in the process.
 .B TGID
 The thread group ID.
 .TP
-.B CTID
-OpenVZ container ID, a.k.a virtual environment ID.
-.TP
-.B VPID
-OpenVZ process ID.
-.TP
-.B VXID
-VServer process ID.
-.TP
 .B RCHAR (RD_CHAR)
 The number of bytes the process has read.
 .TP

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -70,13 +70,6 @@ const ProcessFieldData Process_fields[LAST_PROCESSFIELD] = {
    [TIME] = { .name = "TIME", .title = "  TIME+  ", .description = "Total time the process has spent in user and system time", .flags = 0, .defaultSortDesc = true, },
    [NLWP] = { .name = "NLWP", .title = "NLWP ", .description = "Number of threads in the process", .flags = 0, .defaultSortDesc = true, },
    [TGID] = { .name = "TGID", .title = "TGID", .description = "Thread group ID (i.e. process ID)", .flags = 0, .pidColumn = true, },
-#ifdef HAVE_OPENVZ
-   [CTID] = { .name = "CTID", .title = " CTID    ", .description = "OpenVZ container ID (a.k.a. virtual environment ID)", .flags = PROCESS_FLAG_LINUX_OPENVZ, },
-   [VPID] = { .name = "VPID", .title = "VPID", .description = "OpenVZ process ID", .flags = PROCESS_FLAG_LINUX_OPENVZ, .pidColumn = true, },
-#endif
-#ifdef HAVE_VSERVER
-   [VXID] = { .name = "VXID", .title = " VXID ", .description = "VServer process ID", .flags = PROCESS_FLAG_LINUX_VSERVER, },
-#endif
    [RCHAR] = { .name = "RCHAR", .title = "RCHAR ", .description = "Number of bytes the process has read", .flags = PROCESS_FLAG_IO, .defaultSortDesc = true, },
    [WCHAR] = { .name = "WCHAR", .title = "WCHAR ", .description = "Number of bytes the process has written", .flags = PROCESS_FLAG_IO, .defaultSortDesc = true, },
    [SYSCR] = { .name = "SYSCR", .title = "  READ_SYSC ", .description = "Number of read(2) syscalls for the process", .flags = PROCESS_FLAG_IO, .defaultSortDesc = true, },
@@ -129,9 +122,6 @@ void Process_delete(Object* cast) {
    free(this->container_short);
    free(this->cgroup_short);
    free(this->cgroup);
-#ifdef HAVE_OPENVZ
-   free(this->ctid);
-#endif
    free(this->secattr);
    free(this);
 }
@@ -280,13 +270,6 @@ static void LinuxProcess_rowWriteField(const Row* super, RichString* str, Proces
    case IO_READ_RATE:  Row_printRate(str, lp->io_rate_read_bps, coloring); return;
    case IO_WRITE_RATE: Row_printRate(str, lp->io_rate_write_bps, coloring); return;
    case IO_RATE: Row_printRate(str, LinuxProcess_totalIORate(lp), coloring); return;
-   #ifdef HAVE_OPENVZ
-   case CTID: xSnprintf(buffer, n, "%-8s ", lp->ctid ? lp->ctid : ""); break;
-   case VPID: xSnprintf(buffer, n, "%*d ", Process_pidDigits, lp->vpid); break;
-   #endif
-   #ifdef HAVE_VSERVER
-   case VXID: xSnprintf(buffer, n, "%5u ", lp->vxid); break;
-   #endif
    case CGROUP:
       xSnprintf(buffer, n, "%-*.*s ", Row_fieldWidths[CGROUP], Row_fieldWidths[CGROUP], lp->cgroup ? lp->cgroup : "N/A");
       RichString_appendWide(str, attr, buffer);
@@ -431,16 +414,6 @@ static int LinuxProcess_compareByKey(const Process* v1, const Process* v2, Proce
       return compareRealNumbers(p1->io_rate_write_bps, p2->io_rate_write_bps);
    case IO_RATE:
       return compareRealNumbers(LinuxProcess_totalIORate(p1), LinuxProcess_totalIORate(p2));
-   #ifdef HAVE_OPENVZ
-   case CTID:
-      return SPACESHIP_NULLSTR(p1->ctid, p2->ctid);
-   case VPID:
-      return SPACESHIP_NUMBER(p1->vpid, p2->vpid);
-   #endif
-   #ifdef HAVE_VSERVER
-   case VXID:
-      return SPACESHIP_NUMBER(p1->vxid, p2->vxid);
-   #endif
    case CGROUP:
       return SPACESHIP_NULLSTR(p1->cgroup, p2->cgroup);
    case CCGROUP:

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -19,8 +19,6 @@ in the source distribution for its full text.
 
 
 #define PROCESS_FLAG_LINUX_IOPRIO    0x00000100
-#define PROCESS_FLAG_LINUX_OPENVZ    0x00000200
-#define PROCESS_FLAG_LINUX_VSERVER   0x00000400
 #define PROCESS_FLAG_LINUX_CGROUP    0x00000800
 #define PROCESS_FLAG_LINUX_OOM       0x00001000
 #define PROCESS_FLAG_LINUX_SMAPS     0x00002000
@@ -84,13 +82,6 @@ typedef struct LinuxProcess_ {
    /* Storage data written (in bytes per second) */
    double io_rate_write_bps;
 
-   #ifdef HAVE_OPENVZ
-   char* ctid;
-   pid_t vpid;
-   #endif
-   #ifdef HAVE_VSERVER
-   unsigned int vxid;
-   #endif
    char* cgroup;
    char* cgroup_short;
    char* container_short;

--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -551,9 +551,6 @@ static bool LinuxProcessTable_readStatusFile(Process* process, openat_arg_t proc
 
    unsigned long ctxt = 0;
    process->isRunningInContainer = TRI_OFF;
-#ifdef HAVE_VSERVER
-   lp->vxid = 0;
-#endif
 
    FILE* statusfile = fopenat(procFd, "status", "r");
    if (!statusfile)
@@ -594,23 +591,6 @@ static bool LinuxProcessTable_readStatusFile(Process* process, openat_arg_t proc
          if (ok == 1) {
             ctxt += nvctxt;
          }
-
-#ifdef HAVE_VSERVER
-      } else if (String_startsWith(buffer, "VxID:")) {
-         int vxid;
-         int ok = sscanf(buffer, "VxID:\t%32d", &vxid);
-         if (ok == 1) {
-            lp->vxid = vxid;
-         }
-#ifdef HAVE_ANCIENT_VSERVER
-      } else if (String_startsWith(buffer, "s_context:")) {
-         int vxid;
-         int ok = sscanf(buffer, "s_context:\t%32d", &vxid);
-         if (ok == 1) {
-            lp->vxid = vxid;
-         }
-#endif /* HAVE_ANCIENT_VSERVER */
-#endif /* HAVE_VSERVER */
       }
    }
 
@@ -931,95 +911,6 @@ static bool LinuxProcessTable_readSmapsFile(LinuxProcess* process, openat_arg_t 
    fclose(fp);
    return true;
 }
-
-#ifdef HAVE_OPENVZ
-
-static void LinuxProcessTable_readOpenVZData(LinuxProcess* process, openat_arg_t procFd) {
-   if (access(PROCDIR "/vz", R_OK) != 0) {
-      free(process->ctid);
-      process->ctid = NULL;
-      process->vpid = Process_getPid(&process->super);
-      return;
-   }
-
-   FILE* file = fopenat(procFd, "status", "r");
-   if (!file) {
-      free(process->ctid);
-      process->ctid = NULL;
-      process->vpid = Process_getPid(&process->super);
-      return;
-   }
-
-   bool foundEnvID = false;
-   bool foundVPid = false;
-   char linebuf[256];
-   while (fgets(linebuf, sizeof(linebuf), file) != NULL) {
-      if (strchr(linebuf, '\n') == NULL) {
-         // Partial line, skip to end of this line
-         if (!skipEndOfLine(file)) {
-            break;
-         }
-      }
-
-      char* name_value_sep = strchr(linebuf, ':');
-      if (name_value_sep == NULL) {
-         continue;
-      }
-
-      int field;
-      if (0 == strncasecmp(linebuf, "envID", name_value_sep - linebuf)) {
-         field = 1;
-      } else if (0 == strncasecmp(linebuf, "VPid", name_value_sep - linebuf)) {
-         field = 2;
-      } else {
-         continue;
-      }
-
-      do {
-         name_value_sep++;
-      } while (*name_value_sep != '\0' && *name_value_sep <= 32);
-
-      char* value_end = name_value_sep;
-
-      while (*value_end > 32) {
-         value_end++;
-      }
-
-      if (name_value_sep == value_end) {
-         continue;
-      }
-
-      *value_end = '\0';
-
-      switch (field) {
-         case 1:
-            foundEnvID = true;
-            if (!String_eq(name_value_sep, process->ctid ? process->ctid : ""))
-               free_and_xStrdup(&process->ctid, name_value_sep);
-            break;
-         case 2:
-            if ((process->vpid = strtopid(name_value_sep)) != 0)
-               foundVPid = true;
-            break;
-         default:
-            //Sanity Check: Should never reach here, or the implementation is missing something!
-            assert(false && "OpenVZ handling: Unimplemented case for field handling reached.");
-      }
-   }
-
-   fclose(file);
-
-   if (!foundEnvID) {
-      free(process->ctid);
-      process->ctid = NULL;
-   }
-
-   if (!foundVPid) {
-      process->vpid = Process_getPid(&process->super);
-   }
-}
-
-#endif /* HAVE_OPENVZ */
 
 /*
  * Read /proc/<pid>/cgroup (thread-specific data)
@@ -1772,9 +1663,6 @@ static bool LinuxProcessTable_recurseProcTree(LinuxProcessTable* this, openat_ar
 
       if (ss->flags & PROCESS_FLAG_LINUX_CTXT
          || ((hideRunningInContainer || ss->flags & PROCESS_FLAG_LINUX_CONTAINER) && proc->isRunningInContainer == TRI_INITIAL)
-#ifdef HAVE_VSERVER
-         || ss->flags & PROCESS_FLAG_LINUX_VSERVER
-#endif
       ) {
          proc->isRunningInContainer = TRI_OFF;
          if (!LinuxProcessTable_readStatusFile(proc, procFd))
@@ -1782,12 +1670,6 @@ static bool LinuxProcessTable_recurseProcTree(LinuxProcessTable* this, openat_ar
       }
 
       if (!preExisting) {
-
-         #ifdef HAVE_OPENVZ
-         if (ss->flags & PROCESS_FLAG_LINUX_OPENVZ) {
-            LinuxProcessTable_readOpenVZData(lp, procFd);
-         }
-         #endif
 
          if (proc->isKernelThread) {
             Process_updateCmdline(proc, NULL, 0, 0);

--- a/linux/ProcessField.h
+++ b/linux/ProcessField.h
@@ -19,9 +19,6 @@ in the source distribution for its full text.
    M_TRS = 42,                   \
    M_DRS = 43,                   \
    M_LRS = 44,                   \
-   CTID = 100,                   \
-   VPID = 101,                   \
-   VXID = 102,                   \
    RCHAR = 103,                  \
    WCHAR = 104,                  \
    SYSCR = 105,                  \

--- a/pcp/ProcessField.h
+++ b/pcp/ProcessField.h
@@ -22,7 +22,6 @@ in the source distribution for its full text.
    M_DRS = 43,                   \
    M_LRS = 44,                   \
    M_DT = 45,                    \
-   CTID = 100,                   \
    RCHAR = 103,                  \
    WCHAR = 104,                  \
    SYSCR = 105,                  \


### PR DESCRIPTION
This PR fully removes all of the OpenVZ and Linux VServer legacy that has been dormant and unused for the past few years.

The code has been disabled by default for several releases now and has not been in use for quite some time.

Assisted-By: Claude Haiku 4.5