### PR TITLE
darwin: fix blank STARTTIME and wrong ELAPSED for threads

### DIFF
--- a/darwin/DarwinProcess.c
+++ b/darwin/DarwinProcess.c
@@ -478,6 +478,11 @@ void DarwinProcess_scanThreads(DarwinProcess* dp, DarwinProcessTable* dpt) {
       tprocess->st_uid           = proc->st_uid;
       tprocess->user             = proc->user;
 
+      if (tprocess->starttime_ctime == 0) {
+         tprocess->starttime_ctime = proc->starttime_ctime;
+         Process_fillStarttimeBuffer(tprocess);
+      }
+
 #ifdef HAVE_THREAD_EXTENDED_INFO_DATA_T
       thread_extended_info_data_t extended_info;
       mach_msg_type_number_t extended_info_count = THREAD_EXTENDED_INFO_COUNT;


### PR DESCRIPTION
DarwinProcess_scanThreads() never set starttime_ctime for thread entries, leaving it at zero from xCalloc. This caused STARTTIME to display blank (Process_fillStarttimeBuffer was never called) and ELAPSED to show ~56 years (time since the Unix epoch).

The Mach thread_info() API does not provide a thread creation timestamp, so inherit the parent process start time instead.

Closes: #2052