### PR TITLE
CRT: fix invisible gray color on direct-color terminals

### DIFF
--- a/CRT.c
+++ b/CRT.c
@@ -1356,9 +1356,18 @@ void CRT_setColors(int colorScheme) {
       }
    }
 
-   short int grayBlackFg = COLORS > 8 ? 8 : 0;
-   short int grayBlackBg = (colorScheme != COLORSCHEME_BLACKNIGHT) ? -1 : 0;
-   init_pair(ColorIndexGrayBlack, grayBlackFg, grayBlackBg);
+#if defined(HAVE_INIT_EXTENDED_PAIR)
+   if (COLORS >= 16777216) {
+      int grayBlackBg = (colorScheme != COLORSCHEME_BLACKNIGHT) ? -1 : 0;
+      int grayBlackFg = (colorScheme == COLORSCHEME_LIGHTTERMINAL) ? 0x5F5F5F : 0x949494;
+      init_extended_pair(ColorIndexGrayBlack, grayBlackFg, grayBlackBg);
+   } else
+#endif
+   {
+      short int grayBlackFg = COLORS > 8 ? 8 : 0;
+      short int grayBlackBg = (colorScheme != COLORSCHEME_BLACKNIGHT) ? -1 : 0;
+      init_pair(ColorIndexGrayBlack, grayBlackFg, grayBlackBg);
+   }
 
    init_pair(ColorIndexWhiteDefault, White, -1);
 

--- a/configure.ac
+++ b/configure.ac
@@ -884,6 +884,7 @@ if test "$my_htop_platform" = "solaris"; then
 fi
 AC_CHECK_FUNCS([set_escdelay])
 AC_CHECK_FUNCS([getmouse])
+AC_CHECK_FUNCS([init_extended_pair])
 AC_DEFINE([NCURSES_ENABLE_STDBOOL_H], [1], [Define to enable stdbool.h in ncurses])
 
 


### PR DESCRIPTION
This PR fixes the issue where gray elements render as `RGB(0,0,8)` (effectively black) on direct-color terminals, causing them to disappear against a black background.

## Changes

* Replaced the legacy `init_pair` fallback for `ColorIndexGrayBlack` with `init_extended_pair` when `COLORS >= 16777216`. This makes the fix completely independent.
* Passed `0x949494` (a highly visible 24-bit light gray) instead of the index `8`.
* Wrapped the extended API calls in preprocessor directives to ensure compatibility with older `ncurses` builds.

## Visual Changes

* **Before:** Gray elements (like bar shadows, memory cache lines, and process threads in standard schemes) were rendered as `RGB(0,0,8)`, making them virtually invisible.
* **After:** Elements now render correctly in a clear light gray (`0x949494`), restoring high contrast and readability for standard schemes on `-direct` terminals.

<img width="2560" height="1440" alt="gray_fix" src="https://github.com/user-attachments/assets/1e39fbd8-168d-4f67-8f04-a95bb1c06c88" />

Fixes #2078