### PR TITLE
Scheduling: OR in SCHED_RESET_ON_FORK instead of ANDing it

### DIFF
--- a/Scheduling.c
+++ b/Scheduling.c
@@ -111,7 +111,7 @@ static bool Scheduling_setPolicy(Process* p, Arg arg) {
 
    #ifdef SCHED_RESET_ON_FORK
    if (reset_on_fork)
-      policy &= SCHED_RESET_ON_FORK;
+      policy |= SCHED_RESET_ON_FORK;
    #endif
 
    int r = sched_setscheduler(Process_getPid(p), policy, &param);


### PR DESCRIPTION
### Description

`Scheduling_setPolicy()` sets the reset-on-fork flag with `&=` instead of `|=`:

```c
#ifdef SCHED_RESET_ON_FORK
if (reset_on_fork)
   policy &= SCHED_RESET_ON_FORK;   // should be |=
#endif
```

`SCHED_RESET_ON_FORK` is `0x40000000`, and the scheduling policies (`SCHED_OTHER=0`, `FIFO=1`, `RR=2`, `BATCH=3`, `IDLE=5`) share no bits with it, so `policy &= 0x40000000` is always `0` (`SCHED_OTHER`) — the chosen policy **and** the flag are both lost.

So when a user enables "Reset on fork" and selects a real-time policy (FIFO/RR/BATCH/IDLE), the subsequent `sched_setscheduler(pid, SCHED_OTHER, {sched_priority > 0})` fails with **EINVAL** (a nonzero priority is invalid for `SCHED_OTHER`) and the action silently fails; with priority 0 the process is silently downgraded to `SCHED_OTHER`. Either way, neither the requested policy nor reset-on-fork is applied.

### Fix

Use `|=` so the flag is OR-ed onto the chosen policy — matching the sibling `Scheduling_formatPolicy()`, which strips it back out with `policy & ~SCHED_RESET_ON_FORK`, confirming it's meant to be combined.

### Verification

The block is Linux-only (`#ifdef SCHED_RESET_ON_FORK` inside `SCHEDULER_SUPPORT`), so I confirmed the bitwise logic with a small harness rather than the live UI: for every policy, the current `&=` yields `0x00000000` (policy lost) while `|=` yields the correct `0x40000000 | policy` (e.g. FIFO → `0x40000001`). htop builds cleanly before/after. A repo-wide grep confirms this is the only `&=` used to *set* (rather than clear) a flag.

*This fix was prepared with AI assistance (noted via the `Assisted-by:` commit trailer, per the project's policy); I reviewed the change and verified the logic and the reproduction myself.*
