### PR TITLE
linux: release CPU data when a CPU is hot-unplugged

### DIFF
--- a/linux/LinuxMachine.c
+++ b/linux/LinuxMachine.c
@@ -62,6 +62,7 @@ static void LinuxMachine_updateCPUcount(LinuxMachine* this) {
       return;
 
    unsigned int currExisting = super->existingCPUs;
+   unsigned int maxSeen = 0;
 
    const struct dirent* entry;
    while ((entry = readdir(dir)) != NULL) {
@@ -90,6 +91,7 @@ static void LinuxMachine_updateCPUcount(LinuxMachine* this) {
 
       /* readdir() iterates with no specific order */
       unsigned int max = MAXIMUM(existing, cpuid);
+      maxSeen = MAXIMUM(maxSeen, max);
       if (max > currExisting) {
          this->cpuData = xReallocArrayZero(this->cpuData, currExisting ? (currExisting + 1) : 0, max + /* aggregate */ 1, sizeof(CPUData));
          this->cpuData[0].online = true; /* average is always "online" */
@@ -115,6 +117,16 @@ static void LinuxMachine_updateCPUcount(LinuxMachine* this) {
    if (existing < 1)
       return;
 
+   /* The array is only ever grown inside the loop, because readdir() gives no
+    * ordering guarantee and a CPU may still show up later in the same scan.
+    * Shrinking therefore has to wait until every entry has been seen. Without
+    * this, a hot-unplugged CPU is never released: existingCPUs keeps the old
+    * value forever, so htop goes on drawing a meter for a CPU that is gone. */
+   if (maxSeen < currExisting) {
+      this->cpuData = xReallocArrayZero(this->cpuData, currExisting + 1, maxSeen + /* aggregate */ 1, sizeof(CPUData));
+      currExisting = maxSeen;
+   }
+
 #ifdef HAVE_SENSORS_SENSORS_H
    /* When started with offline CPUs, libsensors does not monitor those,
     * even when they become online. */
@@ -123,7 +135,7 @@ static void LinuxMachine_updateCPUcount(LinuxMachine* this) {
 #endif
 
    super->activeCPUs = active;
-   assert(existing == currExisting);
+   assert(existing <= currExisting);
    super->existingCPUs = currExisting;
 }
 

--- a/linux/LinuxMachine.c
+++ b/linux/LinuxMachine.c
@@ -89,6 +89,19 @@ static void LinuxMachine_updateCPUcount(LinuxMachine* this) {
 
       existing++;
 
+      /* The scan only writes `online` for CPUs it actually finds, so a CPU
+       * unplugged from the middle of the range would keep its last value for
+       * the rest of the session: the count cannot shrink (the array still has
+       * to reach the highest id) and nothing else ever clears the flag.
+       * Clear them once, then let the rest of this scan turn back on whatever
+       * is still there. This sits on the first CPU we count rather than before
+       * the loop so that the "no CPU found" case below still leaves the
+       * previous state alone, instead of marking every CPU offline. */
+      if (existing == 1) {
+         for (unsigned int i = 1; i <= currExisting; i++)
+            this->cpuData[i].online = false;
+      }
+
       /* readdir() iterates with no specific order */
       unsigned int max = MAXIMUM(existing, cpuid);
       maxSeen = MAXIMUM(maxSeen, max);


### PR DESCRIPTION
Closes #1767

`LinuxMachine_updateCPUcount()` only ever grows `existingCPUs`. `cpuData` is resized inside the `readdir()` loop, which it has to be because `readdir()` gives no ordering guarantee and a CPU may still turn up later in the same scan, but nothing ever lowers the count once a CPU goes away. After a hot-unplug the old value therefore survives for the rest of the session.

The two halves of #1767 are in different states on main, so to be explicit about what this does and does not cover:

* **Hot-add was already fixed** by 143147eb, released in 3.5.2. The original report is against 3.4.1. I could not produce a crash on hot-add with current main.
* **Hot-remove is what this PR fixes.** A debug build aborts on `assert(existing == currExisting)`. A release build defines `NDEBUG`, so it does not crash, it just keeps drawing a meter for a CPU that no longer exists. That likely explains why the report shows signal 11 from a distro build rather than signal 6.

### The change

Track the highest index seen during the scan, then shrink `cpuData` once the directory has been read to the end. The missing ordering guarantee inside the loop is precisely what prevents deciding to shrink there, so the decision moves after the loop.

The assertion becomes `existing <= currExisting`, which is the invariant that actually holds. With sparse CPU ids the array is sized to the highest index rather than to the number of CPUs, so equality was never the right condition.

### Reproduction

No VM needed. Bind mounting a fake `/sys/devices/system/cpu` inside a private mount namespace and removing a `cpuN` directory while htop runs exercises the same scan path:

```console
$ # 4 fake CPUs, remove cpu3 four seconds in
$ sudo unshare -m -- bash repro.sh
```

Before, debug build:

```
htop: linux/LinuxMachine.c:126: LinuxMachine_updateCPUcount: Assertion `existing == currExisting' failed.
A signal 6 (Aborted) was received.
exit code 134
```

After, same build and same scenario: no abort, htop runs to the end of the test (exit code 124, from the harness timeout).

### Verifying the count actually follows, rather than the assert just being loosened

With a temporary trace in `updateCPUcount()` and in `AllCPUsMeter_updateValues()`, removing `cpu3` at t=4s and adding it back at t=8s:

```
CPUCOUNT existing=4 maxSeen=4 currExisting=4 prevExisting=1
CPUCOUNT existing=4 maxSeen=4 currExisting=4 prevExisting=4   (x4)
CPUCOUNT existing=3 maxSeen=3 currExisting=3 prevExisting=4   <- unplug
METERS 4 -> 3
CPUCOUNT existing=3 maxSeen=3 currExisting=3 prevExisting=3   (x3)
CPUCOUNT existing=4 maxSeen=4 currExisting=4 prevExisting=3   <- replug
METERS 3 -> 4
```

So the count shrinks and grows with the machine, and the `AllCPUsMeter` array follows it in both directions. The trace was removed before committing.

Checked that hot-add still behaves on both the unpatched and patched build, so this does not regress the 143147eb path.

### Adjacent gap, deliberately not in this PR

Removing a CPU in the middle of the range is a different case, and this PR does not change it. With `cpu0..cpu3` and `cpu1` removed, the count correctly stays at 4, because the array still has to reach `cpu3`, and nothing crashes:

```
existing=3  active=3  currExisting=4  online[]=1111
```

The removed CPU nevertheless keeps `online = true`, since the scan only writes that flag for CPUs it actually finds. `linux/Platform.c` and `Machine_isCPUonline()` both read it, so htop goes on drawing a normal bar with frozen values instead of marking the CPU offline.

`solaris/SolarisMachine.c` already avoids this by clearing the flags before its scan. The wrinkle on Linux is that the `if (existing < 1) return;` guard sits after the loop, so a blanket pre-clear would mark every CPU offline if the sysfs directory ever read empty.

Happy to fold that in here or send it separately, whichever you prefer. I kept it out so this change stays to one thing.
