### PR TITLE
docs: document CPU meter segments in the man page

### DIFF
--- a/htop.1.in
+++ b/htop.1.in
@@ -614,6 +614,56 @@ The autogroup nice value for the process autogroup. Requires Linux CFS to be ena
 .TP
 .B All other flags
 Currently unsupported (always displays '-').
+.SH "METERS"
+Header meters (configured in Setup, F2) show live host statistics. The
+.B CPU
+meter is a bar (or text, depending on display mode) that stacks several kinds
+of CPU time. Left-to-right segments match the on-screen legend
+.RB ( F1 / h
+help also shows this in color).
+.PP
+Default
+.B CPU
+bar segments (\"default\" color scheme). In monochrome mode the same segments
+use text attributes instead of hues:
+.TP
+.B low (nice)
+Blue; monochrome: normal intensity. Time running at nice > 0.
+.TP
+.B normal (user)
+Green; monochrome: bold. Ordinary user-mode time.
+.TP
+.B kernel (system)
+Red; monochrome: bold. Kernel / system time.
+.TP
+.B irq
+Yellow; monochrome: bold. Hardware interrupt time (detailed CPU time).
+.TP
+.B soft-irq
+Magenta; monochrome: bold. Software interrupt time (detailed CPU time).
+.TP
+.B steal
+Cyan; monochrome: dim. Time stolen by the hypervisor (detailed CPU time).
+.TP
+.B guest / virt
+Cyan; monochrome: dim. Guest VM time when detailed CPU time is on.
+Labeled
+.B virt
+when it is off (Linux and PCP: steal plus guest combined).
+.TP
+.B io-wait
+Gray; monochrome: normal. Waiting on block I/O (detailed CPU time).
+.PP
+With
+.B Detailed CPU time
+enabled in Setup, the bar expands to show irq, soft-irq, steal, guest and
+io-wait separately. Otherwise Linux and PCP fold steal and guest into
+.B virt
+and some of the finer classes are folded into the main segments.
+.PP
+Exact hues depend on the selected color scheme; monochrome maps the same
+segments to bold / normal / dim as noted above. The interactive help always
+shows the live legend for your current scheme.
 .SH "EXTERNAL LIBRARIES"
 While
 .B htop


### PR DESCRIPTION
F1 help already labels the CPU bar segments, but the man page did not. Added a short METERS section with each segment, default-scheme colors, and monochrome bold/normal/dim mapping (as discussed on #872).

Fixes #872