### PR TITLE
darwin: fix Mach port leak in DarwinProcess_scanThreads()

### DIFF
--- a/darwin/DarwinProcess.c
+++ b/darwin/DarwinProcess.c
@@ -517,7 +517,10 @@ void DarwinProcess_scanThreads(DarwinProcess* dp, DarwinProcessTable* dpt) {
       dp->super.state = UNINTERRUPTIBLE_WAIT;
    }
 
-   vm_deallocate(mach_task_self(), (vm_address_t) thread_list, sizeof(thread_port_array_t) * thread_count);
+   for (mach_msg_type_number_t i = 0; i < thread_count; i++) {
+      mach_port_deallocate(mach_task_self(), thread_list[i]);
+   }
+   vm_deallocate(mach_task_self(), (vm_address_t) thread_list, sizeof(thread_act_t) * thread_count);
    mach_port_deallocate(mach_task_self(), task);
 }
 


### PR DESCRIPTION
## Summary

- Deallocate individual thread port send rights returned by `task_threads()` — each is a Mach send right that was never released, leaking one port per thread per refresh cycle
- Fix `vm_deallocate` size: use `sizeof(thread_act_t)` (element size) instead of `sizeof(thread_port_array_t)` (pointer size)

Fixes: https://github.com/htop-dev/htop/issues/2014

🤖 Generated with [Claude Code](https://claude.com/claude-code)