### PR TITLE
Settings: guard against null hColumns in Settings_validateMeters

### DIFF
--- a/Settings.c
+++ b/Settings.c
@@ -113,6 +113,9 @@ static void Settings_readMeterModes(Settings* this, const char* line, size_t col
 }
 
 static bool Settings_validateMeters(Settings* this) {
+   if (!this->hColumns)
+      return false;
+
    const size_t colCount = HeaderLayout_getColumns(this->hLayout);
 
    bool anyMeter = false;


### PR DESCRIPTION
Coverity CID 652989: Settings_validateMeters dereferences this->hColumns without checking for NULL first. Add an early return of false so callers fall back to Settings_defaultMeters safely.

Assisted-by: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>