### PR TITLE
Add hide_offline_cpus setting to hide offline CPUs in the CPU meters

### DIFF
--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -44,8 +44,11 @@ static const int CPUMeter_attributes_summary[] = {
 };
 
 typedef struct CPUMeterData_ {
-   unsigned int cpus;
-   Meter** meters;
+   unsigned int ncol;         /* columns the shown sub-meters are laid out in */
+   unsigned int cpus;         /* size of meters: one slot per existing CPU */
+   Meter** meters;            /* sub-meter per CPU id, created when first shown */
+   unsigned int shownCount;
+   Meter** shown;             /* the sub-meters currently shown, in display order */
 } CPUMeterData;
 
 static void CPUMeter_init(Meter* this) {
@@ -233,8 +236,23 @@ static void CPUMeter_display(const Object* cast, RichString* out) {
    #endif
 }
 
+/* Whether the multi-CPU meters show a slot for this CPU (0-based id) */
+static bool CPUMeter_isShown(const Machine* host, unsigned int cpu) {
+   return !host->settings->hideOfflineCPUs || Machine_isCPUonline(host, cpu);
+}
+
+static unsigned int CPUMeter_countShown(const Machine* host) {
+   unsigned int shown = 0;
+   for (unsigned int cpu = 0; cpu < host->existingCPUs; cpu++) {
+      if (CPUMeter_isShown(host, cpu))
+         shown++;
+   }
+   return shown;
+}
+
+/* Range of this meter within the sequence of shown CPUs */
 static void AllCPUsMeter_getRange(const Meter* this, unsigned int* start, unsigned int* count) {
-   unsigned int cpus = this->host->existingCPUs;
+   unsigned int cpus = CPUMeter_countShown(this->host);
    switch (Meter_name(this)[0]) {
       default:
       case 'A': // All
@@ -252,105 +270,144 @@ static void AllCPUsMeter_getRange(const Meter* this, unsigned int* start, unsign
    }
 }
 
-static void CPUMeterCommonInit(Meter* this) {
-   unsigned int start, count, prevCount;
+/* Maps the shown CPUs of this meter onto their sub-meters, creating the ones
+ * seen for the first time. Sub-meters are kept per CPU id, so a CPU that is
+ * hidden or shifts to another slot keeps its history. Returns true if the
+ * shown sequence changed. */
+static bool CPUMeterCommonMapCPUs(Meter* this) {
+   const Machine* host = this->host;
+   CPUMeterData* data = this->meterData;
+   unsigned int start, count;
    AllCPUsMeter_getRange(this, &start, &count);
 
-   CPUMeterData* data = this->meterData;
-   if (!data) {
-      data = xCalloc(1, sizeof(CPUMeterData));
-      data->cpus = 0;   /* no meters allocated yet */
-      data->meters = NULL;
-      this->meterData = data;
-   }
-
-   prevCount = data->cpus;
-   if (count != prevCount) {
-      /* free meters for CPUs that are no longer in range */
-      for (unsigned int i = count; i < prevCount; i++)
+   if (host->existingCPUs != data->cpus) {
+      for (unsigned int i = host->existingCPUs; i < data->cpus; i++)
          Meter_delete((Object*)data->meters[i]);
 
-      if (count > 0) {
-         data->meters = xReallocArrayZero(data->meters, prevCount, count, sizeof(Meter*));
+      if (host->existingCPUs > 0) {
+         data->meters = xReallocArrayZero(data->meters, data->cpus, host->existingCPUs, sizeof(Meter*));
       } else {
          free(data->meters);
          data->meters = NULL;
       }
-      data->cpus = count;
+      data->cpus = host->existingCPUs;
    }
 
-   Meter** meters = data->meters;
-   for (unsigned int i = 0; i < count; i++) {
-      if (!meters[i])
-         meters[i] = Meter_new(this->host, start + i + 1, (const MeterClass*) Class(CPUMeter));
-
-      Meter_init(meters[i]);
+   bool changed = count != data->shownCount;
+   if (changed) {
+      if (count > 0) {
+         data->shown = xReallocArray(data->shown, count, sizeof(Meter*));
+      } else {
+         free(data->shown);
+         data->shown = NULL;
+      }
+      data->shownCount = count;
    }
+
+   unsigned int slot = 0;
+   for (unsigned int cpu = 0, seen = 0; cpu < data->cpus && slot < count; cpu++) {
+      if (!CPUMeter_isShown(host, cpu))
+         continue;
+      if (seen++ < start)
+         continue;
+
+      if (!data->meters[cpu])
+         data->meters[cpu] = Meter_new(host, cpu + 1, (const MeterClass*) Class(CPUMeter));
+
+      if (!changed && data->shown[slot] != data->meters[cpu])
+         changed = true;
+      data->shown[slot++] = data->meters[cpu];
+   }
+   assert(slot == count);
+
+   return changed;
 }
 
-static void AllCPUsMeter_updateValues(Meter* this) {
-   CPUMeterData* data = this->meterData;
-   unsigned int start, count;
-   AllCPUsMeter_getRange(this, &start, &count);
-   /* Reinit if the number of CPUs changed (e.g. hot-plug) */
-   if (count != data->cpus)
-      CPUMeterCommonInit(this);
-   data = this->meterData;
-   Meter** meters = data->meters;
-   for (unsigned int i = 0; i < count; i++)
-      Meter_updateValues(meters[i]);
-}
-
-static void CPUMeterCommonUpdateMode(Meter* this, MeterModeId mode, unsigned int ncol) {
-   /* Reinit first in case the CPU count changed since last init */
-   CPUMeterCommonInit(this);
-   CPUMeterData* data = this->meterData;
-   Meter** meters = data->meters;
-   this->mode = mode;
-   unsigned int start, count;
-   AllCPUsMeter_getRange(this, &start, &count);
-   if (!count) {
+static void CPUMeterCommonUpdateHeight(Meter* this) {
+   const CPUMeterData* data = this->meterData;
+   if (!data->shownCount) {
       this->h = 1;
       return;
    }
-   for (unsigned int i = 0; i < count; i++) {
-      Meter_setMode(meters[i], mode);
-   }
-   int h = meters[0]->h;
+   int h = data->shown[0]->h;
    assert(h > 0);
-   this->h = h * ((count + ncol - 1) / ncol);
+   this->h = h * ((data->shownCount + data->ncol - 1) / data->ncol);
+}
+
+/* (Re)initializes every sub-meter, syncs it to this meter's mode and keeps
+ * the height in sync with the shown CPUs (hot-plug, setup changes) */
+static void CPUMeterCommonInitSubMeters(Meter* this) {
+   const CPUMeterData* data = this->meterData;
+   for (unsigned int i = 0; i < data->cpus; i++) {
+      Meter* meter = data->meters[i];
+      if (!meter)
+         continue;
+
+      Meter_init(meter);
+      if (this->mode != 0)
+         Meter_setMode(meter, this->mode);
+   }
+
+   CPUMeterCommonUpdateHeight(this);
+}
+
+static void CPUMeterCommonInit(Meter* this, unsigned int ncol) {
+   CPUMeterData* data = this->meterData;
+   if (!data) {
+      data = xCalloc(1, sizeof(CPUMeterData));
+      this->meterData = data;
+   }
+   data->ncol = ncol;
+
+   CPUMeterCommonMapCPUs(this);
+   CPUMeterCommonInitSubMeters(this);
+}
+
+static void SingleColCPUsMeter_init(Meter* this) {
+   CPUMeterCommonInit(this, 1);
+}
+
+static void DualColCPUsMeter_init(Meter* this) {
+   CPUMeterCommonInit(this, 2);
+}
+
+static void QuadColCPUsMeter_init(Meter* this) {
+   CPUMeterCommonInit(this, 4);
+}
+
+static void OctoColCPUsMeter_init(Meter* this) {
+   CPUMeterCommonInit(this, 8);
+}
+
+static void AllCPUsMeter_updateValues(Meter* this) {
+   /* Reinit if the shown CPUs changed (e.g. hot-plug, hidden offline CPUs) */
+   if (CPUMeterCommonMapCPUs(this))
+      CPUMeterCommonInitSubMeters(this);
+
+   const CPUMeterData* data = this->meterData;
+   for (unsigned int i = 0; i < data->shownCount; i++)
+      Meter_updateValues(data->shown[i]);
+}
+
+static void AllCPUsMeter_updateMode(Meter* this, MeterModeId mode) {
+   this->mode = mode;
+   Meter_init(this);
 }
 
 static void AllCPUsMeter_done(Meter* this) {
    CPUMeterData* data = this->meterData;
-   Meter** meters = data->meters;
    for (unsigned int i = 0; i < data->cpus; i++)
-      Meter_delete((Object*)meters[i]);
+      Meter_delete((Object*)data->meters[i]);
    free(data->meters);
+   free(data->shown);
    free(data);
 }
 
-static void SingleColCPUsMeter_updateMode(Meter* this, MeterModeId mode) {
-   CPUMeterCommonUpdateMode(this, mode, 1);
-}
-
-static void DualColCPUsMeter_updateMode(Meter* this, MeterModeId mode) {
-   CPUMeterCommonUpdateMode(this, mode, 2);
-}
-
-static void QuadColCPUsMeter_updateMode(Meter* this, MeterModeId mode) {
-   CPUMeterCommonUpdateMode(this, mode, 4);
-}
-
-static void OctoColCPUsMeter_updateMode(Meter* this, MeterModeId mode) {
-   CPUMeterCommonUpdateMode(this, mode, 8);
-}
-
-static void CPUMeterCommonDraw(Meter* this, int x, int y, int w, unsigned int ncol) {
-   CPUMeterData* data = this->meterData;
-   Meter** meters = data->meters;
-   unsigned int start, count;
-   AllCPUsMeter_getRange(this, &start, &count);
+static void AllCPUsMeter_draw(Meter* this, int x, int y, int w) {
+   const CPUMeterData* data = this->meterData;
+   Meter** meters = data->shown;
+   unsigned int count = data->shownCount;
+   unsigned int ncol = data->ncol;
    int colwidth = w / (int)ncol;
    int diff = w % (int)ncol;
    unsigned int nrows = (count + ncol - 1) / ncol;
@@ -360,30 +417,6 @@ static void CPUMeterCommonDraw(Meter* this, int x, int y, int w, unsigned int nc
       int xpos = x + ((int)col * colwidth) + d;
       int ypos = y + ((i % nrows) * meters[0]->h);
       meters[i]->draw(meters[i], xpos, ypos, colwidth);
-   }
-}
-
-static void DualColCPUsMeter_draw(Meter* this, int x, int y, int w) {
-   CPUMeterCommonDraw(this, x, y, w, 2);
-}
-
-static void QuadColCPUsMeter_draw(Meter* this, int x, int y, int w) {
-   CPUMeterCommonDraw(this, x, y, w, 4);
-}
-
-static void OctoColCPUsMeter_draw(Meter* this, int x, int y, int w) {
-   CPUMeterCommonDraw(this, x, y, w, 8);
-}
-
-
-static void SingleColCPUsMeter_draw(Meter* this, int x, int y, int w) {
-   CPUMeterData* data = this->meterData;
-   Meter** meters = data->meters;
-   unsigned int start, count;
-   AllCPUsMeter_getRange(this, &start, &count);
-   for (unsigned int i = 0; i < count; i++) {
-      meters[i]->draw(meters[i], x, y, w);
-      y += meters[i]->h;
    }
 }
 
@@ -423,9 +456,9 @@ const MeterClass AllCPUsMeter_class = {
    .uiName = "CPUs (1/1)",
    .description = "CPUs (1/1): all CPUs",
    .caption = "CPU",
-   .draw = SingleColCPUsMeter_draw,
-   .init = CPUMeterCommonInit,
-   .updateMode = SingleColCPUsMeter_updateMode,
+   .draw = AllCPUsMeter_draw,
+   .init = SingleColCPUsMeter_init,
+   .updateMode = AllCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
 
@@ -445,9 +478,9 @@ const MeterClass AllCPUs2Meter_class = {
    .uiName = "CPUs (1&2/2)",
    .description = "CPUs (1&2/2): all CPUs in 2 shorter columns",
    .caption = "CPU",
-   .draw = DualColCPUsMeter_draw,
-   .init = CPUMeterCommonInit,
-   .updateMode = DualColCPUsMeter_updateMode,
+   .draw = AllCPUsMeter_draw,
+   .init = DualColCPUsMeter_init,
+   .updateMode = AllCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
 
@@ -467,9 +500,9 @@ const MeterClass LeftCPUsMeter_class = {
    .uiName = "CPUs (1/2)",
    .description = "CPUs (1/2): first half of list",
    .caption = "CPU",
-   .draw = SingleColCPUsMeter_draw,
-   .init = CPUMeterCommonInit,
-   .updateMode = SingleColCPUsMeter_updateMode,
+   .draw = AllCPUsMeter_draw,
+   .init = SingleColCPUsMeter_init,
+   .updateMode = AllCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
 
@@ -489,9 +522,9 @@ const MeterClass RightCPUsMeter_class = {
    .uiName = "CPUs (2/2)",
    .description = "CPUs (2/2): second half of list",
    .caption = "CPU",
-   .draw = SingleColCPUsMeter_draw,
-   .init = CPUMeterCommonInit,
-   .updateMode = SingleColCPUsMeter_updateMode,
+   .draw = AllCPUsMeter_draw,
+   .init = SingleColCPUsMeter_init,
+   .updateMode = AllCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
 
@@ -511,9 +544,9 @@ const MeterClass LeftCPUs2Meter_class = {
    .uiName = "CPUs (1&2/4)",
    .description = "CPUs (1&2/4): first half in 2 shorter columns",
    .caption = "CPU",
-   .draw = DualColCPUsMeter_draw,
-   .init = CPUMeterCommonInit,
-   .updateMode = DualColCPUsMeter_updateMode,
+   .draw = AllCPUsMeter_draw,
+   .init = DualColCPUsMeter_init,
+   .updateMode = AllCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
 
@@ -533,9 +566,9 @@ const MeterClass RightCPUs2Meter_class = {
    .uiName = "CPUs (3&4/4)",
    .description = "CPUs (3&4/4): second half in 2 shorter columns",
    .caption = "CPU",
-   .draw = DualColCPUsMeter_draw,
-   .init = CPUMeterCommonInit,
-   .updateMode = DualColCPUsMeter_updateMode,
+   .draw = AllCPUsMeter_draw,
+   .init = DualColCPUsMeter_init,
+   .updateMode = AllCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
 
@@ -555,9 +588,9 @@ const MeterClass AllCPUs4Meter_class = {
    .uiName = "CPUs (1&2&3&4/4)",
    .description = "CPUs (1&2&3&4/4): all CPUs in 4 shorter columns",
    .caption = "CPU",
-   .draw = QuadColCPUsMeter_draw,
-   .init = CPUMeterCommonInit,
-   .updateMode = QuadColCPUsMeter_updateMode,
+   .draw = AllCPUsMeter_draw,
+   .init = QuadColCPUsMeter_init,
+   .updateMode = AllCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
 
@@ -577,9 +610,9 @@ const MeterClass LeftCPUs4Meter_class = {
    .uiName = "CPUs (1-4/8)",
    .description = "CPUs (1-4/8): first half in 4 shorter columns",
    .caption = "CPU",
-   .draw = QuadColCPUsMeter_draw,
-   .init = CPUMeterCommonInit,
-   .updateMode = QuadColCPUsMeter_updateMode,
+   .draw = AllCPUsMeter_draw,
+   .init = QuadColCPUsMeter_init,
+   .updateMode = AllCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
 
@@ -599,9 +632,9 @@ const MeterClass RightCPUs4Meter_class = {
    .uiName = "CPUs (5-8/8)",
    .description = "CPUs (5-8/8): second half in 4 shorter columns",
    .caption = "CPU",
-   .draw = QuadColCPUsMeter_draw,
-   .init = CPUMeterCommonInit,
-   .updateMode = QuadColCPUsMeter_updateMode,
+   .draw = AllCPUsMeter_draw,
+   .init = QuadColCPUsMeter_init,
+   .updateMode = AllCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
 
@@ -621,9 +654,9 @@ const MeterClass AllCPUs8Meter_class = {
    .uiName = "CPUs (1-8/8)",
    .description = "CPUs (1-8/8): all CPUs in 8 shorter columns",
    .caption = "CPU",
-   .draw = OctoColCPUsMeter_draw,
-   .init = CPUMeterCommonInit,
-   .updateMode = OctoColCPUsMeter_updateMode,
+   .draw = AllCPUsMeter_draw,
+   .init = OctoColCPUsMeter_init,
+   .updateMode = AllCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
 
@@ -643,9 +676,9 @@ const MeterClass LeftCPUs8Meter_class = {
    .uiName = "CPUs (1-8/16)",
    .description = "CPUs (1-8/16): first half in 8 shorter columns",
    .caption = "CPU",
-   .draw = OctoColCPUsMeter_draw,
-   .init = CPUMeterCommonInit,
-   .updateMode = OctoColCPUsMeter_updateMode,
+   .draw = AllCPUsMeter_draw,
+   .init = OctoColCPUsMeter_init,
+   .updateMode = AllCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };
 
@@ -665,8 +698,8 @@ const MeterClass RightCPUs8Meter_class = {
    .uiName = "CPUs (9-16/16)",
    .description = "CPUs (9-16/16): second half in 8 shorter columns",
    .caption = "CPU",
-   .draw = OctoColCPUsMeter_draw,
-   .init = CPUMeterCommonInit,
-   .updateMode = OctoColCPUsMeter_updateMode,
+   .draw = AllCPUsMeter_draw,
+   .init = OctoColCPUsMeter_init,
+   .updateMode = AllCPUsMeter_updateMode,
    .done = AllCPUsMeter_done
 };

--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -274,7 +274,7 @@ static void AllCPUsMeter_getRange(const Meter* this, unsigned int* start, unsign
  * seen for the first time. Sub-meters are kept per CPU id, so a CPU that is
  * hidden or shifts to another slot keeps its history. Returns true if the
  * shown sequence changed. */
-static bool CPUMeterCommonMapCPUs(Meter* this) {
+static bool CPUMeter_commonMapCPUs(Meter* this) {
    const Machine* host = this->host;
    CPUMeterData* data = this->meterData;
    unsigned int start, count;
@@ -323,7 +323,7 @@ static bool CPUMeterCommonMapCPUs(Meter* this) {
    return changed;
 }
 
-static void CPUMeterCommonUpdateHeight(Meter* this) {
+static void CPUMeter_commonUpdateHeight(Meter* this) {
    const CPUMeterData* data = this->meterData;
    if (!data->shownCount) {
       this->h = 1;
@@ -336,7 +336,7 @@ static void CPUMeterCommonUpdateHeight(Meter* this) {
 
 /* (Re)initializes every sub-meter, syncs it to this meter's mode and keeps
  * the height in sync with the shown CPUs (hot-plug, setup changes) */
-static void CPUMeterCommonInitSubMeters(Meter* this) {
+static void CPUMeter_commonInitSubMeters(Meter* this) {
    const CPUMeterData* data = this->meterData;
    for (unsigned int i = 0; i < data->cpus; i++) {
       Meter* meter = data->meters[i];
@@ -348,10 +348,10 @@ static void CPUMeterCommonInitSubMeters(Meter* this) {
          Meter_setMode(meter, this->mode);
    }
 
-   CPUMeterCommonUpdateHeight(this);
+   CPUMeter_commonUpdateHeight(this);
 }
 
-static void CPUMeterCommonInit(Meter* this, unsigned int ncol) {
+static void CPUMeter_commonInit(Meter* this, unsigned int ncol) {
    CPUMeterData* data = this->meterData;
    if (!data) {
       data = xCalloc(1, sizeof(CPUMeterData));
@@ -359,30 +359,30 @@ static void CPUMeterCommonInit(Meter* this, unsigned int ncol) {
    }
    data->ncol = ncol;
 
-   CPUMeterCommonMapCPUs(this);
-   CPUMeterCommonInitSubMeters(this);
+   CPUMeter_commonMapCPUs(this);
+   CPUMeter_commonInitSubMeters(this);
 }
 
 static void SingleColCPUsMeter_init(Meter* this) {
-   CPUMeterCommonInit(this, 1);
+   CPUMeter_commonInit(this, 1);
 }
 
 static void DualColCPUsMeter_init(Meter* this) {
-   CPUMeterCommonInit(this, 2);
+   CPUMeter_commonInit(this, 2);
 }
 
 static void QuadColCPUsMeter_init(Meter* this) {
-   CPUMeterCommonInit(this, 4);
+   CPUMeter_commonInit(this, 4);
 }
 
 static void OctoColCPUsMeter_init(Meter* this) {
-   CPUMeterCommonInit(this, 8);
+   CPUMeter_commonInit(this, 8);
 }
 
 static void AllCPUsMeter_updateValues(Meter* this) {
    /* Reinit if the shown CPUs changed (e.g. hot-plug, hidden offline CPUs) */
-   if (CPUMeterCommonMapCPUs(this))
-      CPUMeterCommonInitSubMeters(this);
+   if (CPUMeter_commonMapCPUs(this))
+      CPUMeter_commonInitSubMeters(this);
 
    const CPUMeterData* data = this->meterData;
    for (unsigned int i = 0; i < data->shownCount; i++)

--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -291,6 +291,7 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    Panel_add(super, (Object*) CheckItem_newByRef("Detailed CPU time (System/IO-Wait/Hard-IRQ/Soft-IRQ/Steal/Guest)", &(settings->detailedCPUTime)));
    Panel_add(super, (Object*) CheckItem_newByRef("Count CPUs from 1 instead of 0", &(settings->countCPUsFromOne)));
    Panel_add(super, (Object*) CheckItem_newByRef("Label CPUs based on SMT topology (e.g. 0a, 0b) instead of CPU index", &(settings->showCPUSMTLabels)));
+   Panel_add(super, (Object*) CheckItem_newByRef("Hide offline CPUs in the CPUs meters (e.g. SMT siblings disabled by nosmt)", &(settings->hideOfflineCPUs)));
    Panel_add(super, (Object*) CheckItem_newByRef("Update process names on every refresh", &(settings->updateProcessNames)));
    Panel_add(super, (Object*) CheckItem_newByRef("Add guest time in CPU meter percentage", &(settings->accountGuestInCPUMeter)));
    Panel_add(super, (Object*) CheckItem_newByRef("Also show CPU percentage numerically", &(settings->showCPUUsage)));

--- a/Header.c
+++ b/Header.c
@@ -237,7 +237,9 @@ void Header_draw(const Header* this) {
    }
 }
 
-void Header_updateData(Header* this) {
+/* Returns true if the header height changed, e.g. because a meter resized
+ * itself (CPUs hot-plugged or hidden) */
+bool Header_updateData(Header* this) {
    Header_forEachColumn(this, col) {
       Vector* meters = this->columns[col];
       int items = Vector_size(meters);
@@ -246,6 +248,9 @@ void Header_updateData(Header* this) {
          Meter_updateValues(meter);
       }
    }
+
+   int oldHeight = this->height;
+   return Header_calculateHeight(this) != oldHeight;
 }
 
 /*

--- a/Header.h
+++ b/Header.h
@@ -41,7 +41,7 @@ void Header_reinit(Header* this);
 
 void Header_draw(const Header* this);
 
-void Header_updateData(Header* this);
+bool Header_updateData(Header* this);
 
 int Header_calculateHeight(Header* this);
 

--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -150,7 +150,10 @@ static void checkRecalculation(ScreenManager* this, double* oldTime, int* sortTi
       this->state->failedUpdate = Platform_getFailedState();
 
       // always update header, especially to avoid gaps in graph meters
-      Header_updateData(this->header);
+      if (Header_updateData(this->header)) {
+         ScreenManager_resize(this);
+         *force_redraw = true;
+      }
 
       // force redraw if the number of UID/PID digits changed
       if (Process_uidDigits != oldUidDigits || Process_pidDigits != oldPidDigits)

--- a/Settings.c
+++ b/Settings.c
@@ -507,6 +507,8 @@ static bool Settings_read(Settings* this, const char* fileName, const Machine* h
          this->countCPUsFromOne = !atoi(option[1]);
       } else if (String_eq(option[0], "show_cpu_smt_labels")) {
          this->showCPUSMTLabels = atoi(option[1]);
+      } else if (String_eq(option[0], "hide_offline_cpus")) {
+         this->hideOfflineCPUs = atoi(option[1]);
       } else if (String_eq(option[0], "show_cpu_usage")) {
          this->showCPUUsage = atoi(option[1]);
       } else if (String_eq(option[0], "sticky_follow")) {
@@ -825,6 +827,7 @@ int Settings_write(const Settings* this, bool onCrash) {
    printSettingInteger("detailed_cpu_time", this->detailedCPUTime);
    printSettingInteger("cpu_count_from_one", this->countCPUsFromOne);
    printSettingInteger("show_cpu_smt_labels", this->showCPUSMTLabels);
+   printSettingInteger("hide_offline_cpus", this->hideOfflineCPUs);
    printSettingInteger("show_cpu_usage", this->showCPUUsage);
    printSettingInteger("sticky_follow", this->stickyFollow);
    printSettingInteger("show_cpu_frequency", this->showCPUFrequency);
@@ -933,6 +936,7 @@ Settings* Settings_new(const Machine* host, Hashtable* dynamicMeters, Hashtable*
    this->detailedCPUTime = false;
    this->countCPUsFromOne = false;
    this->showCPUSMTLabels = false;
+   this->hideOfflineCPUs = false;
    this->showCPUUsage = true;
    this->stickyFollow = true;
    this->showCPUFrequency = false;

--- a/Settings.h
+++ b/Settings.h
@@ -80,6 +80,7 @@ typedef struct Settings_ {
    bool stickyFollow;
    bool showCPUFrequency;
    bool showCPUSMTLabels;
+   bool hideOfflineCPUs;
    #ifdef BUILD_WITH_CPU_TEMP
    bool showCPUTemperature;
    bool degreeFahrenheit;


### PR DESCRIPTION
Hello :)

## Context
I was working on a relatively large server where we disabled SMT and this caused the 64 core / 128 threads listing to have 64 `[offline]` CPU displayed. This was less than ideal when using a small terminal pane, especially to see the load on the other 64 cores, so I decided to take a look at it. I noticed #853 and decided to pick it up!

I don't know the codebase, and I'm not a particularly good C dev, but I've reviewed the code and steered my agent for a bit to achieve this. I do believe it went a bit too far with some changes, but I also think it made sense for the purpose of the PR.

I do believe I've followed the contribution guidance and the AI disclosure and all as well, but happy to change.

## Goal

On machines booted with nosmt (or with CPUs otherwise offlined), the multi-CPU meters draw a bar reading "offline" for every disabled thread, doubling the height of the header on large SMT systems for no benefit.

Add a "Hide offline CPUs in the CPUs meters" display option (htoprc key hide_offline_cpus, default off).
When enabled, the CPUs meters lay out the sequence of online CPUs instead of every existing CPU, so the first/second half and multi-column layouts split over the shown CPUs only. Sub-meters are now kept per CPU id and created when a CPU is first shown, so a CPU that is hidden or shifts to another slot keeps its graph history; the meter recomputes its own height whenever the shown sequence changes.

Header_updateData now recalculates the header height and reports whether it changed, so the refresh loop re-lays out the screen when CPUs go online or offline at runtime instead of leaving blank or clipped rows until the terminal is resized.

## Recorded run

Here's an example of how it looks on my 16C/32T machine, with a script that disables cores over time.

https://github.com/user-attachments/assets/76705922-d1c8-432c-8025-1b5b30dc6a93


Closes #853 

Assisted-by: Claude Fable 5.1 <noreply@anthropic.com>