### PR TITLE
Hide userland threads by default

### DIFF
--- a/Settings.c
+++ b/Settings.c
@@ -924,7 +924,7 @@ Settings* Settings_new(const Machine* host, Hashtable* dynamicMeters, Hashtable*
    this->shadowOtherUsers = false;
    this->showThreadNames = false;
    this->hideKernelThreads = true;
-   this->hideUserlandThreads = false;
+   this->hideUserlandThreads = true;
    this->hideRunningInContainer = false;
    this->highlightBaseName = false;
    this->highlightDeletedExe = true;

--- a/htop.1.in
+++ b/htop.1.in
@@ -281,13 +281,13 @@ movement keys like Up, Down, PgUp, and PgDn will end follow mode immediately,
 while Shift+Up and Shift+Down still pan without disabling follow.
 .TP
 .B K
-Hide kernel threads: prevent the threads belonging the kernel to be
+Hide kernel threads: prevent threads belonging to the kernel from being
 displayed in the process list. (This is a toggle key.)
 .TP
 .B H
-Hide user threads: on systems that represent them differently than ordinary
-processes (such as recent NPTL-based systems), this can hide threads from
-userspace processes in the process list. (This is a toggle key.)
+Hide user threads: prevent threads (NPTL, pthreads, LWP, etc.) belonging
+to userspace processes from being displayed in the process list.
+(This is a toggle key.)
 .TP
 .B O
 Hide containerized processes: prevent processes running in a container


### PR DESCRIPTION
This PR changes a long‑standing default, and might be one of the most visible changes yet. Userland threads were originally shown to help users learn about NPTL/LWP at a time when these threading models were still rare, but that historical purpose has since long faded. Modern applications routinely spawn large numbers of lightweight threads, and exposing all of them by default has become more distracting than informative.

With NPTL now widely adopted and commonly used, hiding userland threads provides a cleaner, more relevant process view. The updated default enables `hide_userland_threads`, reducing clutter while still allowing users to inspect userland threads explicitly when needed. Please note that this change only affects new setups while existing configurations are kept unchanged unless they are manually adjusted.

**Please note:** To restore the old behavior for your setup use the <kbd>Shift</kbd>+<kbd>H</kbd> (capital `H`) toggle key while watching the process list OR hit <kbd>F2</kbd> to enter setup, navigate the `Display Options` to the left and toggle the `Hide userland process threads` entry in the `Global options:` section on the right by pressing <kbd>SPACE</kbd> or <kbd>ENTER</kbd> once that entry is selected; hit <kbd>F10</kbd> or <kbd>q</kbd> to leave the setup screen.