### PR TITLE
trace: show error message when fork fails in TraceScreen

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -674,10 +674,8 @@ static Htop_Reaction actionStrace(State* st) {
    assert(Object_isA((const Object*) p, (const ObjectClass*) &Process_class));
 
    TraceScreen* ts = TraceScreen_new(p);
-   bool ok = TraceScreen_forkTracer(ts);
-   if (ok) {
-      InfoScreen_run((InfoScreen*)ts);
-   }
+   TraceScreen_forkTracer(ts);
+   InfoScreen_run((InfoScreen*)ts);
    TraceScreen_delete((Object*)ts);
    clear();
    CRT_enableDelay();

--- a/TraceScreen.c
+++ b/TraceScreen.c
@@ -60,6 +60,16 @@ void TraceScreen_delete(Object* cast) {
    free(InfoScreen_done((InfoScreen*)this));
 }
 
+static void TraceScreen_scan(InfoScreen* super) {
+   TraceScreen* this = (TraceScreen*) super;
+   if (!this->strace_alive) {
+      char* err = NULL;
+      xAsprintf(&err, "%s", strerror(errno));
+      InfoScreen_addLine(super, err);
+      free(err);
+   }
+}
+
 static void TraceScreen_draw(InfoScreen* this) {
    InfoScreen_drawTitled(this, "Trace of process %d - %s", Process_getPid(this->process), Process_getCommand(this->process));
 }
@@ -209,6 +219,7 @@ const InfoScreenClass TraceScreen_class = {
       .extends = Class(Object),
       .delete = TraceScreen_delete
    },
+   .scan = TraceScreen_scan,
    .draw = TraceScreen_draw,
    .onErr = TraceScreen_updateTrace,
    .onKey = TraceScreen_onKey,

--- a/TraceScreen.c
+++ b/TraceScreen.c
@@ -135,10 +135,13 @@ bool TraceScreen_forkTracer(TraceScreen* this) {
 
    return true;
 
-err:
+err: {
+   int saved_errno = errno;
    close(fdpair[1]);
    close(fdpair[0]);
+   errno = saved_errno;
    return false;
+}
 }
 
 static void TraceScreen_updateTrace(InfoScreen* super) {


### PR DESCRIPTION
## Summary
- Show a user-visible error message (e.g. "Out of memory", "Resource temporarily unavailable") in the TraceScreen when `fork()` fails, instead of silently doing nothing
- The error message is the OS error string from `strerror(errno)`

## Changes
| File | Change |
|------|--------|
| `TraceScreen.c` | Add `TraceScreen_scan()` to display the system error when fork fails; register it in the `InfoScreenClass` struct |
| `Action.c` | Remove conditional `if (ok)` — `InfoScreen_run()` is always called so the TraceScreen appears even when fork fails |

## Test Plan
- Press `s` on a process when fork is likely to fail (e.g. PID quota exceeded, or use `ulimit -u` to restrict processes)
- Observe that the TraceScreen appears with a one-line error message instead of nothing

Fixes #1991
