### PR TITLE
Const var make more optimized loops in -O3 GCC/Clang

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -138,7 +138,8 @@ bool Action_setUserOnly(const char* userName, uid_t* userId) {
 static void tagAllChildren(Panel* panel, Row* parent) {
    parent->tag = true;
    int parent_id = parent->id;
-   for (int i = 0; i < Panel_size(panel); i++) {
+   const int size =  Panel_size(panel);
+   for (int i = 0; i < size; i++) {
       Row* row = (Row*) Panel_get(panel, i);
       if (!row->tag && Row_isChildOf(row, parent_id)) {
          tagAllChildren(panel, row);
@@ -160,8 +161,9 @@ static bool collapseIntoParent(Panel* panel) {
    if (!r)
       return false;
 
-   int parent_id = Row_getGroupOrParent(r);
-   for (int i = 0; i < Panel_size(panel); i++) {
+   const int parent_id = Row_getGroupOrParent(r);
+   const int size =  Panel_size(panel);
+   for (int i = 0; i < size; i++) {
       Row* row = (Row*) Panel_get(panel, i);
       if (row->id == parent_id) {
          row->showChildren = false;
@@ -642,7 +644,8 @@ static Htop_Reaction actionBacktrace(State *st) {
 
    Vector* processes = Vector_new(Class(Process), false, VECTOR_DEFAULT_SIZE);
    if (selectedProcess && !Process_isUserlandThread(selectedProcess)) {
-      for (int i = 0; i < Vector_size(allProcesses); i++) {
+      const int size = Vector_size(allProcesses);
+      for (int i = 0; i < size; i++) {
          Process* process = (Process *)Vector_get(allProcesses, i);
          if (process && Process_getThreadGroup(process) == Process_getThreadGroup(selectedProcess)) {
             Vector_add(processes, process);
@@ -920,7 +923,8 @@ static Htop_Reaction actionHelp(State* st) {
 }
 
 static Htop_Reaction actionUntagAll(State* st) {
-   for (int i = 0; i < Panel_size((Panel*)st->mainPanel); i++) {
+   const int size = Panel_size((Panel*)st->mainPanel);
+   for (int i = 0; i < size; i++) {
       Row* row = (Row*) Panel_get((Panel*)st->mainPanel, i);
       row->tag = false;
    }

--- a/AffinityPanel.c
+++ b/AffinityPanel.c
@@ -168,7 +168,8 @@ static void AffinityPanel_updateTopo(AffinityPanel* this, MaskItem* item) {
    if (item->sub_tree == 2)
       return;
 
-   for (int i = 0; i < Vector_size(item->children); i++)
+   const int size = Vector_size(item->children);
+   for (int i = 0; i < size; i++)
       AffinityPanel_updateTopo(this, (MaskItem*) Vector_get(item->children, i));
 }
 
@@ -186,7 +187,8 @@ static void AffinityPanel_update(AffinityPanel* this, bool keepSelected) {
    if (this->topoView) {
       AffinityPanel_updateTopo(this, this->topoRoot);
    } else {
-      for (int i = 0; i < Vector_size(this->cpuids); i++) {
+      const int size = Vector_size(this->cpuids);
+      for (int i = 0; i < size; i++) {
          AffinityPanel_updateItem(this, (MaskItem*) Vector_get(this->cpuids, i));
       }
    }
@@ -451,7 +453,8 @@ Affinity* AffinityPanel_getAffinity(Panel* super, Machine* host) {
       Affinity_add(affinity, (unsigned)i);
    hwloc_bitmap_foreach_end();
    #else
-   for (int i = 0; i < Vector_size(this->cpuids); i++) {
+   const int size = Vector_size(this->cpuids);
+   for (int i = 0; i < size; i++) {
       const MaskItem* item = (const MaskItem*)Vector_get(this->cpuids, i);
       if (item->value) {
          Affinity_add(affinity, item->cpu);

--- a/BacktraceScreen.c
+++ b/BacktraceScreen.c
@@ -128,7 +128,8 @@ static void BacktracePanel_makePrintingHelper(const BacktracePanel* this, Backtr
 
    printingHelper->hasDemangledNames = false;
 
-   for (int i = 0; i < Vector_size(lines); i++) {
+   const int size = Vector_size(lines);
+   for (int i = 0; i < size; i++) {
       const BacktracePanelRow* row = (const BacktracePanelRow*)Vector_get(lines, i);
       if (row->type != BACKTRACE_PANEL_ROW_DATA_FRAME) {
          continue;
@@ -169,7 +170,8 @@ static void BacktracePanel_populateFrames(BacktracePanel* this) {
    char* error = NULL;
 
    Vector* data = Vector_new(Class(BacktraceFrameData), false, VECTOR_DEFAULT_SIZE);
-   for (int i = 0; i < Vector_size(this->processes); i++) {
+   const int size = Vector_size(this->processes);
+   for (int i = 0; i < size; i++) {
       const Process* process = (Process*)Vector_get(this->processes, i);
       BacktracePanel_makeBacktrace(data, Process_getPid(process), &error);
 

--- a/BacktraceScreen.c
+++ b/BacktraceScreen.c
@@ -181,7 +181,8 @@ static void BacktracePanel_populateFrames(BacktracePanel* this) {
       Panel_add((Panel*)this, (Object*)header);
 
       if (!error) {
-         for (int j = 0; j < Vector_size(data); j++) {
+         const int vsize = Vector_size(data);
+         for (int j = 0; j < vsize; j++) {
             BacktracePanelRow* row = BacktracePanelRow_new(this);
             row->process = process;
             row->type = BACKTRACE_PANEL_ROW_DATA_FRAME;

--- a/ColumnsPanel.c
+++ b/ColumnsPanel.c
@@ -36,7 +36,8 @@ static void ColumnsPanel_delete(Object* object) {
 
 static void ColumnsPanel_cancelMoving(ColumnsPanel* this) {
    Panel* super = &this->super;
-   for (int i = 0; i < Panel_size(super); i++) {
+   const int size = Panel_size(super);
+   for (int i = 0; i < size; i++) {
       ListItem* item = (ListItem*) Panel_get(super, i);
       if (item)
          item->moving = false;

--- a/Header.c
+++ b/Header.c
@@ -147,7 +147,7 @@ void Header_writeBackToSettings(const Header* this) {
       free(colSettings->modes);
 
       const Vector* vec = this->columns[col];
-      int len = Vector_size(vec);
+      const int len = Vector_size(vec);
 
       colSettings->names = len ? xCalloc(len + 1, sizeof(*colSettings->names)) : NULL;
       colSettings->modes = len ? xCalloc(len, sizeof(*colSettings->modes)) : NULL;
@@ -214,7 +214,8 @@ void Header_draw(const Header* this) {
          roundingLoss -= 1.0F;
       }
 
-      for (int y = (pad / 2), i = 0; i < Vector_size(meters); i++) {
+      const int size = Vector_size(meters);
+      for (int y = (pad / 2), i = 0; i < size; i++) {
          Meter* meter = (Meter*) Vector_get(meters, i);
 
          float actualWidth = colWidth;
@@ -241,7 +242,7 @@ void Header_draw(const Header* this) {
 void Header_updateData(Header* this) {
    Header_forEachColumn(this, col) {
       Vector* meters = this->columns[col];
-      int items = Vector_size(meters);
+      const int items = Vector_size(meters);
       for (int i = 0; i < items; i++) {
          Meter* meter = (Meter*) Vector_get(meters, i);
          Meter_updateValues(meter);
@@ -259,7 +260,8 @@ static int calcColumnWidthCount(const Header* this, const Meter* curMeter, const
       const Vector* meters = this->columns[i];
 
       int height = pad;
-      for (int j = 0; j < Vector_size(meters); j++) {
+      const int size = Vector_size(meters);
+      for (int j = 0; j < size; j++) {
          const Meter* meter = (const Meter*) Vector_get(meters, j);
 
          if (height >= curHeight + curMeter->h)

--- a/Header.c
+++ b/Header.c
@@ -182,7 +182,8 @@ Meter* Header_addMeterByClass(Header* this, const MeterClass* type, unsigned int
 
 void Header_reinit(Header* this) {
    Header_forEachColumn(this, col) {
-      for (int i = 0; i < Vector_size(this->columns[col]); i++) {
+      const int size = Vector_size(this->columns[col]);
+      for (int i = 0; i < size; i++) {
          Meter* meter = (Meter*) Vector_get(this->columns[col], i);
          if (Meter_initFn(meter)) {
             Meter_init(meter);
@@ -284,7 +285,8 @@ int Header_calculateHeight(Header* this) {
    Header_forEachColumn(this, col) {
       const Vector* meters = this->columns[col];
       int height = pad;
-      for (int i = 0; i < Vector_size(meters); i++) {
+      const int size = Vector_size(meters);
+      for (int i = 0; i < size; i++) {
          Meter* meter = (Meter*) Vector_get(meters, i);
          meter->columnWidthCount = calcColumnWidthCount(this, meter, pad, col, height);
          height += meter->h;

--- a/IncSet.c
+++ b/IncSet.c
@@ -99,7 +99,8 @@ static void updateWeakPanel(IncSet* this, Panel* panel, Vector* lines) {
    if (this->filtering) {
       int n = 0;
       const char* incFilter = LineEditor_getText(&this->modes[INC_FILTER].editor);
-      for (int i = 0; i < Vector_size(lines); i++) {
+      const int size = Vector_size(lines);
+      for (int i = 0; i < size; i++) {
          ListItem* line = (ListItem*)Vector_get(lines, i);
          if (String_contains_i(line->value, incFilter, true)) {
             Panel_add(panel, (Object*)line);
@@ -111,7 +112,8 @@ static void updateWeakPanel(IncSet* this, Panel* panel, Vector* lines) {
          }
       }
    } else {
-      for (int i = 0; i < Vector_size(lines); i++) {
+      const int size = Vector_size(lines);
+      for (int i = 0; i < size; i++) {
          Object* line = Vector_get(lines, i);
          Panel_add(panel, line);
          if (selected == line) {

--- a/MainPanel.c
+++ b/MainPanel.c
@@ -38,7 +38,8 @@ void MainPanel_updateLabels(MainPanel* this, bool list, bool filter) {
 static void MainPanel_idSearch(MainPanel* this, int ch) {
    Panel* super = &this->super;
    pid_t id = ch - 48 + this->idSearch;
-   for (int i = 0; i < Panel_size(super); i++) {
+   const int size = Panel_size(super);
+   for (int i = 0; i < size; i++) {
       const Row* row = (const Row*) Panel_get(super, i);
       if (row && row->id == id) {
          Panel_setSelected(super, i);
@@ -183,7 +184,8 @@ bool MainPanel_foreachRow(MainPanel* this, MainPanel_foreachRowFn fn, Arg arg, b
    Panel* super = &this->super;
    bool ok = true;
    bool anyTagged = false;
-   for (int i = 0; i < Panel_size(super); i++) {
+   const int size = Panel_size(super);
+   for (int i = 0; i < size; i++) {
       Row* row = (Row*) Panel_get(super, i);
       if (row->tag) {
          ok &= fn(row, arg);

--- a/MetersPanel.c
+++ b/MetersPanel.c
@@ -53,7 +53,8 @@ void MetersPanel_setMoving(MetersPanel* this, bool moving) {
    this->moving = moving;
    if (!moving) {
       /* Reset all items' moving flags when canceling move mode */
-      for (int i = 0; i < Panel_size(super); i++) {
+      const int size = Panel_size(super);
+      for (int i = 0; i < size; i++) {
          ListItem* item = (ListItem*) Panel_get(super, i);
          if (item)
             item->moving = false;
@@ -223,7 +224,8 @@ MetersPanel* MetersPanel_new(Settings* settings, const char* header, Vector* met
    this->rightNeighbor = NULL;
    this->leftNeighbor = NULL;
    Panel_setHeader(super, header);
-   for (int i = 0; i < Vector_size(meters); i++) {
+   const int size = Vector_size(meters);
+   for (int i = 0; i < size; i++) {
       const Meter* meter = (const Meter*) Vector_get(meters, i);
       Panel_add(super, (Object*) Meter_toListItem(meter, false));
    }

--- a/Panel.c
+++ b/Panel.c
@@ -208,7 +208,7 @@ int Panel_size(const Panel* this) {
 void Panel_setSelected(Panel* this, int selected) {
    assert(this != NULL);
 
-   int size = Vector_size(this->items);
+   const int size = Vector_size(this->items);
    if (selected >= size) {
       selected = size - 1;
    }
@@ -233,8 +233,8 @@ void Panel_splice(Panel* this, Vector* from) {
 void Panel_draw(Panel* this, bool force_redraw, bool focus, bool highlightSelected, bool hideFunctionBar) {
    assert(this != NULL);
 
-   int size = Vector_size(this->items);
-   int scrollH = this->scrollH;
+   const int size = Vector_size(this->items);
+   const int scrollH = this->scrollH;
    int y = this->y;
    int x = this->x;
    int h = this->h;

--- a/ProcessTable.c
+++ b/ProcessTable.c
@@ -65,10 +65,11 @@ static void ProcessTable_cleanupEntries(Table* super) {
 
    // Lowest index of the row that is soft-removed. Used to speed up
    // compaction.
+   const int size = Vector_size(super->rows);
    int dirtyIndex = Vector_size(super->rows);
 
    // Finish process table update, culling any exit'd processes
-   for (int i = Vector_size(super->rows) - 1; i >= 0; i--) {
+   for (int i = size - 1; i >= 0; i--) {
       Process* p = (Process*) Vector_get(super->rows, i);
 
       // tidy up Process state after refreshing the ProcessTable table

--- a/ScreensPanel.c
+++ b/ScreensPanel.c
@@ -63,7 +63,8 @@ void ScreensPanel_cleanup(void) {
 
 static void ScreensPanel_cancelMoving(ScreensPanel* this) {
    Panel* super = &this->super;
-   for (int i = 0; i < Panel_size(super); i++) {
+   const int size = Panel_size(super);
+   for (int i = 0; i < size; i++) {
       ListItem* item = (ListItem*) Panel_get(super, i);
       if (item)
          item->moving = false;

--- a/Table.c
+++ b/Table.c
@@ -399,7 +399,8 @@ void Table_printHeader(const Settings* settings, RichString* header) {
 
 // set flags on an existing rows before refreshing table
 void Table_prepareEntries(Table* this) {
-   for (int i = 0; i < Vector_size(this->rows); i++) {
+   const int size = Vector_size(this->rows);
+   for (int i = 0; i < size; i++) {
       Row* row = (struct Row_*) Vector_get(this->rows, i);
       row->updated = false;
       row->wasShown = row->show;

--- a/Table.c
+++ b/Table.c
@@ -108,7 +108,7 @@ static void Table_buildTreeBranch(Table* this, int rowid, unsigned int level, in
       return;
 
    // The vector is sorted by parent, find the start of the range by bisection
-   int vsize = Vector_size(this->rows);
+   const int vsize = Vector_size(this->rows);
    int l = 0;
    int r = vsize;
    while (l < r) {
@@ -160,7 +160,7 @@ static void Table_buildTree(Table* this) {
    Vector_prune(this->displayList);
 
    // Mark root processes
-   int vsize = Vector_size(this->rows);
+   const int vsize = Vector_size(this->rows);
    for (int i = 0; i < vsize; i++) {
       Row* row = (Row*) Vector_get(this->rows, i);
       int parent = Row_getGroupOrParent(row);
@@ -215,7 +215,7 @@ void Table_updateDisplayList(Table* this) {
       if (this->needsSort)
          Vector_insertionSort(this->rows);
       Vector_prune(this->displayList);
-      int size = Vector_size(this->rows);
+      const int size = Vector_size(this->rows);
       for (int i = 0; i < size; i++)
          Vector_add(this->displayList, Vector_get(this->rows, i));
    }
@@ -223,7 +223,7 @@ void Table_updateDisplayList(Table* this) {
 }
 
 void Table_expandTree(Table* this) {
-   int size = Vector_size(this->rows);
+   const int size = Vector_size(this->rows);
    for (int i = 0; i < size; i++) {
       Row* row = (Row*) Vector_get(this->rows, i);
       row->showChildren = true;
@@ -234,7 +234,7 @@ void Table_expandTree(Table* this) {
 void Table_collapseAllBranches(Table* this) {
    Table_buildTree(this); // Update `tree_depth` fields of the rows
    this->needsSort = true; // Table is sorted by parent now, force new sort
-   int size = Vector_size(this->rows);
+   const int size = Vector_size(this->rows);
    for (int i = 0; i < size; i++) {
       Row* row = (Row*) Vector_get(this->rows, i);
       // FreeBSD has pid 0 = kernel and pid 1 = init, so init has tree_depth = 1
@@ -438,10 +438,11 @@ remove:
 void Table_cleanupEntries(Table* this) {
    // Lowest index of the row that is soft-removed. Used to speed up
    // compaction.
+   const int size = Vector_size(this->rows);
    int dirtyIndex = Vector_size(this->rows);
 
    // Finish process table update, culling any removed rows
-   for (int i = Vector_size(this->rows) - 1; i >= 0; i--) {
+   for (int i = size - 1; i >= 0; i--) {
       Row* row = (Row*) Vector_get(this->rows, i);
       if (!Table_cleanupRow(this, row, i)) {
          dirtyIndex = i;


### PR DESCRIPTION
Many thanks @fasterit for making me check the loop, I found such a cool optimization on GCC and Clang compilers with the -O3 optimization flag. Amazing results, it's strange that the compiler itself doesn't optimize for -O3.

Example with `actionUntagAll()` function:

<img width="1400" height="590" alt="screen" src="https://github.com/user-attachments/assets/f2f2120b-0991-4a91-af30-250a1ee0e268" />

Opt A my branch (with `const int size`):
```asm
 actionUntagAll:
    subq    $24, %rsp
    movq    %rbp, 8(%rsp)
    movq    %rdi, %rbp
    movq    8(%rdi), %rdi
    call    Panel_size@PLT
    testl    %eax, %eax
    jle    .L33
    movq    %rbx, (%rsp)
    xorl    %ebx, %ebx
    movq    %r12, 16(%rsp)
    movl    %eax, %r12d
.L34:
    movq    8(%rbp), %rdi
    movl    %ebx, %esi
    addl    $1, %ebx
    call    Panel_get@PLT
    movb    $0, 29(%rax)
    cmpl    %ebx, %r12d
    jne    .L34
    movq    (%rsp), %rbx
    movq    16(%rsp), %r12
.L33:
    movq    8(%rsp), %rbp
    movl    $1, %eax
    addq    $24, %rsp
    ret 
```

<img width="1401" height="590" alt="screen2" src="https://github.com/user-attachments/assets/076e683f-3e02-4dcb-bd02-942263ba58de" />

Op B master branch (without `const int size`):
```asm
 actionUntagAll:
    pushq    %rbp
    movq    %rdi, %rbp
    pushq    %rbx
    xorl    %ebx, %ebx
    subq    $8, %rsp
    jmp    .L33
.L34:
    movq    8(%rbp), %rdi
    movl    %ebx, %esi
    addl    $1, %ebx
    call    Panel_get@PLT
    movb    $0, 29(%rax)
.L33:
    movq    8(%rbp), %rdi
    call    Panel_size@PLT
    cmpl    %ebx, %eax
    jg    .L34
    addq    $8, %rsp
    movl    $1, %eax
    popq    %rbx
    popq    %rbp
    ret 
```


Why separate const int (option A) faster

In Option A, I saved the size to a constant size before the loop started.
In the assembler, we see that the call `Panel_size@PLT` occurs only once before the start of the loop (before the label `.L34`). The result is stored in the `%r12d` register, and a simple and very fast comparison with the register takes place inside the loop itself: `cmpl %ebx, %r12d`.

For each iteration of the loop in Variant A, there is 1 function call.:

    `call Panel_get@PLT`

Why Option B vanilla code slower

In Option B, the exit condition of the loop is calculated anew at each iteration.
There is a label in the assembly code `.L33` (which is a loop condition check) contains:
Code snippet
```asm
.L33:
    movq 8(%rbp), %rdi
    call Panel_size@PLT <--- Function call!
    cmpl    %ebx, %eax
    jg      .L34
```
This means that for each iteration of the loop in Option B, there are 2 function calls.:

    `call Panel_get@PLT`

    `call Panel_size@PLT`