### PR TITLE
XUtils: use strchr instead strstr

### DIFF
--- a/XUtils.c
+++ b/XUtils.c
@@ -108,7 +108,7 @@ void* xReallocArrayZero(void* ptr, size_t prevmemb, size_t newmemb, size_t size)
 
 inline bool String_contains_i(const char* s1, const char* s2, bool multi) {
    // we have a multi-string search term, handle as special case for performance reasons
-   if (multi && strstr(s2, "|")) {
+   if (multi && strchr(s2, '|')) {
       size_t nNeedles;
       char** needles = String_split(s2, '|', &nNeedles);
       for (size_t i = 0; i < nNeedles; i++) {


### PR DESCRIPTION
Very minor optimize use more logic function strchr()

<img width="1399" height="544" alt="screen" src="https://github.com/user-attachments/assets/f3099e12-cf4c-4b11-a483-cf2d9232c80b" />

<img width="1410" height="548" alt="screen2" src="https://github.com/user-attachments/assets/4fb526dc-f002-4139-b8cf-2567956b1126" />
