### PR TITLE
Set the terminal window title to the program name

### DIFF
--- a/CRT.c
+++ b/CRT.c
@@ -951,6 +951,8 @@ static int CRT_colorSchemes[LAST_COLORSCHEME][LAST_COLORELEMENT] = {
 
 static bool CRT_retainScreenOnExit = false;
 
+static bool CRT_terminalTitleSet = false;
+
 int CRT_scrollHAmount = 5;
 
 int CRT_scrollWheelVAmount = 10;
@@ -1176,6 +1178,56 @@ static bool terminalSupportsDefinedKeys(const char* termType) {
    return false;
 }
 
+/* Terminals known to understand the XTerm OSC sequence that sets the window
+   title, as well as the CSI window title stack used to restore it on exit. */
+static bool terminalSupportsWindowTitle(const char* termType) {
+   static const char* const knownTerms[] = {
+      "Eterm", "alacritty", "contour", "foot", "gnome", "kitty", "konsole",
+      "mlterm", "putty", "rxvt", "screen", "st", "tmux", "vte", "wezterm",
+      "xterm",
+   };
+
+   if (!termType) {
+      return false;
+   }
+
+   for (size_t i = 0; i < ARRAYSIZE(knownTerms); i++) {
+      if (!String_startsWith(termType, knownTerms[i]))
+         continue;
+
+      /* TERM names join their components with '-' or '.', as in "screen.xterm-256color" */
+      char next = termType[strlen(knownTerms[i])];
+      if (next == '\0' || next == '-' || next == '.')
+         return true;
+   }
+
+   return false;
+}
+
+/* Push the current window title onto the terminal's title stack and replace it
+   with our own, so that the shell's title does not linger while htop runs. */
+static void CRT_setTerminalTitle(const char* title) {
+   if (!terminalSupportsWindowTitle(getenv("TERM"))) {
+      return;
+   }
+
+   printf("\033[22;0t\033]0;%s\007", title);
+   fflush(stdout);
+
+   CRT_terminalTitleSet = true;
+}
+
+static void CRT_restoreTerminalTitle(void) {
+   if (!CRT_terminalTitleSet) {
+      return;
+   }
+
+   CRT_terminalTitleSet = false;
+
+   fputs("\033[23;0t", stdout);
+   fflush(stdout);
+}
+
 void CRT_init(const Settings* settings, bool allowUnicode, bool retainScreenOnExit) {
    initscr();
 
@@ -1269,6 +1321,8 @@ IGNORE_WCASTQUAL_END
       define_key("\033\033[B", KEY_SF); // SF = scroll forward, Alt-DOWN
    }
 
+   CRT_setTerminalTitle(program);
+
    CRT_installSignalHandlers();
 
    use_default_colors();
@@ -1310,6 +1364,8 @@ void CRT_done(void) {
 
    curs_set(1);
    endwin();
+
+   CRT_restoreTerminalTitle();
 
    dumpStderr();
 }


### PR DESCRIPTION
Closes #2070.

### What

htop never set the terminal window title, so a terminal tab running htop kept
showing whatever the shell had put there, typically `user@host: /some/path`,
which makes the htop tab hard to pick out among several open tabs.

This sets the title to the program name on startup and restores the previous
title on exit.

### How

* `CRT_setTerminalTitle()` pushes the current title onto the XTerm window title
  stack (`CSI 22;0t`) and then sets ours (`OSC 0 ; <title> BEL`).
* `CRT_restoreTerminalTitle()` pops it back (`CSI 23;0t`) from `CRT_done()`,
  after `endwin()`. It is guarded by a flag, so the repeated `CRT_done()` calls
  on the signal/fatal-error paths are harmless.
* The title is the existing `program` global, so the PCP build announces itself
  as `pcp-htop` rather than `htop`.

### Why a TERM allowlist instead of terminfo

The natural approach would be the `hs`/`tsl`/`fsl` status-line capabilities, but
the ncurses entries for the terminals people actually use do not carry them:

```
$ infocmp -1 xterm-256color | grep -E '^\s+(hs|tsl|fsl)'   # no output
$ infocmp -1 screen         | grep -E '^\s+(hs|tsl|fsl)'   # no output
```

even though all of those terminals do honour the OSC title sequence. So the
patch uses a `TERM`-name allowlist, in the same spirit as the existing
`terminalSupportsDefinedKeys()`, which leaves terminals that would echo the
escape sequence as garbage (`linux`, `vt100`, `dumb`, …) untouched. Prefixes are
matched up to a `-` or `.` separator so composite names such as
`screen.xterm-256color` are recognised.

### Testing

Verified the `TERM` matcher against the positive set (`xterm`,
`xterm-256color`, `gnome-256color`, `screen`, `screen.xterm-256color`,
`tmux-256color`, `alacritty`, `st-256color`, `rxvt-unicode-256color`, `foot`,
`konsole-256color`, `vte-256color`, `wezterm`, `Eterm`, `kitty`, `xterm-kitty`)
and the negative set (`linux`, `vt100`, `vt220`, `dumb`, `ansi`, `cons25`,
`sun-color`, `""`, `NULL`, plus near-misses like `xtermfoo` and `stterm`).
