### PR TITLE
exit follow mode when search or filter is cancelled

### DIFF
--- a/MainPanel.c
+++ b/MainPanel.c
@@ -121,6 +121,8 @@ static HandlerResult MainPanel_eventHandler(Panel* super, int ch) {
          reaction |= HTOP_KEEP_FOLLOWING;
          if (confirmedSearch)
             reaction |= HTOP_REFRESH;
+      } else {
+         host->activeTable->following = -1;
       }
       result = HANDLED;
    } else if (ch == 27) {


### PR DESCRIPTION
condition change in bbec22d7592ea6cf26dfd615be649855a4e0f22b caused panel state during search to persist after the search was cancelled (e.g. escape key). previous behaviour relied on the absence of the `HTOP_KEEP_FOLLOWING` reaction to stop following, which is no longer the case.

explicitly setting `host->activeTable->following` to `-1` now, has the same effect as not setting `HTOP_KEEP_FOLLOWING` did before bbec22d7592ea6cf26dfd615be649855a4e0f22b.