### PR TITLE
pcp: correct the Linux memory classes and the used memory total

### DIFF
--- a/pcp/PCPMachine.c
+++ b/pcp/PCPMachine.c
@@ -129,7 +129,7 @@ static void PCPMachine_updateDarwinMemoryInfo(PCPMachine* this, Settings* settin
    }
 
    if (Metric_values(PCP_MEM_COMPRESSED, &value, 1, PM_TYPE_U64) != NULL)
-      this->memValue[MEMORY_CLASS_COMPRESSED] = value.ull;
+      this->memValue[MEMORY_CLASS_DARWIN_COMPRESSED] = value.ull;
    if (Metric_values(PCP_MEM_INACTIVE, &value, 1, PM_TYPE_U64) != NULL)
       this->memValue[MEMORY_CLASS_INACTIVE] = value.ull;
 

--- a/pcp/PCPMachine.c
+++ b/pcp/PCPMachine.c
@@ -66,6 +66,7 @@ static void PCPMachine_updateLinuxMemoryInfo(PCPMachine* this) {
    unsigned long long int freeMem = 0;
    unsigned long long int swapFreeMem = 0;
    unsigned long long int sreclaimableMem = 0;
+   unsigned long long int cachedMem = 0;
 
    pmAtomValue value;
    if (Metric_values(PCP_MEM_FREE, &value, 1, PM_TYPE_U64) != NULL)
@@ -76,9 +77,16 @@ static void PCPMachine_updateLinuxMemoryInfo(PCPMachine* this) {
       sreclaimableMem = value.ull;
    if (Metric_values(PCP_MEM_SHARED, &value, 1, PM_TYPE_U64) != NULL)
       this->memValue[MEMORY_CLASS_SHARED] = value.ull;
-   if (Metric_values(PCP_MEM_CACHED, &value, 1, PM_TYPE_U64) != NULL)
-      this->memValue[MEMORY_CLASS_CACHE] = value.ull + sreclaimableMem - this->memValue[MEMORY_CLASS_SHARED];
-   const memory_t usedDiff = freeMem + this->memValue[MEMORY_CLASS_CACHE] + sreclaimableMem + this->memValue[MEMORY_CLASS_BUFFERS];
+   /*
+    * Shmem is part of Cached (see https://lore.kernel.org/patchwork/patch/648763/),
+    * so subtract it from the figure the meter shows, but keep using the raw
+    * Cached below so that it is not subtracted from used a second time.
+    */
+   if (Metric_values(PCP_MEM_CACHED, &value, 1, PM_TYPE_U64) != NULL) {
+      cachedMem = value.ull;
+      this->memValue[MEMORY_CLASS_CACHE] = cachedMem + sreclaimableMem - this->memValue[MEMORY_CLASS_SHARED];
+   }
+   const memory_t usedDiff = freeMem + cachedMem + sreclaimableMem + this->memValue[MEMORY_CLASS_BUFFERS];
    this->memValue[MEMORY_CLASS_USED] = (super->totalMem >= usedDiff) ?
            super->totalMem - usedDiff : super->totalMem - freeMem;
    if (Metric_values(PCP_MEM_AVAILABLE, &value, 1, PM_TYPE_U64) != NULL)

--- a/pcp/PCPMachine.h
+++ b/pcp/PCPMachine.h
@@ -54,18 +54,20 @@ typedef enum CPUMetric_ {
 } CPUMetric;
 
 typedef enum MemoryMetric_ {
-   // Linux
+   // Linux, in the same order as linux/Platform.c
    MEMORY_CLASS_USED = 0,
    MEMORY_CLASS_SHARED = 1,
-   MEMORY_CLASS_BUFFERS = 2,
-   MEMORY_CLASS_CACHE = 3,
-   MEMORY_CLASS_COMPRESSED = 4,
+   MEMORY_CLASS_COMPRESSED = 2,
+   MEMORY_CLASS_BUFFERS = 3,
+   MEMORY_CLASS_CACHE = 4,
    MEMORY_CLASS_AVAILABLE = 5,
-   // Darwin
+   // Darwin, in the same order as darwin/Platform.c; the compressed class
+   // needs its own name because it sits at a different index to the Linux one
    MEMORY_CLASS_WIRED = 0,
    MEMORY_CLASS_SPECULATIVE = 1,
    MEMORY_CLASS_ACTIVE = 2,
    MEMORY_CLASS_PURGEABLE = 3,
+   MEMORY_CLASS_DARWIN_COMPRESSED = 4,
    MEMORY_CLASS_INACTIVE = 5,
    // Maximum
    MEMORY_CLASS_LIMIT = 6

--- a/pcp/Platform.c
+++ b/pcp/Platform.c
@@ -80,9 +80,9 @@ const unsigned int Platform_numberOfSignals = ARRAYSIZE(Platform_signals);
 static const MemoryClass Linux_memoryClasses[] = {
    [MEMORY_CLASS_USED] = { .label = "used", .countsAsUsed = true, .countsAsCache = false, .color = MEMORY_1 },
    [MEMORY_CLASS_SHARED] = { .label = "shared", .countsAsUsed = true, .countsAsCache = false, .color = MEMORY_2 },
-   [MEMORY_CLASS_BUFFERS] = { .label = "compressed", .countsAsUsed = true, .countsAsCache = false, .color = MEMORY_3 },
-   [MEMORY_CLASS_CACHE] = { .label = "buffers", .countsAsUsed = false, .countsAsCache = false, .color = MEMORY_4 },
-   [MEMORY_CLASS_COMPRESSED] = { .label = "cache", .countsAsUsed = false, .countsAsCache = false, .color = MEMORY_5 },
+   [MEMORY_CLASS_COMPRESSED] = { .label = "compressed", .countsAsUsed = true, .countsAsCache = false, .color = MEMORY_3 },
+   [MEMORY_CLASS_BUFFERS] = { .label = "buffers", .countsAsUsed = false, .countsAsCache = true, .color = MEMORY_4 },
+   [MEMORY_CLASS_CACHE] = { .label = "cache", .countsAsUsed = false, .countsAsCache = true, .color = MEMORY_5 },
    [MEMORY_CLASS_AVAILABLE] = { .label = "available", .countsAsUsed = false, .countsAsCache = false, .color = MEMORY_6 },
 };
 
@@ -91,7 +91,7 @@ static const MemoryClass Darwin_memoryClasses[] = {
    [MEMORY_CLASS_SPECULATIVE] = { .label = "speculative", .countsAsUsed = true, .countsAsCache = true, .color = MEMORY_2 },
    [MEMORY_CLASS_ACTIVE] = { .label = "active", .countsAsUsed = true, .countsAsCache = false, .color = MEMORY_3 },
    [MEMORY_CLASS_PURGEABLE] = { .label = "purgeable", .countsAsUsed = false, .countsAsCache = true, .color = MEMORY_4 },
-   [MEMORY_CLASS_COMPRESSED] = { .label = "compressed", .countsAsUsed = true, .countsAsCache = false, .color = MEMORY_5 },
+   [MEMORY_CLASS_DARWIN_COMPRESSED] = { .label = "compressed", .countsAsUsed = true, .countsAsCache = false, .color = MEMORY_5 },
    [MEMORY_CLASS_INACTIVE] = { .label = "inactive", .countsAsUsed = true, .countsAsCache = true, .color = MEMORY_6 },
 };
 
@@ -631,7 +631,7 @@ static void Platform_setDarwinMemoryValues(double* v, const PCPMachine *host) {
    v[MEMORY_CLASS_SPECULATIVE] = host->memValue[MEMORY_CLASS_SPECULATIVE];
    v[MEMORY_CLASS_ACTIVE] = host->memValue[MEMORY_CLASS_ACTIVE];
    v[MEMORY_CLASS_PURGEABLE] = host->memValue[MEMORY_CLASS_PURGEABLE];
-   v[MEMORY_CLASS_COMPRESSED] = host->memValue[MEMORY_CLASS_COMPRESSED];
+   v[MEMORY_CLASS_DARWIN_COMPRESSED] = host->memValue[MEMORY_CLASS_DARWIN_COMPRESSED];
    v[MEMORY_CLASS_INACTIVE] = host->memValue[MEMORY_CLASS_INACTIVE];
 }
 


### PR DESCRIPTION
Fixes the two defects in `pcp/` reported in #2075. Two commits, one per defect, since they are independent and the second survives a fix for the first.

Closes #2075

@natoscott, taking you up on the enum reorder. All the measurements below are on PCP 7.2.0, using the tip you gave me on the issue: no `pmcd`, the `linux` PMDA attached as a DSO through the local context.

## 1. The memory classes were rotated by one slot

`pcp/Platform.c` carries a copy of the Linux memory class table from `linux/Platform.c`, but the `MEMORY_CLASS_*` enum it is keyed on lists the classes in a different order:

```
native   used shared compressed buffers cache      available
pcp      used shared buffers    cache   compressed available
```

The table was copied entry for entry, so the designated initialisers attach the native sequence of labels and flags to the pcp sequence of names, and the last four come out rotated.

The flags rotate with the labels, which is the more serious half. The slot holding the buffers figure inherits `countsAsUsed` from the native compressed class, so buffers is drawn as used memory; the page cache and zswap slots end up carrying neither `countsAsUsed` nor `countsAsCache`, so `MemoryMeter_updateValues()` sets them to `NAN` and the page cache is not drawn at all.

The fix reorders the enum to match the native one and keys each table entry to its own label, which leaves the two tables identical. Darwin shares the enum and keeps its own order, so its compressed class needs a name of its own.

## 2. `SReclaimable` is subtracted from used twice

`PCPMachine_updateLinuxMemoryInfo()` stores the display-adjusted page cache in `memValue[MEMORY_CLASS_CACHE]`, which already has `SReclaimable` added and `Shmem` subtracted, then feeds that value into `usedDiff` and adds `SReclaimable` a second time. `LinuxMachine_scanMemoryInfo()` deliberately does not: it keeps the raw `cachedMem` in `usedDiff`, and the comment above it says why.

So pcp's `usedDiff` is larger than native's by exactly `SReclaimable - Shmem`, and `used` is smaller by the same amount. This one is independent of the labels and would survive a fix that only re-keyed the table.

## Measured

Four binaries built from the same tree, started together, captured at one instant against `/proc/meminfo` sampled with the screen. Memory meter isolated, TEXT in the left column and BAR in the right.

```
MemTotal 24339388  MemFree 1409516  Buffers 296860  Cached 14542688  SReclaimable 1562428  Shmem 1098688  (kB)
```

| binary | meter text | bar |
|---|---|---|
| `htop` (native, reference) | `used:6.23G shared:1.05G compressed:0K buffers:290M cache:14.3G available:15.5G` | 82/93 cells, 7.28G |
| `pcp-htop` on `6f33ddd` | `used:5.79G shared:1.05G compressed:290M buffers:14.3G cache:0K available:15.5G` | 31/93 cells, 7.12G |
| `pcp-htop` with commit 1 only | `used:5.79G shared:1.05G compressed:0K buffers:290M cache:14.3G available:15.5G` | 82/93 cells, 6.84G |
| `pcp-htop` with both | `used:6.23G shared:1.05G compressed:0K buffers:290M cache:14.3G available:15.5G` | 82/93 cells, 7.28G |

The third row is what makes the case for two commits: the labels and the bar are right, and `used` is still 5.79G.

The arithmetic checks out against the same meminfo, so the screen and the source agree:

```
native  usedDiff = free + cached + sreclaim + buffers            = 17811492   used = 6527896 kB = 6.23G
pcp     usedDiff = native + sreclaim - shmem                     = 18275232   used = 6064156 kB = 5.79G
gap     463740 kB, which is SReclaimable - Shmem exactly
```

Same run with `show_cached_memory=0`, since commit 1 changes `countsAsCache` and that is the setting it feeds:

| binary | bar |
|---|---|
| `htop` (native) | 30/93 cells, 7.15G |
| `pcp-htop` on `6f33ddd` | 30/93 cells, 6.99G |
| `pcp-htop` with both | 30/93 cells, 7.15G |

Zero warnings under the default warning set on all three pcp builds.

## What is not covered

The Darwin path is compiled but not run, since I have no macOS to point PCP at. The rename is mechanical: `MEMORY_CLASS_COMPRESSED` is replaced by `MEMORY_CLASS_DARWIN_COMPRESSED` in the three places Darwin uses it, its index 4 is unchanged, and the Linux uses of `MEMORY_CLASS_COMPRESSED` (the zswap pool in `Platform_setLinuxMemoryValues`) keep the old name.

One interaction worth flagging: if #2074 lands, `darwin/Platform.c` reorders its own memory classes, and `pcp/Platform.c`'s Darwin table would then be out of step with it in the same way this PR fixes for Linux. Happy to send that as a follow-up in whichever order the two land.

Assisted-by: Claude:opus-5
