### PR TITLE
dragonflybsd: Fix NULL dereference in jail list parsing

### DIFF
--- a/dragonflybsd/DragonFlyBSDMachine.c
+++ b/dragonflybsd/DragonFlyBSDMachine.c
@@ -323,15 +323,21 @@ retry:
    curpos = jails;
    while (curpos) {
       int jailid;
-      char* str_hostname;
 
       nextpos = strchr(curpos, '\n');
       if (nextpos) {
          *nextpos++ = 0;
       }
 
-      jailid = atoi(strtok(curpos, " "));
-      str_hostname = strtok(NULL, " ");
+      char* str_jailid = strtok(curpos, " ");
+      if (!str_jailid)
+         goto next;
+
+      char* str_hostname = strtok(NULL, " ");
+      if (!str_hostname)
+         goto next;
+
+      jailid = atoi(str_jailid);
 
       char* jname = (char*) (Hashtable_get(this->jails, jailid));
       if (jname == NULL) {
@@ -339,6 +345,7 @@ retry:
          Hashtable_put(this->jails, jailid, jname);
       }
 
+next:
       curpos = nextpos;
    }
 


### PR DESCRIPTION
strtok returns NULL when no delimiter token is found or the input string contains no non-delimiter characters. Previously, the return value of strtok() was passed directly to atoi() and the second call's result was passed to xStrdup() without checking for NULL, which is undefined behaviour and causes a crash when the kernel returns a malformed or empty jail list entry.

Add explicit NULL checks after each strtok() call and use a goto label to safely advance to the next entry when parsing fails

References:
- https://man7.org/linux/man-pages/man3/strtok.3.html