### PR TITLE
darwin: order the memory classes so the used ones come first

### DIFF
--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -114,20 +114,22 @@ const SignalItem Platform_signals[] = {
 const unsigned int Platform_numberOfSignals = ARRAYSIZE(Platform_signals);
 
 enum {
+   // classes that count as used come first, so the chart draws them
+   // contiguously from the left-hand edge
    MEMORY_CLASS_WIRED = 0,
-   MEMORY_CLASS_SPECULATIVE,
    MEMORY_CLASS_ACTIVE,
-   MEMORY_CLASS_PURGEABLE,
    MEMORY_CLASS_COMPRESSED,
+   MEMORY_CLASS_SPECULATIVE,
+   MEMORY_CLASS_PURGEABLE,
    MEMORY_CLASS_INACTIVE,
 }; // N.B. the chart will display categories in this order
 
 const MemoryClass Platform_memoryClasses[] = {
-    [MEMORY_CLASS_WIRED] = { .label = "wired", .countsAsUsed = true, .countsAsCache = false, .color = MEMORY_1 }, // pages wired down to physical memory (kernel)
-   [MEMORY_CLASS_SPECULATIVE] = { .label = "speculative", .countsAsUsed = false, .countsAsCache = true, .color = MEMORY_2 }, // readahead optimization caches
-   [MEMORY_CLASS_ACTIVE] = { .label = "active", .countsAsUsed = true, .countsAsCache = false, .color = MEMORY_3 }, // userland pages actively being used
-   [MEMORY_CLASS_PURGEABLE] = { .label = "purgeable", .countsAsUsed = false, .countsAsCache = true, .color = MEMORY_4 }, // userland pages voluntarily marked "discardable" by apps
-   [MEMORY_CLASS_COMPRESSED] = { .label = "compressed", .countsAsUsed = true, .countsAsCache = false, .color = MEMORY_5 }, // userland pages being compressed (means memory pressure++)
+   [MEMORY_CLASS_WIRED] = { .label = "wired", .countsAsUsed = true, .countsAsCache = false, .color = MEMORY_1 }, // pages wired down to physical memory (kernel)
+   [MEMORY_CLASS_ACTIVE] = { .label = "active", .countsAsUsed = true, .countsAsCache = false, .color = MEMORY_2 }, // userland pages actively being used
+   [MEMORY_CLASS_COMPRESSED] = { .label = "compressed", .countsAsUsed = true, .countsAsCache = false, .color = MEMORY_3 }, // userland pages being compressed (means memory pressure++)
+   [MEMORY_CLASS_SPECULATIVE] = { .label = "speculative", .countsAsUsed = false, .countsAsCache = true, .color = MEMORY_4 }, // readahead optimization caches
+   [MEMORY_CLASS_PURGEABLE] = { .label = "purgeable", .countsAsUsed = false, .countsAsCache = true, .color = MEMORY_5 }, // userland pages voluntarily marked "discardable" by apps
    [MEMORY_CLASS_INACTIVE] = { .label = "inactive", .countsAsUsed = false, .countsAsCache = true, .color = MEMORY_6 }, // pages no longer actively referenced
 };
 


### PR DESCRIPTION
Closes #2073.

`darwin/Platform.c` is the only platform whose `Platform_memoryClasses[]` interleaves the classes that count as used with the ones that count as cache, so `speculative` and `purgeable` are drawn between `wired`, `active` and `compressed`. The used total the meter prints is the sum of the `countsAsUsed` classes and is correct; it just does not correspond to a contiguous run of bars from the left-hand edge, which is what the FAQ describes. The cross-platform table is in the triage comment on the issue.

This reorders the enum so the three used classes come first, keeping the relative order inside each group.

### The colours had to move with them

`.color` is not the only thing that decides a segment's colour, which was not obvious to me until I looked at the two render paths:

- `MemoryMeter_display()` (text mode) colours each value with `Platform_memoryClasses[i].color`.
- `BarMeterMode_draw()` (`Meter.c:181`) colours segment `i` with `Meter_attributes(this)[i]`, which for this meter is `MemoryMeter_attributes[]` = `MEMORY_1 .. MEMORY_6` **by position**, and never looks at `.color`.

Every platform currently keeps `.color` in step with the array position, so the two paths agree and the difference is invisible. That means "reorder the classes but let every label keep the colour it has today" is not actually on the table: bar mode would recolour by position anyway while text mode would not, and the two modes would then disagree about what colour `speculative` is. So `.color` moves with the class and stays in `MEMORY_1 .. MEMORY_6` sequence, which keeps the existing invariant.

With the default colour scheme that means, in both modes:

| class | before | after |
|---|---|---|
| wired | green | green |
| active | bold gray | magenta |
| compressed | yellow | bold gray |
| speculative | magenta | bold blue |
| purgeable | bold blue | yellow |
| inactive | cyan | cyan |

If you would rather nothing changed colour, the alternative is to make bar/graph/LED mode honour `.color` instead of the positional `MemoryMeter_attributes[]`. That is a change to shared meter code rather than to this platform, so I have not done it here, but say the word and I will.

### Verification

Built from `main` (`6f33ddd`) and from this branch on a MacBookPro12,1 running macOS 12.7.6, captured back to back. Not an M-series machine, so #2073 is not Apple Silicon specific.

Text mode:

```
before  Mem:16.0G wired:1.45G speculative:1.33G active:2.99G purgeable:181M compressed:0K inactive:3.96G
after   Mem:16.0G wired:1.45G active:3.00G compressed:0K speculative:1.33G purgeable:181M inactive:3.96G
```

Bar mode, with the SGR runs decoded so the class behind each segment is visible (`compressed` is 0K on this machine, so it has zero width in both):

```
before  Mem[ wired ×5 | speculative ×4 | active ×9 | purgeable ×1 | inactive ×12    4.48G/16.0G]
after   Mem[ wired ×5 | active ×10 | speculative ×4 | purgeable ×1 | inactive ×12   4.51G/16.0G]
```

so the used classes are one contiguous run from the left edge afterwards, and the text and bar modes agree on every class's colour in both builds.

### Not touched

`pcp/Platform.c` carries a second Darwin table (`Darwin_memoryClasses[]`, memcpy'd into `Platform_memoryClasses` when the PCP target reports `Darwin`) with the same interleaving. I left it alone because its flags disagree with this file, `speculative` and `inactive` are `countsAsUsed = true` there, so "used first" does not mean the same thing, and I have no PCP Darwin host to test against. Happy to follow up if you want it aligned.
