### PR TITLE
ScreensPanel: merge duplicate switch case branches

### DIFF
--- a/ScreensPanel.c
+++ b/ScreensPanel.c
@@ -261,17 +261,7 @@ static HandlerResult ScreensPanel_eventHandlerNormal(Panel* super, int ch) {
          }
          /* else: just select the item, do not enter move mode */
          break;
-      case KEY_RECLICK:
-         /* Double click: start renaming */
-         this->renamingNewItem = false;
-         startRenaming(super);
-         result = HANDLED;
-         break;
       case EVENT_SET_SELECTED:
-         if (this->moving)
-            ScreensPanel_cancelMoving(this);
-         result = HANDLED;
-         break;
       case EVENT_PANEL_LOST_FOCUS:
          if (this->moving)
             ScreensPanel_cancelMoving(this);
@@ -285,6 +275,7 @@ static HandlerResult ScreensPanel_eventHandlerNormal(Panel* super, int ch) {
          break;
       case KEY_F(2):
       case KEY_CTRL('R'):
+      case KEY_RECLICK:
          this->renamingNewItem = false;
          startRenaming(super);
          result = HANDLED;


### PR DESCRIPTION
In ScreensPanel_eventHandlerNormal(), EVENT_SET_SELECTED and EVENT_PANEL_LOST_FOCUS performed identical actions, as did KEY_RECLICK and KEY_F(2) / KEY_CTRL('R'). Group these case labels together to eliminate code duplication and resolve static analyzer warnings