### PR TITLE
Fork exit fixes

### DIFF
--- a/OpenFilesScreen.c
+++ b/OpenFilesScreen.c
@@ -46,6 +46,8 @@ typedef struct OpenFiles_FileData_ {
    struct OpenFiles_FileData_* next;
 } OpenFiles_FileData;
 
+static void OpenFiles_Data_clear(OpenFiles_Data* data);
+
 static size_t getIndexForType(char type) {
    switch (type) {
       case 'f':
@@ -216,6 +218,12 @@ static OpenFiles_ProcessData* OpenFilesScreen_getProcessData(pid_t pid) {
 
    int wstatus;
    if (xWaitpid(child, &wstatus, 0, false) < 0) {
+      while (pdata->files) {
+         OpenFiles_FileData* cur = pdata->files;
+         pdata->files = cur->next;
+         OpenFiles_Data_clear(&cur->data);
+         free(cur);
+      }
       pdata->error = 1;
       return pdata;
    }

--- a/OpenFilesScreen.c
+++ b/OpenFilesScreen.c
@@ -215,11 +215,10 @@ static OpenFiles_ProcessData* OpenFilesScreen_getProcessData(pid_t pid) {
    fclose(fp);
 
    int wstatus;
-   while (waitpid(child, &wstatus, 0) == -1)
-      if (errno != EINTR) {
-         pdata->error = 1;
-         return pdata;
-      }
+   if (xWaitpid(child, &wstatus, 0, false) < 0) {
+      pdata->error = 1;
+      return pdata;
+   }
 
    if (!WIFEXITED(wstatus)) {
       pdata->error = 1;

--- a/OpenFilesScreen.c
+++ b/OpenFilesScreen.c
@@ -120,7 +120,7 @@ static OpenFiles_ProcessData* OpenFilesScreen_getProcessData(pid_t pid) {
       close(fdpair[1]);
       int fdnull = open("/dev/null", O_WRONLY);
       if (fdnull < 0) {
-         exit(1);
+         _exit(1);
       }
 
       dup2(fdnull, STDERR_FILENO);
@@ -130,7 +130,7 @@ static OpenFiles_ProcessData* OpenFilesScreen_getProcessData(pid_t pid) {
       // Use of NULL in variadic functions must have a pointer cast.
       // The NULL constant is not required by standard to have a pointer type.
       execlp("lsof", "lsof", "-P", "-o", "-p", buffer, "-F", (char*)NULL);
-      exit(127);
+      _exit(127);
    }
    close(fdpair[1]);
 

--- a/TraceScreen.c
+++ b/TraceScreen.c
@@ -114,13 +114,14 @@ bool TraceScreen_forkTracer(TraceScreen* this) {
       _exit(127);
    }
 
+   this->child = child;
+
    FILE* fp = fdopen(fdpair[0], "r");
    if (!fp)
       goto err;
 
    close(fdpair[1]);
 
-   this->child = child;
    this->strace = fp;
    this->strace_alive = true;
 

--- a/TraceScreen.c
+++ b/TraceScreen.c
@@ -49,9 +49,7 @@ void TraceScreen_delete(Object* cast) {
    TraceScreen* this = (TraceScreen*) cast;
    if (this->child > 0) {
       kill(this->child, SIGTERM);
-      while (waitpid(this->child, NULL, 0) == -1)
-         if (errno != EINTR)
-            break;
+      xWaitpid(this->child, NULL, 0, false);
    }
 
    if (this->strace) {
@@ -178,8 +176,9 @@ static void TraceScreen_updateTrace(InfoScreen* super) {
          Panel_setSelected(this->super.display, Panel_size(this->super.display) - 1);
       }
    } else {
-      if (this->strace_alive && waitpid(this->child, NULL, WNOHANG) != 0)
+      if (this->strace_alive && xWaitpid(this->child, NULL, WNOHANG, false) != 0) {
          this->strace_alive = false;
+      }
    }
 }
 

--- a/TraceScreen.c
+++ b/TraceScreen.c
@@ -111,7 +111,7 @@ bool TraceScreen_forkTracer(TraceScreen* this) {
          (void)! write(STDERR_FILENO, message, strlen(message));
       #endif
 
-      exit(127);
+      _exit(127);
    }
 
    FILE* fp = fdopen(fdpair[0], "r");

--- a/XUtils.c
+++ b/XUtils.c
@@ -20,6 +20,8 @@ in the source distribution for its full text.
 #include <string.h>
 #include <unistd.h>
 
+#include <sys/wait.h>
+
 #include "CRT.h"
 #include "Macros.h"
 
@@ -314,6 +316,29 @@ char* xStrndup(const char* str, size_t len) {
       fail();
    }
    return data;
+}
+
+pid_t xWaitpid(pid_t pid, int* wstatus, int options, bool wait_for_exit) {
+   int status = 0;
+   pid_t ret;
+
+   do {
+      ret = waitpid(pid, &status, options);
+   } while (ret == -1 && errno == EINTR);
+
+   while (wait_for_exit && (ret == 0 || (ret > 0 && !WIFEXITED(status) && !WIFSIGNALED(status)))) {
+      if (options & WNOHANG)
+         options &= ~WNOHANG;
+
+      do {
+         ret = waitpid(pid, &status, options);
+      } while (ret == -1 && errno == EINTR);
+   }
+
+   if (wstatus)
+      *wstatus = status;
+
+   return ret;
 }
 
 ssize_t full_write(int fd, const void* buf, size_t count) {

--- a/XUtils.h
+++ b/XUtils.h
@@ -20,6 +20,7 @@ in the source distribution for its full text.
 #include <stdio.h>
 #include <stdlib.h> // IWYU pragma: keep
 #include <string.h> // IWYU pragma: keep
+#include <sys/types.h>
 
 #include "Macros.h"
 
@@ -122,6 +123,8 @@ void free_and_xStrdup(char** ptr, const char* str);
 
 ATTR_NONNULL ATTR_RETNONNULL ATTR_MALLOC ATTR_ACCESS3_R(1, 2)
 char* xStrndup(const char* str, size_t len);
+
+pid_t xWaitpid(pid_t pid, int* wstatus, int options, bool wait_for_exit);
 
 ATTR_NONNULL ATTR_ACCESS3_R(2, 3)
 ssize_t full_write(int fd, const void* buf, size_t count);

--- a/linux/OpenRCMeter.c
+++ b/linux/OpenRCMeter.c
@@ -132,6 +132,10 @@ static void OpenRCMeter_display(ATTR_UNUSED const Object* cast, RichString* out,
    RichString_writeAscii(out, CRT_colors[METER_TEXT], "Runlevel: ");
    RichString_appendAscii(out, CRT_colors[METER_VALUE], ctx->runlevel ? ctx->runlevel : "N/A");
 
+   if (ctx->services_started == INVALID_VALUE && ctx->services_stopped == INVALID_VALUE) {
+      return;
+   }
+
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " (");
 
    if (ctx->services_started == INVALID_VALUE) {

--- a/linux/OpenRCMeter.c
+++ b/linux/OpenRCMeter.c
@@ -67,7 +67,7 @@ static int OpenRCMeter_execRcStatus(bool user, bool full, pid_t* childPid) {
       close(fdpair[1]);
       int fdnull = open("/dev/null", O_WRONLY);
       if (fdnull < 0)
-         exit(1);
+         _exit(1);
       dup2(fdnull, STDERR_FILENO);
       close(fdnull);
 
@@ -84,7 +84,7 @@ static int OpenRCMeter_execRcStatus(bool user, bool full, pid_t* childPid) {
             execlp("rc-status", "rc-status", "-C", "-r", (char*)NULL);
          }
       }
-      exit(127);
+      _exit(127);
    }
 
    *childPid = child;

--- a/linux/OpenRCMeter.c
+++ b/linux/OpenRCMeter.c
@@ -112,7 +112,7 @@ static void OpenRCMeter_updateViaExec(bool user) {
    FILE* commandOutput = fdopen(fd, "r");
    if (!commandOutput) {
       close(fd);
-      waitpid(child, NULL, 0);
+      xWaitpid(child, NULL, 0, false);
       return;
    }
 
@@ -126,7 +126,7 @@ static void OpenRCMeter_updateViaExec(bool user) {
    fclose(commandOutput);
 
    int wstatus;
-   if (waitpid(child, &wstatus, 0) < 0 || !WIFEXITED(wstatus) || WEXITSTATUS(wstatus) != 0)
+   if (xWaitpid(child, &wstatus, 0, false) < 0 || !WIFEXITED(wstatus) || WEXITSTATUS(wstatus) != 0)
       return;
 
    fd = OpenRCMeter_execRcStatus(user, true, &child);
@@ -136,7 +136,7 @@ static void OpenRCMeter_updateViaExec(bool user) {
    commandOutput = fdopen(fd, "r");
    if (!commandOutput) {
       close(fd);
-      waitpid(child, NULL, 0);
+      xWaitpid(child, NULL, 0, false);
       return;
    }
 
@@ -165,7 +165,7 @@ static void OpenRCMeter_updateViaExec(bool user) {
 
    fclose(commandOutput);
 
-   if (waitpid(child, &wstatus, 0) < 0 || !WIFEXITED(wstatus) || WEXITSTATUS(wstatus) != 0) {
+   if (xWaitpid(child, &wstatus, 0, false) < 0 || !WIFEXITED(wstatus) || WEXITSTATUS(wstatus) != 0) {
       ctx->services_started = INVALID_VALUE;
       ctx->services_stopped = INVALID_VALUE;
    }

--- a/linux/OpenRCMeter.c
+++ b/linux/OpenRCMeter.c
@@ -42,21 +42,23 @@ static void OpenRCMeter_done(ATTR_UNUSED Meter* this) {
    ctx->runlevel = NULL;
 }
 
-static void updateViaExec(bool user) {
-   OpenRCMeterContext_t* ctx = user ? &ctx_user : &ctx_system;
-
-   if (Settings_isReadonly())
-      return;
+ATTR_NONNULL_N(3) ATTR_ACCESS2_W(3)
+static int OpenRCMeter_execRcStatus(bool user, bool full, pid_t* childPid) {
+   if (user) {
+      const char* xdg = getenv("XDG_RUNTIME_DIR");
+      if (!xdg || !*xdg)
+         return -1;
+   }
 
    int fdpair[2] = {-1, -1};
    if (pipe(fdpair) < 0)
-      return;
+      return -1;
 
    pid_t child = fork();
    if (child < 0) {
       close(fdpair[1]);
       close(fdpair[0]);
-      return;
+      return -1;
    }
 
    if (child == 0) {
@@ -68,48 +70,105 @@ static void updateViaExec(bool user) {
          exit(1);
       dup2(fdnull, STDERR_FILENO);
       close(fdnull);
+
       if (user) {
-         execlp("rc-status", "rc-status", "--user", "-a", (char*)NULL);
+         if (full) {
+            execlp("rc-status", "rc-status", "-C", "--user", "-f", "ini", "-a", (char*)NULL);
+         } else {
+            execlp("rc-status", "rc-status", "-C", "--user", "-r", (char*)NULL);
+         }
       } else {
-         execlp("rc-status", "rc-status", "-a", (char*)NULL);
+         if (full) {
+            execlp("rc-status", "rc-status", "-C", "-f", "ini", "-a", (char*)NULL);
+         } else {
+            execlp("rc-status", "rc-status", "-C", "-r", (char*)NULL);
+         }
       }
       exit(127);
    }
-   close(fdpair[1]);
 
-   int wstatus;
-   if (waitpid(child, &wstatus, 0) < 0 || !WIFEXITED(wstatus) || WEXITSTATUS(wstatus) != 0) {
-      close(fdpair[0]);
+   *childPid = child;
+
+   close(fdpair[1]);
+   return fdpair[0];
+}
+
+static void OpenRCMeter_updateViaExec(bool user) {
+   OpenRCMeterContext_t* ctx = user ? &ctx_user : &ctx_system;
+
+   ctx->services_started = INVALID_VALUE;
+   ctx->services_stopped = INVALID_VALUE;
+
+   if (Settings_isReadonly())
+      return;
+
+   char lineBuffer[1024];
+
+   pid_t child;
+   int fd = OpenRCMeter_execRcStatus(user, false, &child);
+   if (fd < 0)
+      return;
+
+   FILE* commandOutput = fdopen(fd, "r");
+   if (!commandOutput) {
+      close(fd);
+      waitpid(child, NULL, 0);
       return;
    }
 
-   FILE* commandOutput = fdopen(fdpair[0], "r");
+   if (fgets(lineBuffer, sizeof(lineBuffer), commandOutput)) {
+      char* newline = strchr(lineBuffer, '\n');
+      if (newline)
+         *newline = '\0';
+
+      free_and_xStrdup(&ctx->runlevel, lineBuffer);
+   }
+   fclose(commandOutput);
+
+   int wstatus;
+   if (waitpid(child, &wstatus, 0) < 0 || !WIFEXITED(wstatus) || WEXITSTATUS(wstatus) != 0)
+      return;
+
+   fd = OpenRCMeter_execRcStatus(user, true, &child);
+   if (fd < 0)
+      return;
+
+   commandOutput = fdopen(fd, "r");
    if (!commandOutput) {
-      close(fdpair[0]);
+      close(fd);
+      waitpid(child, NULL, 0);
       return;
    }
 
    ctx->services_started = 0;
    ctx->services_stopped = 0;
 
-   char lineBuffer[256];
    while (fgets(lineBuffer, sizeof(lineBuffer), commandOutput)) {
-      if (String_startsWith(lineBuffer, "Runlevel: ")) {
-         char* newline = strchr(lineBuffer + strlen("Runlevel: "), '\n');
-         if (newline) {
-            *newline = '\0';
-         }
-         free_and_xStrdup(&ctx->runlevel, lineBuffer + strlen("Runlevel: "));
-      } else {
-         if (strstr(lineBuffer, "[") && strstr(lineBuffer, "started") && strstr(lineBuffer, "]")) {
-            ctx->services_started++;
-         } else if (strstr(lineBuffer, "[") && strstr(lineBuffer, "stopped") && strstr(lineBuffer, "]")) {
-            ctx->services_stopped++;
-         }
+      char* equals = strchr(lineBuffer, '=');
+      if (!equals)
+         continue;
+
+      char* status = equals + 1;
+      while (*status == ' ' || *status == '\t')
+         status++;
+
+      char* newline = strchr(status, '\n');
+      if (newline)
+         *newline = '\0';
+
+      if (strstr(status, "started")) {
+         ctx->services_started++;
+      } else if (strstr(status, "stopped")) {
+         ctx->services_stopped++;
       }
    }
 
    fclose(commandOutput);
+
+   if (waitpid(child, &wstatus, 0) < 0 || !WIFEXITED(wstatus) || WEXITSTATUS(wstatus) != 0) {
+      ctx->services_started = INVALID_VALUE;
+      ctx->services_stopped = INVALID_VALUE;
+   }
 }
 
 static void OpenRCMeter_updateValues(Meter* this) {
@@ -121,7 +180,7 @@ static void OpenRCMeter_updateValues(Meter* this) {
    ctx->services_stopped = INVALID_VALUE;
    ctx->services_started = INVALID_VALUE;
 
-   updateViaExec(user);
+   OpenRCMeter_updateViaExec(user);
 
    xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%s", ctx->runlevel ? ctx->runlevel : "???");
 }
@@ -141,7 +200,7 @@ static void OpenRCMeter_display(ATTR_UNUSED const Object* cast, RichString* out,
    if (ctx->services_started == INVALID_VALUE) {
       xSnprintf(buffer, sizeof(buffer), "?");
    } else {
-      xSnprintf(buffer, sizeof(buffer), "%u", ctx->services_started);
+      xSnprintf(buffer, sizeof(buffer), "%zu", ctx->services_started);
    }
    RichString_appendAscii(out, CRT_colors[METER_VALUE_OK], buffer);
 
@@ -150,7 +209,7 @@ static void OpenRCMeter_display(ATTR_UNUSED const Object* cast, RichString* out,
    if (ctx->services_stopped == INVALID_VALUE) {
       xSnprintf(buffer, sizeof(buffer), "?");
    } else {
-      xSnprintf(buffer, sizeof(buffer), "%u", ctx->services_stopped);
+      xSnprintf(buffer, sizeof(buffer), "%zu", ctx->services_stopped);
    }
    RichString_appendAscii(out, CRT_colors[METER_VALUE_ERROR], buffer);
 

--- a/linux/OpenRCMeter.c
+++ b/linux/OpenRCMeter.c
@@ -24,12 +24,12 @@ in the source distribution for its full text.
 #include "Settings.h"
 #include "XUtils.h"
 
-#define INVALID_VALUE ((unsigned int)-1)
+#define INVALID_VALUE ((size_t)-1)
 
 typedef struct OpenRCMeterContext {
    char* runlevel;
-   unsigned int services_stopped;
-   unsigned int services_started;
+   size_t services_stopped;
+   size_t services_started;
 } OpenRCMeterContext_t;
 
 static OpenRCMeterContext_t ctx_system;

--- a/linux/SystemdMeter.c
+++ b/linux/SystemdMeter.c
@@ -255,7 +255,7 @@ static void updateViaExec(bool user) {
    close(fdpair[1]);
 
    int wstatus;
-   if (waitpid(child, &wstatus, 0) < 0 || !WIFEXITED(wstatus) || WEXITSTATUS(wstatus) != 0) {
+   if (xWaitpid(child, &wstatus, 0, false) < 0 || !WIFEXITED(wstatus) || WEXITSTATUS(wstatus) != 0) {
       close(fdpair[0]);
       return;
    }

--- a/linux/SystemdMeter.c
+++ b/linux/SystemdMeter.c
@@ -234,7 +234,7 @@ static void updateViaExec(bool user) {
       close(fdpair[1]);
       int fdnull = open("/dev/null", O_WRONLY);
       if (fdnull < 0)
-         exit(1);
+         _exit(1);
       dup2(fdnull, STDERR_FILENO);
       close(fdnull);
       // Use of NULL in variadic functions must have a pointer cast.
@@ -250,7 +250,7 @@ static void updateViaExec(bool user) {
          "--property=NJobs",
          "--property=NInstalledJobs",
          (char*)NULL);
-      exit(127);
+      _exit(127);
    }
    close(fdpair[1]);
 


### PR DESCRIPTION
Avoid calling the atexit handlers in forked process paths.

Follow-up on exit handler issue remarked regarding #2019.