### PR TITLE
linux: add a disk-backed swap meter

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -190,6 +190,7 @@ linux_platform_headers = \
 	generic/uname.h \
 	linux/CGroupUtils.h \
 	linux/Compat.h \
+	linux/DiskSwapMeter.h \
 	linux/GPU.h \
 	linux/HugePageMeter.h \
 	linux/IOPriority.h \
@@ -219,6 +220,7 @@ linux_platform_sources = \
 	generic/uname.c \
 	linux/CGroupUtils.c \
 	linux/Compat.c \
+	linux/DiskSwapMeter.c \
 	linux/GPU.c \
 	linux/HugePageMeter.c \
 	linux/IOPriorityPanel.c \

--- a/linux/DiskSwapMeter.c
+++ b/linux/DiskSwapMeter.c
@@ -1,0 +1,70 @@
+/*
+htop - DiskSwapMeter.c
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include "config.h" // IWYU pragma: keep
+
+#include "linux/DiskSwapMeter.h"
+
+#include <stddef.h>
+
+#include "CRT.h"
+#include "Meter.h"
+#include "Object.h"
+#include "Platform.h"
+#include "RichString.h"
+
+
+static const int DiskSwapMeter_attributes[] = {
+   SWAP,
+};
+
+static void DiskSwapMeter_updateValues(Meter* this) {
+   char* buffer = this->txtBuffer;
+   size_t size = sizeof(this->txtBuffer);
+   int written;
+
+   Platform_setDiskSwapValues(this);
+
+   written = Meter_humanUnit(buffer, this->values[0], size);
+   METER_BUFFER_CHECK(buffer, size, written);
+
+   METER_BUFFER_APPEND_CHR(buffer, size, '/');
+
+   Meter_humanUnit(buffer, this->total, size);
+}
+
+static void DiskSwapMeter_display(const Object* cast, RichString* out) {
+   char buffer[50];
+   const Meter* this = (const Meter*)cast;
+
+   RichString_writeAscii(out, CRT_colors[METER_TEXT], ":");
+
+   Meter_humanUnit(buffer, this->total, sizeof(buffer));
+   RichString_appendAscii(out, CRT_colors[METER_VALUE], buffer);
+
+   Meter_humanUnit(buffer, this->values[0], sizeof(buffer));
+   RichString_appendAscii(out, CRT_colors[METER_TEXT], " used:");
+   RichString_appendAscii(out, CRT_colors[SWAP], buffer);
+}
+
+const MeterClass DiskSwapMeter_class = {
+   .super = {
+      .extends = Class(Meter),
+      .delete = Meter_delete,
+      .display = DiskSwapMeter_display,
+   },
+   .updateValues = DiskSwapMeter_updateValues,
+   .defaultMode = BAR_METERMODE,
+   .supportedModes = METERMODE_DEFAULT_SUPPORTED,
+   .maxItems = 1,
+   .isPercentChart = true,
+   .total = 100.0,
+   .attributes = DiskSwapMeter_attributes,
+   .name = "DiskSwap",
+   .uiName = "Disk Swap",
+   .description = "Disk-backed swap usage (not zram)",
+   .caption = "Dsw"
+};

--- a/linux/DiskSwapMeter.h
+++ b/linux/DiskSwapMeter.h
@@ -1,0 +1,13 @@
+#ifndef HEADER_DiskSwapMeter
+#define HEADER_DiskSwapMeter
+/*
+htop - DiskSwapMeter.h
+Released under the GNU GPLv2+, see the COPYING file
+in the source distribution for its full text.
+*/
+
+#include "Meter.h"
+
+extern const MeterClass DiskSwapMeter_class;
+
+#endif

--- a/linux/LinuxMachine.c
+++ b/linux/LinuxMachine.c
@@ -20,6 +20,8 @@ in the source distribution for its full text.
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
 #include <time.h>
 
@@ -352,6 +354,58 @@ static bool LinuxMachine_isZramBlockName(const char* name) {
    }
 
    return true;
+}
+
+static bool LinuxMachine_isZramDevice(const char* path) {
+   struct stat st;
+   if (stat(path, &st) != 0 || !S_ISBLK(st.st_mode)) {
+      const char* name = strrchr(path, '/');
+      return LinuxMachine_isZramBlockName(name ? name + 1 : path);
+   }
+
+   char sysfsPath[64];
+   xSnprintf(sysfsPath, sizeof(sysfsPath), "/sys/dev/block/%u:%u", major(st.st_rdev), minor(st.st_rdev));
+
+   char target[PATH_MAX];
+   ssize_t len = readlink(sysfsPath, target, sizeof(target) - 1);
+   if (len < 0)
+      return false;
+   target[len] = '\0';
+
+   const char* name = strrchr(target, '/');
+   return name && LinuxMachine_isZramBlockName(name + 1);
+}
+
+static void LinuxMachine_scanDiskSwapInfo(LinuxMachine* this) {
+   this->totalDiskSwap = 0;
+   this->usedDiskSwap = 0;
+
+   FILE* file = fopen(PROCSWAPSFILE, "r");
+   if (!file)
+      return;
+
+   char buffer[PATH_MAX + 128];
+   if (!fgets(buffer, sizeof(buffer), file)) { /* skip header */
+      fclose(file);
+      return;
+   }
+
+   while (fgets(buffer, sizeof(buffer), file)) {
+      char path[PATH_MAX];
+      memory_t total;
+      memory_t used;
+
+      if (sscanf(buffer, "%4095s %*s %llu %llu", path, &total, &used) != 3)
+         continue;
+
+      if (LinuxMachine_isZramDevice(path))
+         continue;
+
+      this->totalDiskSwap += total;
+      this->usedDiskSwap += used;
+   }
+
+   fclose(file);
 }
 
 static void LinuxMachine_scanZramDevice(openat_arg_t blockDirFd, const char* name, memory_t* totalZram, memory_t* usedZramComp, memory_t* usedZramOrig) {
@@ -869,6 +923,7 @@ void Machine_scan(Machine* super) {
    LinuxMachine_scanHugePages(this);
    LinuxMachine_scanZfsArcstats(this);
    LinuxMachine_scanZramInfo(this);
+   LinuxMachine_scanDiskSwapInfo(this);
    LinuxMachine_scanCPUTime(this);
 
    const Settings* settings = super->settings;

--- a/linux/LinuxMachine.h
+++ b/linux/LinuxMachine.h
@@ -84,6 +84,8 @@ typedef struct LinuxMachine_ {
    memory_t usedMem;
    memory_t buffersMem;
    memory_t availableMem;
+   memory_t totalDiskSwap;
+   memory_t usedDiskSwap;
 
    CPUData* cpuData;
 
@@ -115,6 +117,10 @@ typedef struct LinuxMachine_ {
 
 #ifndef PROCMEMINFOFILE
 #define PROCMEMINFOFILE PROCDIR "/meminfo"
+#endif
+
+#ifndef PROCSWAPSFILE
+#define PROCSWAPSFILE PROCDIR "/swaps"
 #endif
 
 #ifndef PROCARCSTATSFILE

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -49,6 +49,7 @@ in the source distribution for its full text.
 #include "TasksMeter.h"
 #include "UptimeMeter.h"
 #include "linux/Compat.h"
+#include "linux/DiskSwapMeter.h"
 #include "linux/IOPriority.h"
 #include "linux/IOPriorityPanel.h"
 #include "linux/LinuxMachine.h"
@@ -238,6 +239,7 @@ const MeterClass* const Platform_meterTypes[] = {
    &MemoryMeter_class,
    &SwapMeter_class,
    &MemorySwapMeter_class,
+   &DiskSwapMeter_class,
    &SysArchMeter_class,
    &HugePageMeter_class,
    &TasksMeter_class,
@@ -505,6 +507,13 @@ void Platform_setZramValues(Meter* this) {
    this->total = lhost->zram.totalZram;
    this->values[ZRAM_METER_COMPRESSED] = lhost->zram.usedZramComp;
    this->values[ZRAM_METER_UNCOMPRESSED] = lhost->zram.usedZramOrig - lhost->zram.usedZramComp;
+}
+
+void Platform_setDiskSwapValues(Meter* this) {
+   const LinuxMachine* lhost = (const LinuxMachine*) this->host;
+
+   this->total = lhost->totalDiskSwap;
+   this->values[0] = lhost->usedDiskSwap;
 }
 
 void Platform_setZfsArcValues(Meter* this) {

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -75,6 +75,7 @@ void Platform_setMemoryValues(Meter* this);
 void Platform_setSwapValues(Meter* this);
 
 void Platform_setZramValues(Meter* this);
+void Platform_setDiskSwapValues(Meter* this);
 
 void Platform_setZfsArcValues(Meter* this);
 


### PR DESCRIPTION
Expose disk-backed swap separately from zram so users can distinguish backing-store pressure from compressed RAM usage.
I chose **Dsw** abbreviation that is open to a better alternative.