### PR TITLE
Fix Clang MSan sanitizer security issue

### DIFF
--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -1090,7 +1090,7 @@ static int dropCapabilities(enum CapMode mode) {
       if (!CAP_IS_SUPPORTED(keepcaps[i]))
          continue;
 
-      cap_flag_value_t current;
+      cap_flag_value_t current = CAP_CLEAR;
       if (cap_get_flag(currCaps, keepcaps[i], CAP_PERMITTED, &current) < 0) {
          fprintf(stderr, "Error: cannot get current value of capability %d: %s\n", keepcaps[i], strerror(errno));
          cap_free(currCaps);


### PR DESCRIPTION
My build log with MSAN sanitizer:
[build_msan.log](https://github.com/user-attachments/files/30950875/build_msan.log)


memory sanitizer (MSAN) indicated the use of an uninitialized current value in the dropCapabilities function (linux/Platform.c:1101 file). The error occurred because the current variable might not have been set by an external call (libcap was not compiled with MSAN or terminated differently depending on the platform). I fixed this problem by initializing the variable when declaring: cap_flag_value_t current = CAP_CLEAR;

```
Uninitialized bytes in strlen at offset 0 inside [0x7060000000c0, 1)
==6337==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x7f122c648d12 in _nc_first_db (/usr/lib/x86_64-linux-gnu/libtinfo.so.6+0x12d12) (BuildId: d38f6ae892d3c1ceac7c10c17c7cdb0e173a001c)
    #1 0x7f122c657377 in _nc_read_entry2 (/usr/lib/x86_64-linux-gnu/libtinfo.so.6+0x21377) (BuildId: d38f6ae892d3c1ceac7c10c17c7cdb0e173a001c)
    #2 0x7f122c64bd73  (/usr/lib/x86_64-linux-gnu/libtinfo.so.6+0x15d73) (BuildId: d38f6ae892d3c1ceac7c10c17c7cdb0e173a001c)
    #3 0x7f122c64c1cc in _nc_setupterm (/usr/lib/x86_64-linux-gnu/libtinfo.so.6+0x161cc) (BuildId: d38f6ae892d3c1ceac7c10c17c7cdb0e173a001c)
    #4 0x7f122c684d3a in newterm_sp (/usr/lib/x86_64-linux-gnu/libncursesw.so.6+0x18d3a) (BuildId: c63328954e6de2b625027fffdf1a4179e5bca0f2)
    #5 0x7f122c6851c8 in newterm (/usr/lib/x86_64-linux-gnu/libncursesw.so.6+0x191c8) (BuildId: c63328954e6de2b625027fffdf1a4179e5bca0f2)
    #6 0x7f122c6809ca in initscr (/usr/lib/x86_64-linux-gnu/libncursesw.so.6+0x149ca) (BuildId: c63328954e6de2b625027fffdf1a4179e5bca0f2)
    #7 0x55d3b11e1a7b in CRT_init /media/devuan/7b0651a1-06b3-47ec-97cb-73b496ab459f/htop/CRT.c:1180:4
    #8 0x55d3b11dbf0d in CommandLine_run /media/devuan/7b0651a1-06b3-47ec-97cb-73b496ab459f/htop/CommandLine.c:448:4
    #9 0x7f122c331f76 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #10 0x7f122c332026 in __libc_start_main csu/../csu/libc-start.c:360:3
    #11 0x55d3b112fa30 in _start (/media/devuan/7b0651a1-06b3-47ec-97cb-73b496ab459f/htop/htop+0x46a30) (BuildId: e09893b8b8a7892c82a866345fbf917fd9045cf8)

  Uninitialized value was created by a heap allocation
    #0 0x55d3b116eb46 in malloc (/media/devuan/7b0651a1-06b3-47ec-97cb-73b496ab459f/htop/htop+0x85b46) (BuildId: e09893b8b8a7892c82a866345fbf917fd9045cf8)
    #1 0x7f122c648cd8 in _nc_first_db (/usr/lib/x86_64-linux-gnu/libtinfo.so.6+0x12cd8) (BuildId: d38f6ae892d3c1ceac7c10c17c7cdb0e173a001c)
    #2 0x7f122c6595bf  (/usr/lib/x86_64-linux-gnu/libtinfo.so.6+0x235bf) (BuildId: d38f6ae892d3c1ceac7c10c17c7cdb0e173a001c)

SUMMARY: MemorySanitizer: use-of-uninitialized-value (/usr/lib/x86_64-linux-gnu/libtinfo.so.6+0x12d12) (BuildId: d38f6ae892d3c1ceac7c10c17c7cdb0e173a001c) in _nc_first_db
Exiting
```