### PR TITLE
Linux: read GPU usage from drm-cycles when there is no ns counter

### DIFF
--- a/linux/GPU.c
+++ b/linux/GPU.c
@@ -45,7 +45,7 @@ static bool is_duplicate_client(const ClientInfo* parsed, ClientID id, const cha
    return false;
 }
 
-static void update_machine_gpu(LinuxProcessTable* lpt, unsigned long long int time, const char* engine, size_t engine_len) {
+static GPUEngineData* get_machine_gpu_engine(LinuxProcessTable* lpt, const char* engine, size_t engine_len) {
    Machine* host = lpt->super.super.host;
    LinuxMachine* lhost = (LinuxMachine*) host;
    GPUEngineData** engineData = &lhost->gpuEngineData;
@@ -60,17 +60,86 @@ static void update_machine_gpu(LinuxProcessTable* lpt, unsigned long long int ti
    if (!*engineData) {
       GPUEngineData* newData = xMalloc(sizeof(*newData));
       *newData = (GPUEngineData) {
-         .prevTime = 0,
-         .curTime  = 0,
-         .key      = xStrndup(engine, engine_len),
-         .next     = NULL,
+         .prevTime        = 0,
+         .curTime         = 0,
+         .prevCycles      = 0,
+         .curCycles       = 0,
+         .prevTotalCycles = 0,
+         .curTotalCycles  = 0,
+         .key             = xStrndup(engine, engine_len),
+         .next            = NULL,
       };
 
       *engineData = newData;
    }
 
-   (*engineData)->curTime += time;
+   return *engineData;
+}
+
+static void update_machine_gpu(LinuxProcessTable* lpt, unsigned long long int time, const char* engine, size_t engine_len) {
+   LinuxMachine* lhost = (LinuxMachine*) lpt->super.super.host;
+
+   get_machine_gpu_engine(lpt, engine, engine_len)->curTime += time;
    lhost->curGpuTime += time;
+}
+
+static void update_machine_gpu_cycles(LinuxProcessTable* lpt, unsigned long long int cycles, const char* engine, size_t engine_len) {
+   get_machine_gpu_engine(lpt, engine, engine_len)->curCycles += cycles;
+}
+
+/* drm-total-cycles-* is a device global counter, all clients of a device
+ * report the same value, so aggregate by taking the maximum. */
+static void update_machine_gpu_total_cycles(LinuxProcessTable* lpt, unsigned long long int totalCycles, const char* engine, size_t engine_len) {
+   GPUEngineData* engineData = get_machine_gpu_engine(lpt, engine, engine_len);
+
+   if (totalCycles > engineData->curTotalCycles)
+      engineData->curTotalCycles = totalCycles;
+}
+
+static bool count_section(enum section_state* sstate, ClientID client_id, const char* pdev, const ClientInfo* parsed_ids) {
+   if (*sstate == SECST_UNKNOWN) {
+      if (client_id != INVALID_CLIENT_ID && !is_duplicate_client(parsed_ids, client_id, pdev))
+         *sstate = SECST_NEW;
+      else
+         *sstate = SECST_DUPLICATE;
+   }
+
+   return *sstate == SECST_NEW;
+}
+
+/*
+ * Parses a "<prefix><engine>: <value><unit>" line, e.g. "engine-rcs: 1234 ns".
+ * An empty unit requires the value to be the last item on the line.
+ */
+static bool parse_engine_value(const char* line, const char* prefix, const char* unit,
+                               const char** engine, size_t* engine_len, unsigned long long int* value) {
+   const char* engineStart = line + strlen(prefix);
+
+   const char* delim = strchr(engineStart, ':');
+   if (!delim)
+      return false;
+
+   const char* numStart = delim + 1;
+   while (isspace((unsigned char)*numStart))
+      numStart++;
+
+   /* strtoull() would accept a sign and wrap the result around */
+   if (!isdigit((unsigned char)*numStart))
+      return false;
+
+   char* endptr;
+   errno = 0;
+   unsigned long long int parsed = strtoull(numStart, &endptr, 10);
+   if (errno != 0)
+      return false;
+
+   if (unit[0] ? !String_startsWith(endptr, unit) : *endptr != '\0')
+      return false;
+
+   *engine = engineStart;
+   *engine_len = delim - engineStart;
+   *value = parsed;
+   return true;
 }
 
 /*
@@ -83,6 +152,8 @@ void GPU_readProcessData(LinuxProcessTable* lpt, LinuxProcess* lp, openat_arg_t 
    DIR* fdinfoDir = NULL;
    ClientInfo* parsed_ids = NULL;
    unsigned long long int new_gpu_time = 0;
+   unsigned long long int new_gpu_cycles = 0;
+   unsigned long long int new_gpu_totalCycles = 0;
 
    /* check only if active in last check or last scan was more than 5s ago */
    if (lp->gpu_activityMs != 0 && host->monotonicMs - lp->gpu_activityMs < 5000) {
@@ -170,27 +241,48 @@ void GPU_readProcessData(LinuxProcessTable* lpt, LinuxProcess* lp, openat_arg_t 
             if (sstate == SECST_DUPLICATE)
                continue;
 
-            const char* engineStart = line + strlen("engine-");
-
-            if (String_startsWith(engineStart, "capacity-"))
+            if (String_startsWith(line + strlen("engine-"), "capacity-"))
                continue;
 
-            const char* delim = strchr(line, ':');
-
-            char* endptr;
-            errno = 0;
-            unsigned long long int value = strtoull(delim + 1, &endptr, 10);
-            if (errno == 0 && String_startsWith(endptr, " ns")) {
-               if (sstate == SECST_UNKNOWN) {
-                  if (client_id != INVALID_CLIENT_ID && !is_duplicate_client(parsed_ids, client_id, pdev))
-                     sstate = SECST_NEW;
-                  else
-                     sstate = SECST_DUPLICATE;
-               }
-
-               if (sstate == SECST_NEW) {
+            const char* engine;
+            size_t engine_len;
+            unsigned long long int value;
+            if (parse_engine_value(line, "engine-", " ns", &engine, &engine_len, &value)) {
+               if (count_section(&sstate, client_id, pdev, parsed_ids)) {
                   new_gpu_time += value;
-                  update_machine_gpu(lpt, value, engineStart, delim - engineStart);
+                  update_machine_gpu(lpt, value, engine, engine_len);
+               }
+            }
+         } else if (line[0] == 'c' && String_startsWith(line, "cycles-")) {
+            /* Drivers that cannot provide a nanosecond resolution timestamp
+             * (e.g. Intel Xe) export the busy cycles of an engine together with
+             * the cycles elapsed on that engine. */
+            if (sstate == SECST_DUPLICATE)
+               continue;
+
+            const char* engine;
+            size_t engine_len;
+            unsigned long long int value;
+            if (parse_engine_value(line, "cycles-", "", &engine, &engine_len, &value)) {
+               if (count_section(&sstate, client_id, pdev, parsed_ids)) {
+                  new_gpu_cycles += value;
+                  update_machine_gpu_cycles(lpt, value, engine, engine_len);
+               }
+            }
+         } else if (line[0] == 't' && String_startsWith(line, "total-cycles-")) {
+            if (sstate == SECST_DUPLICATE)
+               continue;
+
+            const char* engine;
+            size_t engine_len;
+            unsigned long long int value;
+            if (parse_engine_value(line, "total-cycles-", "", &engine, &engine_len, &value)) {
+               if (count_section(&sstate, client_id, pdev, parsed_ids)) {
+                  /* The same free running counter is reported for all engines
+                   * of a device, so don't accumulate it. */
+                  if (value > new_gpu_totalCycles)
+                     new_gpu_totalCycles = value;
+                  update_machine_gpu_total_cycles(lpt, value, engine, engine_len);
                }
             }
          }
@@ -213,21 +305,44 @@ void GPU_readProcessData(LinuxProcessTable* lpt, LinuxProcess* lp, openat_arg_t 
       free(pdev);
    } /* finished parsing fdinfo entries */
 
-   if (new_gpu_time > 0) {
-      unsigned long long int gputimeDelta;
-      uint64_t monotonicTimeDelta;
+   {
+      uint64_t monotonicTimeDelta = host->monotonicMs - host->prevMonotonicMs;
+      unsigned long long int gputimeDelta = saturatingSub(new_gpu_time, lp->gpu_timeRaw);
 
-      gputimeDelta = saturatingSub(new_gpu_time, lp->gpu_time);
-      monotonicTimeDelta = host->monotonicMs - host->prevMonotonicMs;
-      lp->gpu_percent = 100.0F * gputimeDelta / (1000 * 1000) / monotonicTimeDelta;
+      /* Cycle based accounting only yields a ratio of busy to elapsed cycles,
+       * which is turned into a busy time using the sampling interval. */
+      unsigned long long int cyclesDelta = saturatingSub(new_gpu_cycles, lp->gpu_cycles);
+      unsigned long long int totalCyclesDelta = lp->gpu_totalCycles ? saturatingSub(new_gpu_totalCycles, lp->gpu_totalCycles) : 0;
+      if (cyclesDelta > 0 && totalCyclesDelta > 0)
+         gputimeDelta += (unsigned long long int)((double)cyclesDelta / totalCyclesDelta * monotonicTimeDelta * (1000 * 1000));
 
-      lp->gpu_activityMs = 0;
-   } else
-      lp->gpu_percent = 0.0F;
+      if (gputimeDelta > 0 && monotonicTimeDelta > 0) {
+         lp->gpu_time += gputimeDelta;
+         lp->gpu_percent = 100.0F * gputimeDelta / (1000 * 1000) / monotonicTimeDelta;
+      } else {
+         lp->gpu_percent = 0.0F;
+      }
+
+      /* Keep visiting a process as long as it holds a counter, even while it is
+       * idle: the machine wide totals are summed up from the counters of the
+       * processes seen in this pass, so skipping one makes the sum drop. */
+      if (new_gpu_time > 0 || new_gpu_cycles > 0)
+         lp->gpu_activityMs = 0;
+
+      lp->gpu_timeRaw = new_gpu_time;
+      lp->gpu_cycles = new_gpu_cycles;
+      lp->gpu_totalCycles = new_gpu_totalCycles;
+   }
+
+   goto cleanup;
 
 out:
+   /* Hold on to the counters of the last successful read: failing to look at a
+    * process is not the same as it having released the GPU, and starting over
+    * from zero would account for the whole counter a second time. */
+   lp->gpu_percent = 0.0F;
 
-   lp->gpu_time = new_gpu_time;
+cleanup:
 
    while (parsed_ids) {
       ClientInfo* next = parsed_ids->next;

--- a/linux/LinuxMachine.h
+++ b/linux/LinuxMachine.h
@@ -61,7 +61,9 @@ typedef struct CPUData_ {
 } CPUData;
 
 typedef struct GPUEngineData_ {
-   unsigned long long int prevTime, curTime;  /* absolute GPU time in nano seconds */
+   unsigned long long int prevTime, curTime;              /* absolute GPU time in nano seconds (drm-engine-*) */
+   unsigned long long int prevCycles, curCycles;          /* absolute busy cycles (drm-cycles-*) */
+   unsigned long long int prevTotalCycles, curTotalCycles; /* absolute elapsed cycles (drm-total-cycles-*) */
    char* key;                                 /* engine name */
    struct GPUEngineData_* next;
 } GPUEngineData;

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -102,6 +102,12 @@ typedef struct LinuxProcess_ {
 
    /* Total GPU time used in nano seconds */
    unsigned long long int gpu_time;
+   /* Last raw sum of the drm-engine-* counters in nano seconds */
+   unsigned long long int gpu_timeRaw;
+   /* Last raw sum of the drm-cycles-* counters */
+   unsigned long long int gpu_cycles;
+   /* Last raw value of the drm-total-cycles-* counters */
+   unsigned long long int gpu_totalCycles;
    /* GPU utilization in percent */
    float gpu_percent;
    /* Activity of GPU: 0 if active, otherwise time of last scan in milliseconds */

--- a/linux/LinuxProcessTable.c
+++ b/linux/LinuxProcessTable.c
@@ -1859,6 +1859,10 @@ void ProcessTable_goThroughEntries(ProcessTable* super) {
       for (GPUEngineData* engine = lhost->gpuEngineData; engine; engine = engine->next) {
          engine->prevTime = engine->curTime;
          engine->curTime = 0;
+         engine->prevCycles = engine->curCycles;
+         engine->curCycles = 0;
+         engine->prevTotalCycles = engine->curTotalCycles;
+         engine->curTotalCycles = 0;
       }
    }
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -405,32 +405,50 @@ void Platform_setGPUValues(Meter* this, double* totalUsage, unsigned long long* 
 
    static uint64_t prevMonotonicMs;
    static double residuePercentage;
-   static unsigned long long int prevResidueTime;
 
    // The results are cached so that we can update values of multiple meter
    // instances. We also need a local cache of the monotonic timestamp, thus we
    // don't use host->prevMonotonicMs.
-   if (host->monotonicMs > prevMonotonicMs) {
+   if (prevMonotonicMs == 0) {
+      // First call, there's no sampling interval to relate the counters to yet
+      prevMonotonicMs = host->monotonicMs;
+   } else if (host->monotonicMs > prevMonotonicMs) {
       uint64_t monotonictimeDelta = host->monotonicMs - prevMonotonicMs;
 
-      unsigned long long int curResidueTime = lhost->curGpuTime;
+      unsigned long long int totalTimeDiff = saturatingSub(lhost->curGpuTime, lhost->prevGpuTime);
+      unsigned long long int namedTimeDiff = 0;
 
       const GPUEngineData* gpuEngineData;
       size_t i;
-      for (gpuEngineData = lhost->gpuEngineData, i = 0; gpuEngineData && i < ARRAYSIZE(GPUMeter_engineData); gpuEngineData = gpuEngineData->next, i++) {
-         GPUMeter_engineData[i].key        = gpuEngineData->key;
-         GPUMeter_engineData[i].timeDiff   = saturatingSub(gpuEngineData->curTime, gpuEngineData->prevTime);
-         GPUMeter_engineData[i].percentage = 100.0 * GPUMeter_engineData[i].timeDiff / (1000 * 1000) / monotonictimeDelta;
+      for (gpuEngineData = lhost->gpuEngineData, i = 0; gpuEngineData; gpuEngineData = gpuEngineData->next, i++) {
+         unsigned long long int timeDiff = saturatingSub(gpuEngineData->curTime, gpuEngineData->prevTime);
 
-         curResidueTime = saturatingSub(curResidueTime, gpuEngineData->curTime);
+         // Drivers reporting cycles instead of nanoseconds (e.g. Intel Xe) only
+         // provide a ratio of busy to elapsed cycles; scale it to the sampling
+         // interval to get a comparable busy time.
+         unsigned long long int totalCyclesDiff = gpuEngineData->prevTotalCycles ? saturatingSub(gpuEngineData->curTotalCycles, gpuEngineData->prevTotalCycles) : 0;
+         if (totalCyclesDiff > 0) {
+            unsigned long long int cyclesDiff = saturatingSub(gpuEngineData->curCycles, gpuEngineData->prevCycles);
+            unsigned long long int cyclesTime = (unsigned long long int)((double)cyclesDiff / totalCyclesDiff * monotonictimeDelta * (1000 * 1000));
+
+            timeDiff += cyclesTime;
+            totalTimeDiff += cyclesTime;
+         }
+
+         if (i < ARRAYSIZE(GPUMeter_engineData)) {
+            GPUMeter_engineData[i].key        = gpuEngineData->key;
+            GPUMeter_engineData[i].timeDiff   = timeDiff;
+            GPUMeter_engineData[i].percentage = 100.0 * timeDiff / (1000 * 1000) / monotonictimeDelta;
+
+            namedTimeDiff += timeDiff;
+         }
       }
 
-      residuePercentage = 100.0 * saturatingSub(curResidueTime, prevResidueTime) / (1000 * 1000) / monotonictimeDelta;
+      residuePercentage = 100.0 * saturatingSub(totalTimeDiff, namedTimeDiff) / (1000 * 1000) / monotonictimeDelta;
 
-      *totalGPUTimeDiff = saturatingSub(lhost->curGpuTime, lhost->prevGpuTime);
-      *totalUsage = 100.0 * (*totalGPUTimeDiff) / (1000 * 1000) / monotonictimeDelta;
+      *totalGPUTimeDiff = totalTimeDiff;
+      *totalUsage = 100.0 * totalTimeDiff / (1000 * 1000) / monotonictimeDelta;
 
-      prevResidueTime = curResidueTime;
       prevMonotonicMs = host->monotonicMs;
    }
 


### PR DESCRIPTION
On my Lunar Lake laptop (Arc 140V, `xe` driver) the GPU meter and the GPU columns
are stuck at `0.0%` no matter what the GPU is doing, while nvtop and gputop show
it pegged.

The reason is that [drm-usage-stats](https://www.kernel.org/doc/html/latest/gpu/drm-usage-stats.html)
allows two ways of reporting engine utilisation:

* `drm-engine-<engine>: <uint> ns` - busy time in nanoseconds
* `drm-cycles-<engine>` plus `drm-total-cycles-<engine>` - busy cycles and
  elapsed cycles, whose ratio is the utilisation

We only parse the first one, and the Xe driver only implements the second one.
There is not a single `drm-engine-*` line to be found:

```
$ grep drm- /proc/$(pidof glxgears)/fdinfo/*
drm-driver:xe
drm-client-id:607
drm-pdev:0000:00:02.0
...
drm-cycles-rcs:29821070
drm-total-cycles-rcs:5044293186233
drm-cycles-ccs:571
drm-total-cycles-ccs:5044293186233
...
```

Since Xe is what recent Intel hardware gets by default, this will affect more
and more machines. `intel_gpu_top` has the same problem, it refuses to start and
tells you to use `gputop` instead.

### What the patch does

`GPU.c` now also parses `drm-cycles-*` and `drm-total-cycles-*`, reusing the
existing client-id/pdev deduplication. Utilisation is `Δcycles / Δtotal-cycles`,
scaled with the sampling interval so it can be added up together with the
nanosecond values everywhere else. Doing it as a ratio means there is no need to
know the GPU clock, which is good, because on this machine it swings between
400 MHz and 1950 MHz while sampling.

`drm-total-cycles` is a device wide free running counter that every client
repeats, so it is aggregated with max instead of sum, both per process and per
engine.

Because the raw counters are no longer always nanoseconds, `LinuxProcess` keeps
them separately (`gpu_timeRaw`, `gpu_cycles`, `gpu_totalCycles`) and `gpu_time`
accumulates the observed busy time. For `drm-engine-*` drivers the accumulated
value comes out the same as the old absolute one, except it no longer goes
backwards when a client closes its fds.

Two things in `Platform.c` that got in the way and are fixed here as well: the
meter residue is now derived from the per engine deltas instead of a second
absolute counter, and the first sample is skipped because there is no interval
to divide by yet. That first sample used to display things like `20679d` of GPU
time.

I also pulled the line parsing and the duplicate client bookkeeping into two
small helpers, they were about to be written a third time.

### Testing

One machine per reporting style.

**Arc 140V, `xe`, cycle counters**, compared against `gputop` from
igt-gpu-tools:

```
workload                    htop GPU%   gputop
glxgears (rcs)               46.9 %     47.1 %
compute benchmark (ccs)      99.9 %    100.0 %
idle                          0.0 %      0.0 %
```

With glxgears running, the meter total of 85.6-86.4 % matches gputop adding up
its clients for the same period (Xorg 40.3 % + glxgears 45.3 % + picom 1.7 %).

**Radeon 8060S (Strix Halo), `amdgpu`, nanosecond counters**, to check that the
existing path did not move. Two glmark2 processes rendering off-screen at
1920x1080, `gpu_busy_percent` pinned at 100 %, one sample per second, this
branch next to the same tree without the patch:

```
this branch   96.6 101.4  99.2 100.4 101.4  98.6  99.5 100.6  99.7 101.9  98.0 ...
main          96.7 100.9  99.9  99.6 102.0  97.8 100.8  99.5  99.7 102.6  97.9 ...
```

Per process both glmark2 clients read ~49 % in either build, while an
independent aggregation of the fdinfo counters says 50.08 % and 49.92 %. Killing
the load gives a flat 0.00 % for as long as I watched it.

Builds clean with `-Wall -Wextra` on both machines, and with `--enable-debug`,
where no assertion fired during the runs. Still untested on NVIDIA.

### Two things I noticed but did not touch

`GPUMeter_engineData` holds four engines while Xe exposes five (`rcs`, `vcs`,
`vecs`, `bcs`, `ccs`), so the fifth one always lands in the residue. On this
laptop compute work goes to `ccs`, which means the named bars stay empty while
the total is right. Bumping the array is easy, but it needs a fifth colour and I
did not want to mix that in here.

A process with fds on two devices whose `drm-total-cycles` counters differ will
be slightly off, as only one reference counter is kept per process. That is the
same kind of conflation as #1657.
