### PR TITLE
linux: fix reading zram values

### DIFF
--- a/linux/LinuxMachine.c
+++ b/linux/LinuxMachine.c
@@ -292,7 +292,7 @@ static bool LinuxMachine_isZramBlockName(const char* name) {
 
 static void LinuxMachine_scanZramDevice(openat_arg_t blockDirFd, const char* name, memory_t* totalZram, memory_t* usedZramComp, memory_t* usedZramOrig) {
 #ifdef HAVE_OPENAT
-   int zramDirFd = Compat_openat(blockDirFd, name, O_DIRECTORY | O_PATH | O_NOFOLLOW);
+   int zramDirFd = Compat_openat(blockDirFd, name, O_DIRECTORY | O_PATH);
    if (zramDirFd < 0)
       return;
 #else


### PR DESCRIPTION
This is a follow-up on an earlier commit 'linux: avoid repeated zram ENOENT probes'.
Actually `/sys/block/zramN` are symlinks, so setting O_NOFOLLOW breaks this. Let's drop the option.

Fixes: 9fe974b823207e0f19a7bc4ae9cc31eba6e6cd47