### PR TITLE
Linux: decouple deleted-library maps scan cadence

### DIFF
--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -107,6 +107,7 @@ typedef struct LinuxProcess_ {
    unsigned long ctxt_diff;
    char* secattr;
    unsigned long long int last_mlrs_calctime;
+   unsigned long long int last_deleted_lib_calctime;
 
    /* Total GPU time used in nano seconds */
    unsigned long long int gpu_time;

--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -745,7 +745,8 @@ static void LinuxProcessTable_calcLibSize_helper(ATTR_UNUSED ht_key_t key, void*
 static void LinuxProcessTable_readMaps(LinuxProcess* process, openat_arg_t procFd, const LinuxMachine* host, bool calcSize, bool checkDeletedLib) {
    Process* proc = (Process*)process;
 
-   proc->usesDeletedLib = false;
+   if (checkDeletedLib)
+      proc->usesDeletedLib = false;
 
    FILE* mapsfile = fopenat(procFd, "maps", "r");
    if (!mapsfile)
@@ -1703,17 +1704,39 @@ static bool LinuxProcessTable_recurseProcTree(LinuxProcessTable* this, openat_ar
       {
          bool prev = proc->usesDeletedLib;
 
-         if (!proc->isKernelThread && !proc->isUserlandThread &&
-             ((ss->flags & PROCESS_FLAG_LINUX_LRS_FIX) || (settings->highlightDeletedExe && !proc->procExeDeleted && isOlderThan(proc, 10)))) {
+         if (!proc->isKernelThread && !proc->isUserlandThread) {
+            bool checkLrs = false;
+            bool checkDeletedLib = false;
+            const bool checkForDeletedLib = settings->highlightDeletedExe && !proc->procExeDeleted && isOlderThan(proc, 10);
 
-            // Check if we really should recalculate the M_LRS value for this process
-            uint64_t passedTimeInMs = host->realtimeMs - lp->last_mlrs_calctime;
+            if (ss->flags & PROCESS_FLAG_LINUX_LRS_FIX) {
+               // Check if we really should recalculate the M_LRS value for this process
+               uint64_t passedTimeInMs = host->realtimeMs - lp->last_mlrs_calctime;
 
-            uint64_t recheck = ((uint64_t)rand()) % 2048;
+               uint64_t recheck = ((uint64_t)rand()) % 2048;
 
-            if (passedTimeInMs > recheck) {
-               lp->last_mlrs_calctime = host->realtimeMs;
-               LinuxProcessTable_readMaps(lp, procFd, lhost, ss->flags & PROCESS_FLAG_LINUX_LRS_FIX, settings->highlightDeletedExe);
+               checkLrs = passedTimeInMs > recheck;
+            }
+
+            if (checkForDeletedLib) {
+               uint64_t passedTimeInMs = host->realtimeMs - lp->last_deleted_lib_calctime;
+
+               uint64_t recheck = ((uint64_t)rand()) % 2048;
+
+               checkDeletedLib = passedTimeInMs > 10000 + recheck;
+            }
+
+            if (checkLrs || checkDeletedLib) {
+               if (checkLrs)
+                  lp->last_mlrs_calctime = host->realtimeMs;
+               if (checkDeletedLib)
+                  lp->last_deleted_lib_calctime = host->realtimeMs;
+               LinuxProcessTable_readMaps(lp, procFd, lhost, checkLrs, checkDeletedLib);
+            } else if (!checkForDeletedLib) {
+               proc->usesDeletedLib = false;
+            }
+            if (!(ss->flags & PROCESS_FLAG_LINUX_LRS_FIX)) {
+               lp->m_lrs = 0;
             }
          } else {
             /* Copy from process structure in threads and reset if setting got disabled */


### PR DESCRIPTION
## Summary

When deleted executable/library highlighting is enabled, Linux process refresh currently shares the same `last_mlrs_calctime` throttle for both the `M_LRS` column and deleted-library detection.

That couples two different behaviours:

- `M_LRS` can need frequent maps scans while the column is visible.
- Deleted-library highlighting only needs occasional rechecks, and should not be cleared by an unrelated `M_LRS`-only scan.

This adds a separate `last_deleted_lib_calctime`, clears `usesDeletedLib` only when the deleted-library check actually runs, and keeps a periodic deleted-library recheck so the marker can clear after a process unloads the deleted mapping.

## Validation

- `./autogen.sh && ./configure && make -j8`
- `make check`
- `git diff --check origin/main...HEAD`
- Manual runtime repro with a process that `dlopen()`s a temporary shared object and unlinks it while it remains mapped.
- Noninteractive htop smoke with a config showing `EXE` and `M_LRS` columns confirmed the process row is rendered and `M_LRS` is populated.
- TTY `strace -yy` comparison with only `EXE`/`Command` visible and deleted-library highlighting enabled:
  - patched branch, ~14.5s: 798 total `maps` opens, 2 for the target process
  - current `main`, ~15.4s: 3450 total `maps` opens, 9 for the target process
- A second repro process `dlclose()`d the deleted library after startup; the patched branch rechecked the target maps 4 times during a ~35.7s run after the mapping disappeared.
