### PR TITLE
freebsd: unifying buffer/cache memory usage for both ufs and zfs

### DIFF
--- a/freebsd/FreeBSDMachine.c
+++ b/freebsd/FreeBSDMachine.c
@@ -306,6 +306,7 @@ static void FreeBSDMachine_scanMemoryInfo(Machine* super) {
    FreeBSDMachine* this = (FreeBSDMachine*) super;
 
    // comment by Pierre-Marie Baty <pm@pmbaty.com>
+   // reviewed and expanded by Bruno Croci <bruno@croci.me>
    //
    // FreeBSD has the following memory classes:
    //    active:   userland pages currently mapped to physical memory (i.e. in use)
@@ -314,15 +315,10 @@ static void FreeBSDMachine_scanMemoryInfo(Machine* super) {
    //    wired:    kernel pages currently mapped to physical memory, cannot be paged out nor swapped
    //       buffers: subcategory of 'wired' corresponding to the filesystem caches
    //    free:     pages that haven't been allocated yet, or have been released
-   //
-   // With ZFS, the ARC area is NOT counted in the 'buffers' class, but is still counted in the 'wired'
-   // class. The ARC total must thus be subtracted from the 'wired' class AND added to the 'buffer' class,
-   // so that the result (ARC being shown in buffersMem) is consistent with what ZFS users would expect.
-   // This adjustment is done in Platform_setMemoryValues() in freebsd/Platform.c.
 
    u_long totalMem;
    u_int memActive, memWire, memInactive, memLaundry;
-   long buffersMem;
+   long cacheMem;
    size_t len;
 
    // total memory
@@ -360,13 +356,22 @@ static void FreeBSDMachine_scanMemoryInfo(Machine* super) {
    else
       this->laundryMem = 0;
 
-   // "buffers" pages (separate read, should be deducted from 'wired')
-   len = sizeof(buffersMem);
-   if ((sysctl(MIB_vfs_bufspace, 2, &(buffersMem), &len, NULL, 0) == 0) && (buffersMem > 0))
-      this->buffersMem = buffersMem / 1024;
+   // "cache" (considers main vfs buffer and ARC caches, should be deducted from 'wired')
+   len = sizeof(cacheMem);
+   if ((sysctl(MIB_vfs_bufspace, 2, &(cacheMem), &len, NULL, 0) == 0) && (cacheMem > 0))
+      this->cacheMem = cacheMem / 1024;
    else
-      this->buffersMem = 0;
-   this->wiredMem -= this->buffersMem; // subtract (NB: "buffers" can't be larger than "wired")
+      this->cacheMem = 0;
+
+   if (this->zfs.enabled) {
+      // ZFS does not shrink below the value of zfs_arc_min.
+      unsigned long long int shrinkableSize = 0;
+      if (this->zfs.size > this->zfs.min)
+         shrinkableSize = this->zfs.size - this->zfs.min;
+      this->cacheMem += shrinkableSize;
+   }
+
+   this->wiredMem -= this->cacheMem > this->wiredMem ? this->wiredMem : this->cacheMem; // subtract (NB: "cache" can't be larger than "wired")
 
    // NOTE: it is wrong in FreeBSD to represent the "shared" memory as a memory class by itself.
    // The only page classes exposed by the kernel are "active", "inactive", "wired", "laundry" and "free".

--- a/freebsd/FreeBSDMachine.h
+++ b/freebsd/FreeBSDMachine.h
@@ -37,11 +37,10 @@ typedef struct FreeBSDMachine_ {
    int kernelFScale;
 
    memory_t wiredMem;
-   memory_t buffersMem;
    memory_t activeMem;
    memory_t laundryMem;
+   memory_t cacheMem;
    memory_t inactiveMem;
-   memory_t arcMem;
 
    ZfsArcStats zfs;
 

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -100,20 +100,18 @@ const unsigned int Platform_numberOfSignals = ARRAYSIZE(Platform_signals);
 
 enum {
    MEMORY_CLASS_WIRED = 0,
-   MEMORY_CLASS_BUFFERS,
    MEMORY_CLASS_ACTIVE,
    MEMORY_CLASS_LAUNDRY,
+   MEMORY_CLASS_CACHE,
    MEMORY_CLASS_INACTIVE,
-   MEMORY_CLASS_ARC,
 }; // N.B. the chart will display categories in this order
 
 const MemoryClass Platform_memoryClasses[] = {
    [MEMORY_CLASS_WIRED] = { .label = "wired", .countsAsUsed = true, .countsAsCache = false, .color = MEMORY_1 },
-   [MEMORY_CLASS_BUFFERS] = { .label = "buffers", .countsAsUsed = true, .countsAsCache = false, .color = MEMORY_2 },
-   [MEMORY_CLASS_ACTIVE] = { .label = "active", .countsAsUsed = true, .countsAsCache = false, .color = MEMORY_3 },
-   [MEMORY_CLASS_LAUNDRY] = { .label = "laundry", .countsAsUsed = true, .countsAsCache = false, .color = MEMORY_4 },
+   [MEMORY_CLASS_ACTIVE] = { .label = "active", .countsAsUsed = true, .countsAsCache = false, .color = MEMORY_2 },
+   [MEMORY_CLASS_LAUNDRY] = { .label = "laundry", .countsAsUsed = true, .countsAsCache = false, .color = MEMORY_3 },
+   [MEMORY_CLASS_CACHE] = { .label = "cache", .countsAsUsed = false, .countsAsCache = true, .color = MEMORY_4 },
    [MEMORY_CLASS_INACTIVE] = { .label = "inactive", .countsAsUsed = false, .countsAsCache = true, .color = MEMORY_5 },
-   [MEMORY_CLASS_ARC] = { .label = "ARC", .countsAsUsed = false, .countsAsCache = true, .color = MEMORY_6 },
 };
 
 const unsigned int Platform_numberOfMemoryClasses = ARRAYSIZE(Platform_memoryClasses);
@@ -251,24 +249,14 @@ void Platform_setMemoryValues(Meter* this) {
    this->total = host->totalMem;
    if (host->settings->showCachedMemory) {
       this->values[MEMORY_CLASS_WIRED]    = fhost->wiredMem;
-      this->values[MEMORY_CLASS_BUFFERS]  = fhost->buffersMem;
-   } else { // if showCachedMemory is disabled, merge buffers into the wired pages
-      this->values[MEMORY_CLASS_WIRED]    = fhost->wiredMem + fhost->buffersMem;
-      this->values[MEMORY_CLASS_BUFFERS]  = 0;
+      this->values[MEMORY_CLASS_CACHE]    = fhost->cacheMem;
+   } else { // if showCachedMemory is disabled, merge cache into the wired pages
+      this->values[MEMORY_CLASS_WIRED]    = fhost->wiredMem + fhost->cacheMem;
+      this->values[MEMORY_CLASS_CACHE]    = 0;
    }
    this->values[MEMORY_CLASS_ACTIVE]   = fhost->activeMem;
    this->values[MEMORY_CLASS_LAUNDRY]  = fhost->laundryMem;
    this->values[MEMORY_CLASS_INACTIVE] = fhost->inactiveMem;
-
-   if (fhost->zfs.enabled) {
-      // ZFS does not shrink below the value of zfs_arc_min.
-      unsigned long long int shrinkableSize = 0;
-      if (fhost->zfs.size > fhost->zfs.min)
-         shrinkableSize = fhost->zfs.size - fhost->zfs.min;
-      this->values[MEMORY_CLASS_ARC] = shrinkableSize;
-   } else {
-      this->values[MEMORY_CLASS_ARC] = 0;
-   }
 }
 
 void Platform_setSwapValues(Meter* this) {


### PR DESCRIPTION
Hi everyone! :)

This is more of a suggestion on how to improve readability of FreeBSD memory monitoring. Here I'm basically unifying `MEMORY_CLASS_BUFFER` and `MEMORY_CLASS_ARC` into `MEMORY_CLASS_CACHE`. This is because of a few reasons:

 1. `MEMORY_CLASS_BUFFER` is checking for `vfs.bufspace`, which reports the metadata buffer cache for **UFS** specifically. On **ZFS** only, it's always zero, because ARC bypasses the vfs system.
 2. `MEMORY_CLASS_ARC` is not being subtracted from `wired` memory (although being part of it), and is being counted as used memory, although `MEMORY_CLASS_BUFFER` is not. And the behavior of disk cache on Linux is to not being counted as used.

With the new `MEMORY_CLASS_CACHE`, it will always report the current buffer/cache for the current filesystems. It's easier to understand and more accurate not considering ARC cache as used memory.

EDIT: I did not consider, at first, that both UFS and ZFS could be active in the system, but it's not true. So I changed to effectively sum those two values.

Thanks.