### PR TITLE
Fix SIGABRT crash when CGROUP column encounters long cgroup paths (#1913)

### DIFF
--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -230,9 +230,9 @@ static void LinuxProcess_rowWriteField(const Row* super, RichString* str, Proces
    const LinuxMachine* lhost = (const LinuxMachine*) super->host;
 
    bool coloring = host->settings->highlightMegabytes;
-   char buffer[256]; buffer[255] = '\0';
+   char buffer[UINT8_MAX + sizeof(" ")]; buffer[sizeof(buffer) - 1] = '\0';
    int attr = CRT_colors[DEFAULT_COLOR];
-   size_t n = sizeof(buffer) - 1;
+   size_t n = sizeof(buffer);
 
    switch (field) {
    case CMINFLT: Row_printCount(str, lp->cminflt, coloring); return;


### PR DESCRIPTION
Fixes the SIGABRT from #1913.

## Root cause

When a cgroup path reaches >= 254 characters, `Row_fieldWidths` saturates at `UINT8_MAX` (255). The CGROUP/CCGROUP/CONTAINER cases in `LinuxProcess_rowWriteField` then format `width + 1` bytes (256) via `xSnprintf` into a row buffer bound by `n = sizeof(buffer) - 1 = 255`, so `xSnprintf` truncates, calls `fail()`, and aborts (SIGABRT).

The row buffer (`sizeof(buffer) - 1`) and the header's `titleBuffer` (`UINT8_MAX + sizeof(" ")`, `Row.c`) also had inconsistent capacities, so at the maximum stored width the column could not hold the field plus the trailing separator the header rendered — a header/column mismatch.

## Fix

Give the row buffer the same capacity as the header, `UINT8_MAX + sizeof(" ")` (257 bytes: 255 field + separator + NUL), and use the full `sizeof(buffer)` as the `xSnprintf` bound (it already NUL-terminates). With `n == 257` and `Row_fieldWidths` being `uint8_t` (<= 255), the format produces at most 256 characters, which is `< n`, so `xSnprintf` never truncates and the trailing separator is preserved at every width. No width clamp is needed — the `uint8_t` type already bounds the width below `n - 1`.

## Verification

Per @ravi-arnan's review: the crash reproduces on `main` (a 262-char delegated cgroup path aborts unpatched htop with exit 134); with the resize htop runs with the column truncated. The two halves of the earlier patch were alternative fixes, not complementary — after the resize the `CLAMP` hunks were no-ops (`Row_fieldWidths` is `uint8_t` <= 255, `n == 257`, so clamping to `n - 2 == 255` is the type's own guarantee), so they have been dropped along with the `Row.c` hunk. The buffer resize alone is the fix, and it keeps the row buffer's capacity visibly in sync with `titleBuffer`. Build is clean with no new warnings (`-Wall -Wextra -Wformat=2 -Wshadow`); rebased onto current `main`.

Fixes #1913.