### PR TITLE
Show error message when trace feature fails on fork

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -10,6 +10,7 @@ in the source distribution for its full text.
 #include "Action.h"
 
 #include <assert.h>
+#include <errno.h>
 #include <pwd.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -675,9 +676,13 @@ static Htop_Reaction actionStrace(State* st) {
 
    TraceScreen* ts = TraceScreen_new(p);
    bool ok = TraceScreen_forkTracer(ts);
-   if (ok) {
-      InfoScreen_run((InfoScreen*)ts);
+   if (!ok) {
+      char errmsg[256];
+      int saved_errno = errno;
+      snprintf(errmsg, sizeof(errmsg), "Failed to start tracer: %s", strerror(saved_errno));
+      InfoScreen_addLine(&ts->super, errmsg);
    }
+   InfoScreen_run((InfoScreen*)ts);
    TraceScreen_delete((Object*)ts);
    clear();
    CRT_enableDelay();

--- a/TraceScreen.c
+++ b/TraceScreen.c
@@ -127,21 +127,27 @@ bool TraceScreen_forkTracer(TraceScreen* this) {
    return true;
 
 err:
-   close(fdpair[1]);
-   close(fdpair[0]);
+   {
+      int saved_errno = errno;
+      close(fdpair[1]);
+      close(fdpair[0]);
+      errno = saved_errno;
+   }
    return false;
 }
 
 static void TraceScreen_updateTrace(InfoScreen* super) {
    TraceScreen* this = (TraceScreen*) super;
 
-   int fd_strace = fileno(this->strace);
+   int fd_strace = -1;
+   if (this->strace) {
+      fd_strace = fileno(this->strace);
+   }
 
    fd_set fds;
    FD_ZERO(&fds);
    FD_SET(STDIN_FILENO, &fds);
-   if (this->strace_alive) {
-      assert(fd_strace != -1);
+   if (this->strace_alive && fd_strace >= 0) {
       FD_SET(fd_strace, &fds);
    }
 
@@ -150,7 +156,7 @@ static void TraceScreen_updateTrace(InfoScreen* super) {
 
    char buffer[1025];
    size_t nread = 0;
-   if (ready > 0 && FD_ISSET(fd_strace, &fds))
+   if (fd_strace >= 0 && ready > 0 && FD_ISSET(fd_strace, &fds))
       nread = fread(buffer, 1, sizeof(buffer) - 1, this->strace);
 
    if (nread && this->tracing) {


### PR DESCRIPTION
## Summary

- Show error message in TraceScreen when `TraceScreen_forkTracer()` fails
- Preserve errno across cleanup in error path to ensure accurate error reporting

## Problem

When the trace feature (strace/truss) fails during the fork phase (e.g., out of memory, PID quota exceeded, seccomp/AppArmor restrictions), the TraceScreen was not displayed and users received no feedback. The UI appeared unresponsive even when pressing the `s` key multiple times.

## Solution

- Modified `actionStrace()` to always run the InfoScreen, adding an error message line when `forkTracer` fails
- Modified `TraceScreen_forkTracer()` to preserve errno across cleanup operations for accurate error reporting

## Changes

| File | Change |
|------|--------|
| `Action.c` | Show error message in TraceScreen when forkTracer fails |
| `TraceScreen.c` | Preserve errno in error cleanup path |

## Test Plan

- [x] Build succeeds with `./autogen.sh && ./configure && make`
- [x] `make check` passes
- [ ] Manual test: Simulate fork failure (e.g., set `ulimit -u 0` or use seccomp) and verify error message appears in TraceScreen

## AI disclosure

Assisted-by: Claude (Anthropic)

Fixes #1991
