### PR TITLE
Filter by path

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -858,8 +858,12 @@ static bool Process_matchesFilter(const Process* this, const Table* table) {
       return true;
 
    const char* incFilter = table->incFilter;
-   if (incFilter && !String_contains_i(Process_getCommand(this), incFilter, true))
-      return true;
+   if (incFilter){
+      bool matchesCmdline = String_contains_i(Process_getCommand(this), incFilter, true);
+      bool matchesExePath = this->procExe && String_contains_i(this->procExe, incFilter, true);
+      if (!matchesCmdline && !matchesExePath)
+         return true;
+   }
 
    const ProcessTable* pt = (const ProcessTable*) host->activeTable;
    assert(Object_isA((const Object*) pt, (const ObjectClass*) &ProcessTable_class));


### PR DESCRIPTION
Hey Folks, 

This PR is about an issue which was marked as feature [1825](https://github.com/htop-dev/htop/issues/1825).

**ABOUT**:
Now Process_matchesFilter are now checks executable path also. 
for example. There are two binaries:  ~/projects/a/binary and ~/projects/b/binary

                       Original behaviour:
                                        htop -F binary will give two binaries. No way to isolate from one another. 
                       Now:
                                        htop -F a can give only processes involved with ~/projects/a
                       
**NOTE**
This feature involves the changes in traditional Filter (-F) feature. 