### PR TITLE
Sticky follow

### DIFF
--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -315,6 +315,7 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    Panel_add(super, (Object*) CheckItem_newByRef("Highlight new and old processes", &(settings->highlightChanges)));
    Panel_add(super, (Object*) NumberItem_newByRef("- Highlight time (in seconds)", &(settings->highlightDelaySecs), 0, 1, 24 * 60 * 60));
    Panel_add(super, (Object*) NumberItem_newByRef("Hide main function bar (0 - off, 1 - on ESC until next input, 2 - permanently)", &(settings->hideFunctionBar), 0, 0, 2));
+   Panel_add(super, (Object*) CheckItem_newByRef("Sticky follow", &(settings->stickyFollow)));
    #ifdef HAVE_LIBHWLOC
    Panel_add(super, (Object*) CheckItem_newByRef("Show topology when selecting affinity by default", &(settings->topologyAffinity)));
    #endif

--- a/MainPanel.c
+++ b/MainPanel.c
@@ -80,7 +80,7 @@ static HandlerResult MainPanel_eventHandler(Panel* super, int ch) {
    ScreenSettings* ss = settings->ss;
 
    if ((ch == KEY_UP || ch == KEY_DOWN || ch == KEY_PPAGE || ch == KEY_NPAGE) &&
-       host->activeTable->following != -1) {
+       host->activeTable->following != -1 && !settings->stickyFollow) {
       host->activeTable->following = -1;
       Panel_setSelectionColor(super, PANEL_SELECTION_FOCUS);
    }

--- a/MainPanel.c
+++ b/MainPanel.c
@@ -79,6 +79,12 @@ static HandlerResult MainPanel_eventHandler(Panel* super, int ch) {
    Settings* settings = host->settings;
    ScreenSettings* ss = settings->ss;
 
+   if ((ch == KEY_UP || ch == KEY_DOWN || ch == KEY_PPAGE || ch == KEY_NPAGE) &&
+       host->activeTable->following != -1) {
+      host->activeTable->following = -1;
+      Panel_setSelectionColor(super, PANEL_SELECTION_FOCUS);
+   }
+
    if (EVENT_IS_HEADER_CLICK(ch)) {
       int x = EVENT_HEADER_CLICK_GET_X(ch);
       int hx = super->scrollH + x + 1;

--- a/Settings.c
+++ b/Settings.c
@@ -473,6 +473,8 @@ static bool Settings_read(Settings* this, const char* fileName, const Machine* h
          this->showCPUSMTLabels = atoi(option[1]);
       } else if (String_eq(option[0], "show_cpu_usage")) {
          this->showCPUUsage = atoi(option[1]);
+      } else if (String_eq(option[0], "sticky_follow")) {
+         this->stickyFollow = atoi(option[1]);
       } else if (String_eq(option[0], "show_cpu_frequency")) {
          this->showCPUFrequency = atoi(option[1]);
       } else if (String_eq(option[0], "show_cached_memory")) {
@@ -713,6 +715,7 @@ int Settings_write(const Settings* this, bool onCrash) {
    printSettingInteger("cpu_count_from_one", this->countCPUsFromOne);
    printSettingInteger("show_cpu_smt_labels", this->showCPUSMTLabels);
    printSettingInteger("show_cpu_usage", this->showCPUUsage);
+   printSettingInteger("sticky_follow", this->stickyFollow);
    printSettingInteger("show_cpu_frequency", this->showCPUFrequency);
    #ifdef BUILD_WITH_CPU_TEMP
    printSettingInteger("show_cpu_temperature", this->showCPUTemperature);
@@ -820,6 +823,7 @@ Settings* Settings_new(const Machine* host, Hashtable* dynamicMeters, Hashtable*
    this->countCPUsFromOne = false;
    this->showCPUSMTLabels = false;
    this->showCPUUsage = true;
+   this->stickyFollow = true;
    this->showCPUFrequency = false;
    #ifdef BUILD_WITH_CPU_TEMP
    this->showCPUTemperature = false;

--- a/Settings.h
+++ b/Settings.h
@@ -77,6 +77,7 @@ typedef struct Settings_ {
    bool countCPUsFromOne;
    bool detailedCPUTime;
    bool showCPUUsage;
+   bool stickyFollow;
    bool showCPUFrequency;
    bool showCPUSMTLabels;
    #ifdef BUILD_WITH_CPU_TEMP

--- a/htop.1.in
+++ b/htop.1.in
@@ -272,9 +272,13 @@ Sort by time (top compatibility key).
 "Follow" process: if the sort order causes the currently selected process
 to move in the list, make the selection bar follow it. This is useful for
 monitoring a process: this way, you can keep a process always visible on
-screen. When a movement key is used, "follow" loses effect.
+screen. The behavior of the movement keys depends on the sticky follow setting.
 You can press Shift or Alt plus the Up and Down cursor keys to pan the view
 when following a process.
+When the sticky follow setting is enabled (the default), follow mode remains
+active until Shift+F is pressed again. If sticky follow is disabled, pressing
+movement keys like Up, Down, PgUp, and PgDown will end follow mode immediately,
+while Shift+Up and Shift+Down still pan without disabling follow.
 .TP
 .B K
 Hide kernel threads: prevent the threads belonging the kernel to be


### PR DESCRIPTION
This PR is two parts:

- The first commit restores the old scroll/pan behavior even while in Follow mode
- The second commit introduces a setting to toggle between a sticky follow (only exit follow mode with <kbd>Shift</kbd>+<kbd>F</kbd>) and the old behavior (exit follow mode also when moving the cursor up/down).

When merging, either merge just the first commit OR merge both commits.