### PR TITLE
CPUMeter: avoid crash when CPU count increases

### DIFF
--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -234,7 +234,8 @@ static void CPUMeter_display(const Object* cast, RichString* out) {
 }
 
 static void AllCPUsMeter_getRange(const Meter* this, int* start, int* count) {
-   unsigned int cpus = this->host->existingCPUs;
+   const CPUMeterData* data = this->meterData;
+   unsigned int cpus = data ? data->cpus : this->host->existingCPUs;
    switch (Meter_name(this)[0]) {
       default:
       case 'A': // All


### PR DESCRIPTION
Fix a crash in CPU meters when the number of available CPUs increases.

AllCPUsMeter_getRange() used the current host CPU count, while the meter array was allocated based on the CPU count at initialization. After CPU hotplug, the updated count could cause accesses beyond the allocated array.

Uses the CPU count stored in CPUMeterData after initialization to keep  the range consistent with the allocated meter array. During initial setup, when meterData is not yet available,  it uses the current host CPU count.

Fixes #2024

Tested in a Fedora 44 QEMU VM:
- Started with 2 vCPUs and maxcpus=4.
- Reproduced the crash on current main after hot-adding and bringing a CPU online.
- Applied the fix.
- Hot-added and brought two additional CPUs online.
- Verified that htop remained running with 4 online CPUs.