### PR TITLE
linux: add M_PFT column (proportional memory footprint)

### DIFF
--- a/htop.1.in
+++ b/htop.1.in
@@ -483,6 +483,11 @@ number of processes sharing it.
 The proportional swap share of this mapping, unlike M_SWAP this does not take
 into account swapped out page of underlying shmem objects.
 .TP
+.B M_EPSS (EPSS)
+The effective proportional set size of the process - the proportional set size
+plus the proportional swap share. Like M_PSSWP, the swap part does not take
+into account swapped out pages of underlying shmem objects.
+.TP
 .B ST_UID (UID)
 The user ID of the process owner.
 .TP

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -100,6 +100,7 @@ const ProcessFieldData Process_fields[LAST_PROCESSFIELD] = {
    [M_PSS] = { .name = "M_PSS", .title = "  PSS ", .description = "proportional set size, same as M_RESIDENT but each page is divided by the number of processes sharing it", .flags = PROCESS_FLAG_LINUX_SMAPS, .defaultSortDesc = true, },
    [M_SWAP] = { .name = "M_SWAP", .title = " SWAP ", .description = "Size of the process's swapped pages", .flags = PROCESS_FLAG_LINUX_SMAPS, .defaultSortDesc = true, },
    [M_PSSWP] = { .name = "M_PSSWP", .title = " PSSWP ", .description = "shows proportional swap share of this mapping, unlike \"Swap\", this does not take into account swapped out page of underlying shmem objects", .flags = PROCESS_FLAG_LINUX_SMAPS, .defaultSortDesc = true, },
+   [M_EPSS] = { .name = "M_EPSS", .title = " EPSS ", .description = "effective proportional set size - sum of PSS and SwapPss, showing proportional total memory usage (swap part ignores swapped out shmem)", .flags = PROCESS_FLAG_LINUX_SMAPS, .defaultSortDesc = true, },
    [CTXT] = { .name = "CTXT", .title = " CTXT ", .description = "Context switches (incremental sum of voluntary_ctxt_switches and nonvoluntary_ctxt_switches)", .flags = PROCESS_FLAG_LINUX_CTXT, .defaultSortDesc = true, },
    [SECATTR] = { .name = "SECATTR", .title = "Security Attribute", .description = "Security attribute of the process (e.g. SELinux or AppArmor)", .flags = PROCESS_FLAG_LINUX_SECATTR, .autoWidth = true, },
    [PROC_COMM] = { .name = "COMM", .title = "COMM            ", .description = "comm string of the process from /proc/[pid]/comm", .flags = 0, },
@@ -264,6 +265,7 @@ static void LinuxProcess_rowWriteField(const Row* super, RichString* str, Proces
    case M_PSS: Row_printKBytes(str, lp->m_pss, coloring); return;
    case M_SWAP: Row_printKBytes(str, lp->m_swap, coloring); return;
    case M_PSSWP: Row_printKBytes(str, lp->m_psswp, coloring); return;
+   case M_EPSS: Row_printKBytes(str, lp->m_epss, coloring); return;
    case UTIME: Row_printTime(str, lp->utime, coloring); return;
    case STIME: Row_printTime(str, lp->stime, coloring); return;
    case CUTIME: Row_printTime(str, lp->cutime, coloring); return;
@@ -399,6 +401,8 @@ static int LinuxProcess_compareByKey(const Process* v1, const Process* v2, Proce
       return SPACESHIP_NUMBER(p1->m_swap, p2->m_swap);
    case M_PSSWP:
       return SPACESHIP_NUMBER(p1->m_psswp, p2->m_psswp);
+   case M_EPSS:
+      return SPACESHIP_NUMBER(p1->m_epss, p2->m_epss);
    case UTIME:
       return SPACESHIP_NUMBER(p1->utime, p2->utime);
    case CUTIME:

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -46,6 +46,7 @@ typedef struct LinuxProcess_ {
    long m_pss;
    long m_swap;
    long m_psswp;
+   long m_epss;
    long m_trs;
    long m_drs;
    long m_lrs;

--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -904,6 +904,7 @@ static bool LinuxProcessTable_readSmapsFile(LinuxProcess* process, openat_arg_t 
    process->m_pss   = 0;
    process->m_swap  = 0;
    process->m_psswp = 0;
+   process->m_epss  = 0;
 
    char buffer[256];
    while (fgets(buffer, sizeof(buffer), fp)) {
@@ -924,6 +925,8 @@ static bool LinuxProcessTable_readSmapsFile(LinuxProcess* process, openat_arg_t 
          process->m_psswp += strtol(buffer + 8, NULL, 10);
       }
    }
+
+   process->m_epss = process->m_pss + process->m_psswp;
 
    fclose(fp);
    return true;
@@ -1846,6 +1849,7 @@ static bool LinuxProcessTable_recurseProcTree(LinuxProcessTable* this, openat_ar
             lp->m_pss   = mainTask->m_pss;
             lp->m_swap  = mainTask->m_swap;
             lp->m_psswp = mainTask->m_psswp;
+            lp->m_epss  = mainTask->m_epss;
          }
       }
 

--- a/linux/ProcessField.h
+++ b/linux/ProcessField.h
@@ -51,6 +51,7 @@ in the source distribution for its full text.
    GPU_TIME = 132,               \
    GPU_PERCENT = 133,            \
    ISCONTAINER = 134,            \
+   M_EPSS = 135,                 \
    // End of list
 
 


### PR DESCRIPTION
Ref #1992

Adds a new M_PFT (Proportional memory FooTprint) column that shows the sum of PSS + SwapPss as a single sortable value.

This gives a proportional view of total memory usage per process - shared pages in both RAM and swap are divided by the number of processes using them, rather than counted fully in each.

Naming is open for discussion - happy to rename if there's a better fit.