### PR TITLE
Settings: Validate column index sign before size_t conversion

### DIFF
--- a/Settings.c
+++ b/Settings.c
@@ -519,10 +519,14 @@ static bool Settings_read(Settings* this, const char* fileName, const Machine* h
          Settings_readMeterModes(this, option[1], 1);
          didReadMeters = true;
       } else if (String_startsWith(option[0], "column_meters_")) {
-         Settings_readMeters(this, option[1], atoi(option[0] + strlen("column_meters_")));
+         long idx = strtol(option[0] + strlen("column_meters_"), NULL, 10);
+         if (idx >= 0)
+            Settings_readMeters(this, option[1], (size_t)idx);
          didReadMeters = true;
       } else if (String_startsWith(option[0], "column_meter_modes_")) {
-         Settings_readMeterModes(this, option[1], atoi(option[0] + strlen("column_meter_modes_")));
+         long idx = strtol(option[0] + strlen("column_meter_modes_"), NULL, 10);
+         if (idx >= 0)
+            Settings_readMeterModes(this, option[1], (size_t)idx);
          didReadMeters = true;
       } else if (String_eq(option[0], "hide_function_bar")) {
          this->hideFunctionBar = atoi(option[1]);


### PR DESCRIPTION
When reading 'column_meters_N' and 'column_meter_modes_N' keys from .htoprc, column idx N was parsed with atoi() and passed directly as a size_t argument. atoi() returns int, so a malformed key such as 'column_meters_-1' would produce -1, whose implicit conversion to size_t wraps to SIZE_MAX  its UB in C standard

Ref: https://news.ycombinator.com/item?id=45545217

Replace atoi() with strtol() and explicitly skip entries where parsed idx is negative, making cast to size_t well-def in all cases