### PR TITLE
Vector: use size_t for count comparison

### DIFF
--- a/Vector.c
+++ b/Vector.c
@@ -54,8 +54,8 @@ static bool Vector_isConsistent(const Vector* this) {
    return true;
 }
 
-bool Vector_countEquals(const Vector* this, unsigned int expectedCount) {
-   unsigned int n = 0;
+bool Vector_countEquals(const Vector* this, size_t expectedCount) {
+   size_t n = 0;
    for (int i = 0; i < this->items; i++) {
       if (this->array[i]) {
          n++;

--- a/Vector.h
+++ b/Vector.h
@@ -71,7 +71,7 @@ int Vector_size(const Vector* this);
 /* Vector_countEquals returns true if the number of non-NULL items
    in the Vector is equal to expectedCount. This is only for debugging
    and consistency checks. */
-bool Vector_countEquals(const Vector* this, unsigned int expectedCount);
+bool Vector_countEquals(const Vector* this, size_t expectedCount);
 
 #else /* NDEBUG */
 


### PR DESCRIPTION
`Hashtable_count()` returns `size_t`, while `Vector_countEquals()` accepts an `unsigned int`. In debug builds, calls from `Table.c` therefore trigger `-Wshorten-64-to-32` with Clang.

Use `size_t` for both the `expectedCount` parameter and the internal counter in `Vector_countEquals()`.

Follow-up to #1673, which tracked `-Wshorten-64-to-32` warnings and related integer type mismatches

Tested with a debug build using Clang and:

    -Wshorten-64-to-32 -Werror

The full build completes without warnings