### PR TITLE
linux: fix out-of-bounds access when parsing power supply type

### DIFF
--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -877,12 +877,13 @@ static void Platform_Battery_getSysData(double* percent, ACPresence* isOnAC) {
       } else {
          char buffer[32];
          ssize_t ret = Compat_readfileat(entryFd, "type", buffer, sizeof(buffer));
-         if (ret <= 0)
+         if (ret <= 0 || (size_t)ret > sizeof(buffer))
             goto next;
 
-         /* drop optional trailing newlines */
-         for (char* buf = &buffer[(size_t)ret - 1]; *buf == '\n'; buf--)
-            *buf = '\0';
+         /* truncate on non-printable characters */
+         for (size_t idx = 0; idx < (size_t)ret; idx++)
+            if (buffer[idx] <= ' ')
+               buffer[idx] = 0;
 
          if (String_eq(buffer, "Battery"))
             type = BAT;


### PR DESCRIPTION
## Problem

`Platform_Battery_getSysData()` in `linux/Platform.c` reads `/sys/class/power_supply/<name>/type` into a stack buffer and trims trailing newlines with:

```c
char buffer[32];
ssize_t ret = Compat_readfileat(entryFd, "type", buffer, sizeof(buffer));
if (ret <= 0)
   goto next;

/* drop optional trailing newlines */
for (char* buf = &buffer[(size_t)ret - 1]; *buf == '\n'; buf--)
   *buf = '\0';
```

`Compat_readfileat()` reads up to `count - 1` bytes (reserving one for the `'\0'` terminator), so for a 32-byte buffer it can return up to 31 bytes. If the `type` file contains only newline bytes (e.g. 31 `'\n'`), the loop walks the pointer from `buffer[30]` down to `buffer[0]` and then — because there is no lower-bound check — performs an **out-of-bounds read at `buffer[-1]`** to re-evaluate `*buf == '\n'`.

The loop only stops there if the OOB byte is not `'\n'`. If the OOB byte happens to be `0x0a` (e.g. leftover stack content), the loop continues:
- writing `'\0'` into `buffer[-1]` (OOB **write**), and
- reading `buffer[-2]`, `buffer[-3]`, …

corrupting the stack below the buffer for as many consecutive `'\n'` bytes as are present, until a non-`'\n'` byte or an unmapped page is reached.

## Trigger

A malicious or buggy `power_supply` device whose `type` attribute contains only newlines. Such devices can be created via USB/ACPI/container power supply class registrations (e.g. `/sys/class/power_supply/<name>/type`). Any entry whose name does not start with `BAT` or `AC` reaches this code path.

## Impact

- OOB stack **read** is guaranteed whenever the `type` file is all newlines.
- OOB stack **write** (and unbounded downward walk) occurs when the OOB bytes read are `'\n'`.

This is reachable from an unprivileged trigger (a crafted `power_supply` sysfs entry) and can corrupt the stack of the `Platform_Battery_getSysData` frame.

## Fix

Add a lower-bound check so the loop stops at `buffer[0]`:

```c
for (char* buf = &buffer[(size_t)ret - 1]; buf >= buffer && *buf == '\n'; buf--)
   *buf = '\0';
```

One line, one file.

## Verification

Reproduced the OOB with a standalone canary test that mimics `Compat_readfileat` returning 31 newlines into a 32-byte buffer sandwiched between guard regions:

- With the guard byte below `buffer[0]` set to a non-`'\n'` value, the loop performs an OOB read at `buffer[-1]` (final pointer offset `-1`) and stops only because that byte is not `'\n'`.
- With 3 `'\n'` bytes placed below `buffer[0]`, the loop performs 3 OOB writes, clobbering the guard bytes from `0x0a` to `0x00`, and walks to offset `-4`.

With this patch applied, the loop stops at `buffer[0]` and no OOB access occurs. `htop` rebuilds cleanly with `-Wall -Wextra`.

## Notes

- Introduced by #890 ("Linux: read generic sysfs batteries"), which added the `type`-file probing for entries not prefixed with `BAT`/`AC`.
- The open PR #1967 ("Extend BatteryMeter display") rewrites the battery-data body that follows this loop but does not touch the trimming loop itself; this fix should rebased cleanly if #1967 lands first.

Assisted-by: lilu <lilu@kylinos.cn>
