### PR TITLE
Store htop_history in XDG state directory

### DIFF
--- a/CommandLine.c
+++ b/CommandLine.c
@@ -472,19 +472,8 @@ int CommandLine_run(int argc, char** argv) {
    if (flags.commFilter)
       setCommFilter(&state, &(flags.commFilter));
 
-   /* Set up shared search/filter history, stored next to the config file */
-   const char* rcPath = settings->filename;
-   const char* lastSlash = strrchr(rcPath, '/');
-   char historyPath[PATH_MAX];
-   if (lastSlash) {
-      int dirLen = (int)(lastSlash - rcPath + 1);
-      xSnprintf(historyPath, sizeof(historyPath), "%.*s" "htop_history", dirLen, rcPath);
-   } else {
-   /* no history file saved unless we have a sane rcPath */
-      historyPath[0] = '\0';
-   }
-
-   IncSet_setHistoryFile(panel->inc, historyPath);
+   /* Set up shared search/filter history in XDG state directory */
+   IncSet_setHistoryFile(panel->inc, settings->historyFilename);
 
    ScreenManager* scr = ScreenManager_new(header, host, &state, true);
    ScreenManager_add(scr, (Panel*) panel, -1);

--- a/Settings.c
+++ b/Settings.c
@@ -51,6 +51,7 @@ static void Settings_deleteScreens(Settings* this) {
 void Settings_delete(Settings* this) {
    free(this->filename);
    free(this->initialFilename);
+   free(this->historyFilename);
    Settings_deleteColumns(this);
    Settings_deleteScreens(this);
    free(this);
@@ -871,8 +872,34 @@ Settings* Settings_new(const Machine* host, Hashtable* dynamicMeters, Hashtable*
       }
       (void) mkdir(configDir, 0700);
       (void) mkdir(htopDir, 0700);
-      free(htopDir);
       free(configDir);
+
+      /* Compute XDG state dir for the history file */
+      const char* xdgStateHome = getenv("XDG_STATE_HOME");
+      char* htopStateDir;
+      if (xdgStateHome && xdgStateHome[0] == '/') {
+         (void) mkdir(xdgStateHome, 0700);
+         htopStateDir = String_cat(xdgStateHome, "/htop");
+      } else {
+         char* localDir = String_cat(home, "/.local");
+         (void) mkdir(localDir, 0700);
+         free(localDir);
+         char* stateDir = String_cat(home, "/.local/state");
+         (void) mkdir(stateDir, 0700);
+         free(stateDir);
+         htopStateDir = String_cat(home, "/.local/state/htop");
+      }
+      (void) mkdir(htopStateDir, 0700);
+      this->historyFilename = String_cat(htopStateDir, "/htop_history");
+      free(htopStateDir);
+
+      /* One-time migration: move history from config dir to state dir */
+      char* oldHistory = String_cat(htopDir, "/htop_history");
+      struct stat st;
+      if (stat(this->historyFilename, &st) != 0 && stat(oldHistory, &st) == 0)
+         rename(oldHistory, this->historyFilename);
+      free(oldHistory);
+      free(htopDir);
 
       legacyDotfile = String_cat(home, "/.htoprc");
    }

--- a/Settings.h
+++ b/Settings.h
@@ -58,6 +58,7 @@ typedef struct ScreenSettings_ {
 typedef struct Settings_ {
    char* filename;
    char* initialFilename;
+   char* historyFilename;
    bool writeConfig; /* whether to write the current settings on exit */
    int config_version;
    HeaderLayout hLayout;


### PR DESCRIPTION
fixes: #1944

The history file is runtime state, not configuration, so it belongs in $XDG_STATE_HOME/htop/htop_history (defaulting to ~/.local/state/htop/htop_history) rather than alongside htoprc. A one-time rename migration moves an existing history file from the config dir to the new state dir on first run.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>