### PR TITLE
lpt: fix misprint fgets buffer size in cgroup parsing

### DIFF
--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -938,7 +938,7 @@ static void LinuxProcessTable_readCGroupFile(LinuxProcess* process, openat_arg_t
    size_t left = PROC_LINE_LENGTH;
    while (!feof(file) && left > 0) {
       char buffer[PROC_LINE_LENGTH + 1];
-      const char* ok = fgets(buffer, PROC_LINE_LENGTH, file);
+      const char* ok = fgets(buffer, sizeof(buffer), file);
       if (!ok)
          break;
 


### PR DESCRIPTION
https://github.com/htop-dev/htop/blob/main/linux/LinuxProcessTable.c#L935-L941

LinuxProcessTable_readCGroupFile() declares an inner buffer of PROC_LINE_LENGTH + 1 bytes but passes PROC_LINE_LENGTH to fgets(), telling it that the buffer is one byte smaller than it actually is