### PR TITLE
systemd: fix SystemdMeter parsing when falling back to systemctl show

### DIFF
--- a/linux/SystemdMeter.c
+++ b/linux/SystemdMeter.c
@@ -277,19 +277,19 @@ static void updateViaExec(bool user) {
          free_and_xStrdup(&ctx->systemState, lineBuffer + strlen("SystemState="));
       } else if (String_startsWith(lineBuffer, "NFailedUnits=")) {
          unsigned long value = strtoul(lineBuffer + strlen("NFailedUnits="), &endptr, 10);
-         if (value <= UINT_MAX && *endptr == '\0')
+         if (value <= UINT_MAX && (*endptr == '\n' || *endptr == '\0'))
             ctx->nFailedUnits = (unsigned int) value;
       } else if (String_startsWith(lineBuffer, "NNames=")) {
          unsigned long value = strtoul(lineBuffer + strlen("NNames="), &endptr, 10);
-         if (value <= UINT_MAX && *endptr == '\0')
+         if (value <= UINT_MAX && (*endptr == '\n' || *endptr == '\0'))
             ctx->nNames = (unsigned int) value;
       } else if (String_startsWith(lineBuffer, "NJobs=")) {
          unsigned long value = strtoul(lineBuffer + strlen("NJobs="), &endptr, 10);
-         if (value <= UINT_MAX && *endptr == '\0')
+         if (value <= UINT_MAX && (*endptr == '\n' || *endptr == '\0'))
             ctx->nJobs = (unsigned int) value;
       } else if (String_startsWith(lineBuffer, "NInstalledJobs=")) {
          unsigned long value = strtoul(lineBuffer + strlen("NInstalledJobs="), &endptr, 10);
-         if (value <= UINT_MAX && *endptr == '\0')
+         if (value <= UINT_MAX && (*endptr == '\n' || *endptr == '\0'))
             ctx->nInstalledJobs = (unsigned int) value;
       }
    }


### PR DESCRIPTION
## Summary
- Fix SystemdMeter displaying `(?/? failed) (?/? jobs)` when htop falls back to `systemctl show` for parsing systemd state

## Root Cause
`fgets()` preserves trailing newlines in the buffer, so `strtoul()` leaves `endptr` pointing to `'\n'` instead of `'\0'`. The validation check `*endptr == '\0'` fails, causing all numeric fields to remain at `INVALID_VALUE`.

This only affects the `systemctl show` fallback path (used when `sd_bus_open_user` fails, e.g. under file capabilities). The `sd_bus` path is unaffected.

Note: `SystemState=` was already handled correctly — it explicitly strips the newline with `strchr(lineBuffer, '\n')`.

## Changes
| File | Change |
|------|--------|
| `linux/SystemdMeter.c` | Accept `'\n'` as valid end-of-value terminator in addition to `'\0'` (4 occurrences) |

## Test Plan
- [x] Build passes with `--enable-werror`
- [ ] Verify on a system where `sd_bus_open_user` fails (e.g. Gentoo with filecaps), or test by temporarily forcing `updateViaExec` path

Fixes #1982
