### PR TITLE
linux: add support Dinit, Runit, S6, SysVInit meters

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -198,11 +198,15 @@ linux_platform_headers = \
 	linux/LinuxMachine.h \
 	linux/LinuxProcess.h \
 	linux/LinuxProcessTable.h \
+	linux/DinitMeter.h \
 	linux/OpenRCMeter.h \
 	linux/Platform.h \
+	linux/RunitMeter.h \
+	linux/S6Meter.h \
 	linux/PressureStallMeter.h \
 	linux/ProcessField.h \
 	linux/SELinuxMeter.h \
+	linux/SysVInitMeter.h \
 	linux/SystemdMeter.h \
 	linux/ZramMeter.h \
 	linux/ZramStats.h \
@@ -226,10 +230,14 @@ linux_platform_sources = \
 	linux/LinuxMachine.c \
 	linux/LinuxProcess.c \
 	linux/LinuxProcessTable.c \
+	linux/DinitMeter.c \
 	linux/OpenRCMeter.c \
 	linux/Platform.c \
 	linux/PressureStallMeter.c \
+	linux/RunitMeter.c \
+	linux/S6Meter.c \
 	linux/SELinuxMeter.c \
+	linux/SysVInitMeter.c \
 	linux/SystemdMeter.c \
 	linux/ZramMeter.c \
 	linux/ZswapMeter.c \

--- a/linux/DinitMeter.c
+++ b/linux/DinitMeter.c
@@ -1,0 +1,186 @@
+/*
+htop - linux/DinitMeter.c
+(C) 2024 htop dev team
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include "config.h" // IWYU pragma: keep
+
+#include "linux/DinitMeter.h"
+
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+#include "CRT.h"
+#include "Macros.h"
+#include "Object.h"
+#include "RichString.h"
+#include "Settings.h"
+#include "XUtils.h"
+
+#define INVALID_VALUE ((size_t)-1)
+
+typedef struct DinitMeterContext {
+   size_t servicesStarted;
+   size_t servicesStopped;
+   size_t servicesFailed;
+} DinitMeterContext_t;
+
+static DinitMeterContext_t ctx_dinit;
+
+/*
+ * `dinitctl list` outputs lines like:
+ *   [[+]   ] boot
+ *   [[ ]   ] sshd
+ *   [{  }  ] network
+ *
+ * Column 1 (inside first brackets): '+' = started, ' ' = stopped, '-' = stopping,
+ * '{' = starting, '}' = stopping, '!' = failed.
+ *
+ * We use the machine-readable `dinitctl --list` format:
+ *   started boot
+ *   stopped sshd
+ *   failed myservice
+ */
+static void DinitMeter_updateValues(Meter* this) {
+   ctx_dinit.servicesStarted = INVALID_VALUE;
+   ctx_dinit.servicesStopped = INVALID_VALUE;
+   ctx_dinit.servicesFailed = INVALID_VALUE;
+
+   if (Settings_isReadonly())
+      goto done;
+
+   /* Check dinit is present */
+   if (access("/sbin/dinit", F_OK) != 0 &&
+       access("/usr/sbin/dinit", F_OK) != 0 &&
+       access("/usr/bin/dinit", F_OK) != 0)
+      goto done;
+
+   int fdpair[2] = {-1, -1};
+   if (pipe(fdpair) < 0)
+      goto done;
+
+   pid_t child = fork();
+   if (child < 0) {
+      close(fdpair[1]);
+      close(fdpair[0]);
+      goto done;
+   }
+
+   if (child == 0) {
+      close(fdpair[0]);
+      dup2(fdpair[1], STDOUT_FILENO);
+      close(fdpair[1]);
+      int fdnull = open("/dev/null", O_WRONLY);
+      if (fdnull < 0)
+         _exit(1);
+      dup2(fdnull, STDERR_FILENO);
+      close(fdnull);
+      execlp("dinitctl", "dinitctl", "list", (char*)NULL);
+      _exit(127);
+   }
+
+   close(fdpair[1]);
+
+   FILE* commandOutput = fdopen(fdpair[0], "r");
+   if (!commandOutput) {
+      close(fdpair[0]);
+      xWaitpid(child, NULL, 0, false);
+      goto done;
+   }
+
+   ctx_dinit.servicesStarted = 0;
+   ctx_dinit.servicesStopped = 0;
+   ctx_dinit.servicesFailed = 0;
+
+   /*
+    * Parse the human-readable dinitctl list output.
+    * Lines look like:
+    *   [[+]   ] servicename
+    *   [[ ]   ] servicename
+    *   [[!]   ] servicename   <- failed
+    *
+    * Character at index 2 is the state indicator:
+    *   '+' = started, ' ' = stopped, '-' = stopping/starting,
+    *   '{' = starting, '}' = stopping, '!' = failed/error
+    */
+   char lineBuffer[512];
+   while (fgets(lineBuffer, sizeof(lineBuffer), commandOutput)) {
+      /* Skip lines that don't start with '[' */
+      if (lineBuffer[0] != '[')
+         continue;
+
+      char stateChar = lineBuffer[2];
+      if (stateChar == '+') {
+         ctx_dinit.servicesStarted++;
+      } else if (stateChar == '!') {
+         ctx_dinit.servicesFailed++;
+         ctx_dinit.servicesStopped++;
+      } else {
+         ctx_dinit.servicesStopped++;
+      }
+   }
+   fclose(commandOutput);
+   xWaitpid(child, NULL, 0, false);
+
+done:
+   if (ctx_dinit.servicesStarted != INVALID_VALUE) {
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer),
+         "%zu started, %zu failed",
+         ctx_dinit.servicesStarted, ctx_dinit.servicesFailed);
+   } else {
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "N/A");
+   }
+}
+
+static void DinitMeter_display(ATTR_UNUSED const Object* cast, RichString* out) {
+   char buffer[32];
+
+   if (ctx_dinit.servicesStarted == INVALID_VALUE) {
+      RichString_writeAscii(out, CRT_colors[METER_VALUE_ERROR], "N/A");
+      return;
+   }
+
+   xSnprintf(buffer, sizeof(buffer), "%zu", ctx_dinit.servicesStarted);
+   RichString_writeAscii(out, CRT_colors[METER_VALUE_OK], buffer);
+
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " started, ");
+
+   xSnprintf(buffer, sizeof(buffer), "%zu", ctx_dinit.servicesStopped);
+   RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
+
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " stopped");
+
+   if (ctx_dinit.servicesFailed > 0) {
+      xSnprintf(buffer, sizeof(buffer), ", %zu failed", ctx_dinit.servicesFailed);
+      RichString_appendAscii(out, CRT_colors[METER_VALUE_ERROR], buffer);
+   }
+}
+
+static const int DinitMeter_attributes[] = {
+   METER_VALUE
+};
+
+const MeterClass DinitMeter_class = {
+   .super = {
+      .extends = Class(Meter),
+      .delete = Meter_delete,
+      .display = DinitMeter_display,
+   },
+   .updateValues = DinitMeter_updateValues,
+   .defaultMode = TEXT_METERMODE,
+   .supportedModes = (1 << TEXT_METERMODE),
+   .maxItems = 0,
+   .total = 0.0,
+   .attributes = DinitMeter_attributes,
+   .name = "Dinit",
+   .uiName = "dinit services",
+   .description = "dinit service manager state overview",
+   .caption = "dinit: ",
+};

--- a/linux/DinitMeter.h
+++ b/linux/DinitMeter.h
@@ -1,0 +1,15 @@
+/*
+htop - linux/DinitMeter.h
+(C) 2024 htop dev team
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#ifndef HEADER_DinitMeter
+#define HEADER_DinitMeter
+
+#include "Meter.h"
+
+extern const MeterClass DinitMeter_class;
+
+#endif

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -49,12 +49,16 @@ in the source distribution for its full text.
 #include "TasksMeter.h"
 #include "UptimeMeter.h"
 #include "linux/Compat.h"
+#include "linux/DinitMeter.h"
 #include "linux/IOPriority.h"
 #include "linux/IOPriorityPanel.h"
 #include "linux/LinuxMachine.h"
 #include "linux/LinuxProcess.h"
 #include "linux/OpenRCMeter.h"
+#include "linux/RunitMeter.h"
+#include "linux/S6Meter.h"
 #include "linux/SELinuxMeter.h"
+#include "linux/SysVInitMeter.h"
 #include "linux/SystemdMeter.h"
 #include "linux/ZramMeter.h"
 #include "linux/ZramStats.h"
@@ -278,6 +282,10 @@ const MeterClass* const Platform_meterTypes[] = {
    &SystemdUserMeter_class,
    &OpenRCMeter_class,
    &OpenRCUserMeter_class,
+   &SysVInitMeter_class,
+   &RunitMeter_class,
+   &S6Meter_class,
+   &DinitMeter_class,
    &FileDescriptorMeter_class,
    &GPUMeter_class,
    NULL

--- a/linux/RunitMeter.c
+++ b/linux/RunitMeter.c
@@ -1,0 +1,167 @@
+/*
+htop - linux/RunitMeter.c
+(C) 2024 htop dev team
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include "config.h" // IWYU pragma: keep
+
+#include "linux/RunitMeter.h"
+
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+#include "CRT.h"
+#include "Macros.h"
+#include "Object.h"
+#include "RichString.h"
+#include "Settings.h"
+#include "XUtils.h"
+
+#define INVALID_VALUE ((size_t)-1)
+
+typedef struct RunitMeterContext {
+   size_t servicesUp;
+   size_t servicesDown;
+   size_t servicesFinish;
+} RunitMeterContext_t;
+
+static RunitMeterContext_t ctx_runit;
+
+/*
+ * sv(8) outputs lines like:
+ *   run: sshd: (pid 1234) 3600s
+ *   down: cron: 42s, normally up
+ *   finish: foo: ...
+ *
+ * We run: sv status /var/service/[name...]
+ * The exit status is non-zero when any service is down, so we ignore it.
+ */
+static void RunitMeter_updateValues(Meter* this) {
+   ctx_runit.servicesUp = INVALID_VALUE;
+   ctx_runit.servicesDown = INVALID_VALUE;
+   ctx_runit.servicesFinish = INVALID_VALUE;
+
+   if (Settings_isReadonly())
+      goto done;
+
+   /* Check that the runit service directory exists */
+   if (access("/var/service", F_OK) != 0 && access("/service", F_OK) != 0)
+      goto done;
+
+   int fdpair[2] = {-1, -1};
+   if (pipe(fdpair) < 0)
+      goto done;
+
+   pid_t child = fork();
+   if (child < 0) {
+      close(fdpair[1]);
+      close(fdpair[0]);
+      goto done;
+   }
+
+   if (child == 0) {
+      close(fdpair[0]);
+      dup2(fdpair[1], STDOUT_FILENO);
+      close(fdpair[1]);
+      int fdnull = open("/dev/null", O_WRONLY);
+      if (fdnull < 0)
+         _exit(1);
+      dup2(fdnull, STDERR_FILENO);
+      close(fdnull);
+      /* Try /var/service first, fall back to /service */
+      if (access("/var/service", F_OK) == 0) {
+         execlp("sv", "sv", "status", "/var/service/.", (char*)NULL);
+      } else {
+         execlp("sv", "sv", "status", "/service/.", (char*)NULL);
+      }
+      _exit(127);
+   }
+
+   close(fdpair[1]);
+
+   FILE* commandOutput = fdopen(fdpair[0], "r");
+   if (!commandOutput) {
+      close(fdpair[0]);
+      xWaitpid(child, NULL, 0, false);
+      goto done;
+   }
+
+   ctx_runit.servicesUp = 0;
+   ctx_runit.servicesDown = 0;
+   ctx_runit.servicesFinish = 0;
+
+   char lineBuffer[256];
+   while (fgets(lineBuffer, sizeof(lineBuffer), commandOutput)) {
+      if (String_startsWith(lineBuffer, "run: ")) {
+         ctx_runit.servicesUp++;
+      } else if (String_startsWith(lineBuffer, "down: ")) {
+         ctx_runit.servicesDown++;
+      } else if (String_startsWith(lineBuffer, "finish: ")) {
+         ctx_runit.servicesFinish++;
+      }
+   }
+   fclose(commandOutput);
+   xWaitpid(child, NULL, 0, false);
+
+done:
+   if (ctx_runit.servicesUp != INVALID_VALUE) {
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer),
+         "%zu up, %zu down", ctx_runit.servicesUp, ctx_runit.servicesDown);
+   } else {
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "N/A");
+   }
+}
+
+static void RunitMeter_display(ATTR_UNUSED const Object* cast, RichString* out) {
+   char buffer[32];
+
+   if (ctx_runit.servicesUp == INVALID_VALUE) {
+      RichString_writeAscii(out, CRT_colors[METER_VALUE_ERROR], "N/A");
+      return;
+   }
+
+   xSnprintf(buffer, sizeof(buffer), "%zu", ctx_runit.servicesUp);
+   RichString_writeAscii(out, CRT_colors[METER_VALUE_OK], buffer);
+
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " up, ");
+
+   xSnprintf(buffer, sizeof(buffer), "%zu", ctx_runit.servicesDown);
+   int downColor = (ctx_runit.servicesDown > 0) ? METER_VALUE_ERROR : METER_VALUE;
+   RichString_appendAscii(out, CRT_colors[downColor], buffer);
+
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " down");
+
+   if (ctx_runit.servicesFinish > 0) {
+      xSnprintf(buffer, sizeof(buffer), ", %zu finishing", ctx_runit.servicesFinish);
+      RichString_appendAscii(out, CRT_colors[METER_VALUE_NOTICE], buffer);
+   }
+}
+
+static const int RunitMeter_attributes[] = {
+   METER_VALUE
+};
+
+const MeterClass RunitMeter_class = {
+   .super = {
+      .extends = Class(Meter),
+      .delete = Meter_delete,
+      .display = RunitMeter_display,
+   },
+   .updateValues = RunitMeter_updateValues,
+   .defaultMode = TEXT_METERMODE,
+   .supportedModes = (1 << TEXT_METERMODE),
+   .maxItems = 0,
+   .total = 0.0,
+   .attributes = RunitMeter_attributes,
+   .name = "Runit",
+   .uiName = "runit services",
+   .description = "runit service supervisor state overview",
+   .caption = "runit: ",
+};

--- a/linux/RunitMeter.h
+++ b/linux/RunitMeter.h
@@ -1,0 +1,15 @@
+/*
+htop - linux/RunitMeter.h
+(C) 2024 htop dev team
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#ifndef HEADER_RunitMeter
+#define HEADER_RunitMeter
+
+#include "Meter.h"
+
+extern const MeterClass RunitMeter_class;
+
+#endif

--- a/linux/S6Meter.c
+++ b/linux/S6Meter.c
@@ -1,0 +1,152 @@
+/*
+htop - linux/S6Meter.c
+(C) 2024 htop dev team
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include "config.h" // IWYU pragma: keep
+
+#include "linux/S6Meter.h"
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+#include "CRT.h"
+#include "Macros.h"
+#include "Object.h"
+#include "RichString.h"
+#include "Settings.h"
+#include "XUtils.h"
+
+#define INVALID_VALUE ((size_t)-1)
+
+/* Common s6 scan directories, tried in order */
+static const char* const s6ScanDirs[] = {
+   "/run/s6/services",
+   "/run/s6-rc/services",
+   "/etc/s6/services",
+   NULL,
+};
+
+typedef struct S6MeterContext {
+   size_t servicesUp;
+   size_t servicesDown;
+} S6MeterContext_t;
+
+static S6MeterContext_t ctx_s6;
+
+static const char* S6Meter_findScanDir(void) {
+   for (int i = 0; s6ScanDirs[i]; i++) {
+      if (access(s6ScanDirs[i], F_OK) == 0)
+         return s6ScanDirs[i];
+   }
+   return NULL;
+}
+
+/*
+ * s6-svstat outputs one line per invocation:
+ *   up (pid 1234) 3600 seconds
+ *   down 42 seconds, normally up, ready 42 seconds
+ *
+ * We iterate service directories and run s6-svstat for each.
+ */
+static void S6Meter_updateValues(Meter* this) {
+   ctx_s6.servicesUp = INVALID_VALUE;
+   ctx_s6.servicesDown = INVALID_VALUE;
+
+   if (Settings_isReadonly())
+      goto done;
+
+   const char* scanDir = S6Meter_findScanDir();
+   if (!scanDir)
+      goto done;
+
+   DIR* dir = opendir(scanDir);
+   if (!dir)
+      goto done;
+
+   ctx_s6.servicesUp = 0;
+   ctx_s6.servicesDown = 0;
+
+   struct dirent* entry;
+   while ((entry = readdir(dir)) != NULL) {
+      if (entry->d_name[0] == '.')
+         continue;
+
+      /* Build path: scanDir + "/" + entry->d_name + "/supervise/stat" */
+      char statPath[512];
+      xSnprintf(statPath, sizeof(statPath), "%s/%s/supervise/stat", scanDir, entry->d_name);
+
+      FILE* statFile = fopen(statPath, "r");
+      if (!statFile)
+         continue;
+
+      char line[64];
+      if (fgets(line, sizeof(line), statFile)) {
+         if (String_startsWith(line, "up")) {
+            ctx_s6.servicesUp++;
+         } else {
+            ctx_s6.servicesDown++;
+         }
+      }
+      fclose(statFile);
+   }
+   closedir(dir);
+
+done:
+   if (ctx_s6.servicesUp != INVALID_VALUE) {
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer),
+         "%zu up, %zu down", ctx_s6.servicesUp, ctx_s6.servicesDown);
+   } else {
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "N/A");
+   }
+}
+
+static void S6Meter_display(ATTR_UNUSED const Object* cast, RichString* out) {
+   char buffer[32];
+
+   if (ctx_s6.servicesUp == INVALID_VALUE) {
+      RichString_writeAscii(out, CRT_colors[METER_VALUE_ERROR], "N/A");
+      return;
+   }
+
+   xSnprintf(buffer, sizeof(buffer), "%zu", ctx_s6.servicesUp);
+   RichString_writeAscii(out, CRT_colors[METER_VALUE_OK], buffer);
+
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " up, ");
+
+   xSnprintf(buffer, sizeof(buffer), "%zu", ctx_s6.servicesDown);
+   int downColor = (ctx_s6.servicesDown > 0) ? METER_VALUE_ERROR : METER_VALUE;
+   RichString_appendAscii(out, CRT_colors[downColor], buffer);
+
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " down");
+}
+
+static const int S6Meter_attributes[] = {
+   METER_VALUE
+};
+
+const MeterClass S6Meter_class = {
+   .super = {
+      .extends = Class(Meter),
+      .delete = Meter_delete,
+      .display = S6Meter_display,
+   },
+   .updateValues = S6Meter_updateValues,
+   .defaultMode = TEXT_METERMODE,
+   .supportedModes = (1 << TEXT_METERMODE),
+   .maxItems = 0,
+   .total = 0.0,
+   .attributes = S6Meter_attributes,
+   .name = "S6",
+   .uiName = "s6 services",
+   .description = "s6 service supervisor state overview",
+   .caption = "s6: ",
+};

--- a/linux/S6Meter.h
+++ b/linux/S6Meter.h
@@ -1,0 +1,15 @@
+/*
+htop - linux/S6Meter.h
+(C) 2024 htop dev team
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#ifndef HEADER_S6Meter
+#define HEADER_S6Meter
+
+#include "Meter.h"
+
+extern const MeterClass S6Meter_class;
+
+#endif

--- a/linux/SysVInitMeter.c
+++ b/linux/SysVInitMeter.c
@@ -1,0 +1,133 @@
+/*
+htop - linux/SysVInitMeter.c
+(C) 2024 htop dev team
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include "config.h" // IWYU pragma: keep
+
+#include "linux/SysVInitMeter.h"
+
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+#include "CRT.h"
+#include "Macros.h"
+#include "Object.h"
+#include "RichString.h"
+#include "Settings.h"
+#include "XUtils.h"
+
+typedef struct SysVInitMeterContext {
+   char runlevel;       /* current runlevel character, '\0' if unknown */
+   char prevRunlevel;   /* previous runlevel character, 'N' means none */
+} SysVInitMeterContext_t;
+
+static SysVInitMeterContext_t ctx_sysvInit;
+
+static void SysVInitMeter_updateValues(Meter* this) {
+   ctx_sysvInit.runlevel = '\0';
+   ctx_sysvInit.prevRunlevel = 'N';
+
+   if (Settings_isReadonly())
+      goto done;
+
+   int fdpair[2] = {-1, -1};
+   if (pipe(fdpair) < 0)
+      goto done;
+
+   pid_t child = fork();
+   if (child < 0) {
+      close(fdpair[1]);
+      close(fdpair[0]);
+      goto done;
+   }
+
+   if (child == 0) {
+      close(fdpair[0]);
+      dup2(fdpair[1], STDOUT_FILENO);
+      close(fdpair[1]);
+      int fdnull = open("/dev/null", O_WRONLY);
+      if (fdnull < 0)
+         _exit(1);
+      dup2(fdnull, STDERR_FILENO);
+      close(fdnull);
+      execlp("runlevel", "runlevel", (char*)NULL);
+      _exit(127);
+   }
+
+   close(fdpair[1]);
+
+   int wstatus;
+   if (xWaitpid(child, &wstatus, 0, false) < 0 || !WIFEXITED(wstatus) || WEXITSTATUS(wstatus) != 0) {
+      close(fdpair[0]);
+      goto done;
+   }
+
+   FILE* commandOutput = fdopen(fdpair[0], "r");
+   if (!commandOutput) {
+      close(fdpair[0]);
+      goto done;
+   }
+
+   /* runlevel outputs "PREV CURRENT\n", e.g. "N 3" or "3 5" */
+   char prev = '\0', cur = '\0';
+   if (fscanf(commandOutput, "%c %c", &prev, &cur) == 2) {
+      ctx_sysvInit.prevRunlevel = prev;
+      ctx_sysvInit.runlevel = cur;
+   }
+   fclose(commandOutput);
+
+done:
+   if (ctx_sysvInit.runlevel != '\0') {
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "%c", ctx_sysvInit.runlevel);
+   } else {
+      xSnprintf(this->txtBuffer, sizeof(this->txtBuffer), "???");
+   }
+}
+
+static void SysVInitMeter_display(ATTR_UNUSED const Object* cast, RichString* out) {
+   RichString_writeAscii(out, CRT_colors[METER_TEXT], "Runlevel: ");
+
+   if (ctx_sysvInit.runlevel != '\0') {
+      char buf[4];
+      xSnprintf(buf, sizeof(buf), "%c", ctx_sysvInit.runlevel);
+      RichString_appendAscii(out, CRT_colors[METER_VALUE], buf);
+   } else {
+      RichString_appendAscii(out, CRT_colors[METER_VALUE_ERROR], "N/A");
+   }
+
+   if (ctx_sysvInit.prevRunlevel != '\0' && ctx_sysvInit.prevRunlevel != 'N') {
+      char buf[16];
+      xSnprintf(buf, sizeof(buf), " (prev: %c)", ctx_sysvInit.prevRunlevel);
+      RichString_appendAscii(out, CRT_colors[METER_TEXT], buf);
+   }
+}
+
+static const int SysVInitMeter_attributes[] = {
+   METER_VALUE
+};
+
+const MeterClass SysVInitMeter_class = {
+   .super = {
+      .extends = Class(Meter),
+      .delete = Meter_delete,
+      .display = SysVInitMeter_display,
+   },
+   .updateValues = SysVInitMeter_updateValues,
+   .defaultMode = TEXT_METERMODE,
+   .supportedModes = (1 << TEXT_METERMODE),
+   .maxItems = 0,
+   .total = 0.0,
+   .attributes = SysVInitMeter_attributes,
+   .name = "SysVInit",
+   .uiName = "SysV Init runlevel",
+   .description = "SysV Init current runlevel",
+   .caption = "SysVInit: ",
+};

--- a/linux/SysVInitMeter.h
+++ b/linux/SysVInitMeter.h
@@ -1,0 +1,15 @@
+/*
+htop - linux/SysVInitMeter.h
+(C) 2024 htop dev team
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#ifndef HEADER_SysVInitMeter
+#define HEADER_SysVInitMeter
+
+#include "Meter.h"
+
+extern const MeterClass SysVInitMeter_class;
+
+#endif


### PR DESCRIPTION
This affected popular Linux/BSD distrs:
- SysVInit (Devuan, antiX, MX Linux, Slackware, FreeBSD, NetBSD, OpenBSD)
- S6 (Artix Linux, Obarun, Parabola, Devuan)
- Runit (FreeBSD, OpenBSD, NetBSD, Void Linux, antiX, Dragora GNU/Linux-Libre, Artix Linux, Devuan, Gentoo Linux, Hyperbola GNU/Linux-libre, Debian, Ubuntu, Linux From Scratch)
- Dinit (Artix Linux, Chimera Linux, KaOS, antiX, OpenBSD, FreeBSD)