### PR TITLE
htop: fix possible integer overflow in format strings

### DIFF
--- a/AffinityPanel.c
+++ b/AffinityPanel.c
@@ -409,7 +409,7 @@ Panel* AffinityPanel_new(Machine* host, const Affinity* affinity, int* width) {
          continue;
 
       char number[16];
-      xSnprintf(number, 9, "CPU %d", Settings_cpuId(host->settings, i));
+      xSnprintf(number, 9, "CPU %u", Settings_cpuId(host->settings, i));
       unsigned int cpu_width = 4 + (unsigned int)strlen(number);
       if (cpu_width > this->width) {
          this->width = cpu_width;

--- a/AvailableMetersPanel.c
+++ b/AvailableMetersPanel.c
@@ -105,7 +105,7 @@ static void AvailableMetersPanel_addCPUMeters(Panel* super, const MeterClass* ty
       Panel_add(super, (Object*) ListItem_new("CPU average", 0));
       for (unsigned int i = 1; i <= host->existingCPUs; i++) {
          char buffer[50];
-         xSnprintf(buffer, sizeof(buffer), "%s %d", type->uiName, Settings_cpuId(host->settings, i - 1));
+         xSnprintf(buffer, sizeof(buffer), "%s %u", type->uiName, Settings_cpuId(host->settings, i - 1));
          Panel_add(super, (Object*) ListItem_new(buffer, i));
       }
    } else {

--- a/FileDescriptorMeter.c
+++ b/FileDescriptorMeter.c
@@ -71,9 +71,9 @@ static void FileDescriptorMeter_updateValues(Meter* this) {
    if (!isNonnegative(this->values[0])) {
       xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "unknown/unknown");
    } else if (FD_EFFECTIVE_UNLIMITED(this->values[1])) {
-      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%.0lf/unlimited", this->values[0]);
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%.0f/unlimited", this->values[0]);
    } else {
-      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%.0lf/%.0lf", this->values[0], this->values[1]);
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%.0f/%.0f", this->values[0], this->values[1]);
    }
 }
 
@@ -88,14 +88,14 @@ static void FileDescriptorMeter_display(const Object* cast, RichString* out) {
    }
 
    RichString_appendAscii(out, CRT_colors[METER_TEXT], "used: ");
-   len = xSnprintf(buffer, sizeof(buffer), "%.0lf", this->values[0]);
+   len = xSnprintf(buffer, sizeof(buffer), "%.0f", this->values[0]);
    RichString_appendnAscii(out, CRT_colors[FILE_DESCRIPTOR_USED], buffer, len);
 
    RichString_appendAscii(out, CRT_colors[METER_TEXT], " max: ");
    if (FD_EFFECTIVE_UNLIMITED(this->values[1])) {
       RichString_appendAscii(out, CRT_colors[FILE_DESCRIPTOR_MAX], "unlimited");
    } else {
-      len = xSnprintf(buffer, sizeof(buffer), "%.0lf", this->values[1]);
+      len = xSnprintf(buffer, sizeof(buffer), "%.0f", this->values[1]);
       RichString_appendnAscii(out, CRT_colors[FILE_DESCRIPTOR_MAX], buffer, len);
    }
 }

--- a/Process.c
+++ b/Process.c
@@ -773,7 +773,7 @@ void Process_writeField(const Process* this, RichString* str, RowField field) {
          break;
       }
       break;
-   case ST_UID: xSnprintf(buffer, n, "%*d ", Process_uidDigits, this->st_uid); break;
+   case ST_UID: xSnprintf(buffer, n, "%*u ", Process_uidDigits, this->st_uid); break;
    case TIME: Row_printTime(str, this->time, coloring); return;
    case TGID:
       if (Process_getThreadGroup(this) == Process_getPid(this))
@@ -802,7 +802,7 @@ void Process_writeField(const Process* this, RichString* str, RowField field) {
          return;
       }
 
-      xSnprintf(buffer, n, "%-10d ", this->st_uid);
+      xSnprintf(buffer, n, "%-10u ", this->st_uid);
       break;
    default:
       if (DynamicColumn_writeField(this, str, field))

--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -1432,13 +1432,13 @@ static char* LinuxProcessTable_updateTtyDevice(TtyDriver* ttyDrivers, unsigned l
 
       for (;;) {
          char* fullPath = NULL;
-         size_t fullPathLen = xAsprintf(&fullPath, "%s/%d", ttyDrivers[i].path, idx);
+         size_t fullPathLen = xAsprintf(&fullPath, "%s/%u", ttyDrivers[i].path, idx);
          int err = stat(fullPath, &sb);
          if (err == 0 && major(sb.st_rdev) == maj && minor(sb.st_rdev) == min) {
             return fullPath;
          }
 
-         xSnprintf(fullPath, fullPathLen + 1, "%s%d", ttyDrivers[i].path, idx);
+         xSnprintf(fullPath, fullPathLen + 1, "%s%u", ttyDrivers[i].path, idx);
          err = stat(fullPath, &sb);
          if (err == 0 && major(sb.st_rdev) == maj && minor(sb.st_rdev) == min) {
             return fullPath;

--- a/linux/PressureStallMeter.c
+++ b/linux/PressureStallMeter.c
@@ -51,7 +51,7 @@ static void PressureStallMeter_updateValues(Meter* this) {
    /* only print bar for ten (not sixty and three hundred), cause the sum is meaningless */
    this->curItems = 1;
 
-   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%s %s %5.2lf%% %5.2lf%% %5.2lf%%", some ? "some" : "full", file, this->values[0], this->values[1], this->values[2]);
+   xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%s %s %5.2f%% %5.2f%% %5.2f%%", some ? "some" : "full", file, this->values[0], this->values[1], this->values[2]);
 }
 
 static void PressureStallMeter_display(const Object* cast, RichString* out) {
@@ -59,11 +59,11 @@ static void PressureStallMeter_display(const Object* cast, RichString* out) {
    char buffer[20];
    int len;
 
-   len = xSnprintf(buffer, sizeof(buffer), "%5.2lf%% ", this->values[0]);
+   len = xSnprintf(buffer, sizeof(buffer), "%5.2f%% ", this->values[0]);
    RichString_appendnAscii(out, CRT_colors[PRESSURE_STALL_TEN], buffer, len);
-   len = xSnprintf(buffer, sizeof(buffer), "%5.2lf%% ", this->values[1]);
+   len = xSnprintf(buffer, sizeof(buffer), "%5.2f%% ", this->values[1]);
    RichString_appendnAscii(out, CRT_colors[PRESSURE_STALL_SIXTY], buffer, len);
-   len = xSnprintf(buffer, sizeof(buffer), "%5.2lf%% ", this->values[2]);
+   len = xSnprintf(buffer, sizeof(buffer), "%5.2f%% ", this->values[2]);
    RichString_appendnAscii(out, CRT_colors[PRESSURE_STALL_THREEHUNDRED], buffer, len);
 }
 


### PR DESCRIPTION
%lf usage is redundant